### PR TITLE
[quick] Base dir check

### DIFF
--- a/capstone/cap/tests/test_storages.py
+++ b/capstone/cap/tests/test_storages.py
@@ -37,4 +37,5 @@ def base_test_iter_files(storage):
     assert set(sub_dir) == set(storage.iter_files('d'))
 
     # list dirs
+    assert {'a', 'd'} == set(storage.iter_subdirs())
     assert {'d/e', 'd/g'} == set(storage.iter_subdirs('d'))


### PR DESCRIPTION
Add a test for `iter_subdirs()` with no path — check for that error case we hit the other day