### PR TITLE
Slash adjustment, and multiprocessing fix

### DIFF
--- a/capstone/cap/storages.py
+++ b/capstone/cap/storages.py
@@ -23,6 +23,10 @@ class CapS3Storage(CapStorageMixin, S3Boto3Storage):
         """
             Yield each immediate subdirectory in path.  
         """
+        
+        if path:
+            path = path.rstrip('/')+'/'  # exactly one slash on right
+
         paginator = self.connection.meta.client.get_paginator('list_objects')
         for result in paginator.paginate(Bucket=self.bucket_name, Prefix=self._fix_path(path), Delimiter='/'):
             for prefix in result.get('CommonPrefixes', []):

--- a/capstone/cap/storages.py
+++ b/capstone/cap/storages.py
@@ -24,7 +24,6 @@ class CapS3Storage(CapStorageMixin, S3Boto3Storage):
             Yield each immediate subdirectory in path.  
         """
         paginator = self.connection.meta.client.get_paginator('list_objects')
-        path = path.rstrip('/')+'/'  # exactly one slash on right
         for result in paginator.paginate(Bucket=self.bucket_name, Prefix=self._fix_path(path), Delimiter='/'):
             for prefix in result.get('CommonPrefixes', []):
                 yield(self.relpath(prefix.get('Prefix').rstrip('/')))

--- a/capstone/scripts/ingest_files.py
+++ b/capstone/scripts/ingest_files.py
@@ -140,6 +140,8 @@ def volume_files(volume_path):
         goes, the request is the biggest drag, so having a different request for alto,
         casemets, and volume files would be much slower.
     """
+    ingest_storage_local = ingest_storage_class(**settings.INGEST_STORAGE.get('kwargs', {}))
+    
     files = defaultdict(list)
 
     # check file paths for these patterns in order until we find one that matches
@@ -152,7 +154,7 @@ def volume_files(volume_path):
     ]
 
     print("Getting Volume Files for " + volume_path)
-    for file_name in ingest_storage.iter_files(volume_path):
+    for file_name in ingest_storage_local.iter_files(volume_path):
         for category, regex in regexes:
             if regex.search(file_name):
                 files[category].append(file_name)


### PR DESCRIPTION
removed 'exactly one slash on right' rstrip code in storages. Was killing ingesting on harvard-ftl-shared/from_vendor and it still works with all other configurations i have tried.