### PR TITLE
Refactor slug creation

### DIFF
--- a/capstone/capdb/migrations/0009_casemetadata_fill_slug.py
+++ b/capstone/capdb/migrations/0009_casemetadata_fill_slug.py
@@ -16,7 +16,7 @@ def fill_in_slug(apps, schema_editor):
         except ObjectDoesNotExist:
             citation = case.citations.first().cite
 
-        case.slug = generate_unique_slug(CaseMetadata, 'slug', citation)
+        case.slug = generate_unique_slug(case, citation)
         case.save(update_fields=['slug'])
 
 

--- a/capstone/capdb/tests/conftest.py
+++ b/capstone/capdb/tests/conftest.py
@@ -29,3 +29,7 @@ def ingest_volumes(ingest_metadata):
 @pytest.fixture
 def volume_xml(ingest_volumes):
     return VolumeXML.objects.get(barcode='32044057892259')
+
+@pytest.fixture
+def case_xml(volume_xml):
+    return volume_xml.case_xmls.first()

--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -1,0 +1,31 @@
+import pytest
+
+from capdb.models import CaseMetadata
+from scripts.helpers import parse_xml
+
+
+### CaseMetadata ###
+
+@pytest.mark.django_db
+def test_update_case_metadata(case_xml):
+    # fetch current metadata
+    case_metadata = CaseMetadata.objects.get(case_id=case_xml.case_id)
+
+    # change xml
+    parsed = parse_xml(case_xml.orig_xml)
+    parsed('case|citation[category="official"]').text('123 Test 456')
+    case_xml.orig_xml = str(parsed)
+    case_xml.save()
+    case_xml.update_case_metadata()
+
+    # fetch new metadata
+    new_case_metadata = CaseMetadata.objects.get(case_id=case_xml.case_id)
+    new_citations = list(new_case_metadata.citations.all())
+
+    # case_metadata should have been updated, not duplicated
+    assert new_case_metadata.pk == case_metadata.pk
+    assert new_case_metadata.slug == '123-test-456'
+
+    # citations should have been replaced
+    assert len(new_citations) == 1
+    assert new_citations[0].cite == '123 Test 456'

--- a/capstone/capdb/tests/test_utils.py
+++ b/capstone/capdb/tests/test_utils.py
@@ -6,12 +6,12 @@ from capdb.models import Reporter
 @pytest.mark.django_db
 def test_generate_unique_slug(ingest_metadata):
     unique_name = "Caselaw Access Project"
-    slug1 = utils.generate_unique_slug(Reporter, "full_name", unique_name)
+    slug1 = utils.generate_unique_slug(Reporter(), unique_name, field="full_name")
 
     assert slug1 == "caselaw-access-project"
 
     reporter = Reporter.objects.first()
     reporter_name = reporter.full_name
-    slug2 = utils.generate_unique_slug(Reporter, "full_name", reporter_name)
+    slug2 = utils.generate_unique_slug(Reporter(), reporter_name, field="full_name")
 
     assert slug2 == utils.slugify(reporter_name)

--- a/capstone/scripts/ingest_tt_data.py
+++ b/capstone/scripts/ingest_tt_data.py
@@ -107,5 +107,5 @@ def populate_jurisdiction():
             continue
         new_jurisdiction = Jurisdiction()
         new_jurisdiction.name = jurisdiction['state']
-        new_jurisdiction.slug = generate_unique_slug(Jurisdiction, 'slug', jurisdiction['state'])
+        new_jurisdiction.slug = generate_unique_slug(new_jurisdiction, jurisdiction['state'])
         new_jurisdiction.save()


### PR DESCRIPTION
There's an issue with `update_case_metadata` where it always creates a new CaseMetadata instead of updating the existing one. This is because it finds CaseMetadata based on a newly-generated slug, which is required to be unique, so it never finds the existing one.

Changes here:

* `update_case_metadata` finds the existing CaseMetadata, by not running get_or_create based on slug.
* `generate_unique_slug` accepts an instance instead of a model, so it can ignore database entries with the same ID.
* when setting CaseMetadata.citations, `update_case_metadata` replaces existing citations instead of adding.
* Add test to try modifying the xml of a CaseXML and rerunning update_case_metadata.