### PR TITLE
CAPAPI - get JSON responses, serve only useful XML data

### DIFF
--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -78,7 +78,7 @@ class APIUser(AbstractBaseUser):
 
     def get_case_allowance_update_time_remaining(self):
         td = self.case_allowance_last_updated + timedelta(hours=settings.API_CASE_EXPIRE_HOURS) - timezone.now()
-        return "%sh. %sm." % (td.seconds / 3600, (td.seconds / 60) % 60)
+        return "%s hours or %s minutes." % (round(td.seconds / 3600, 2), round((td.seconds / 60) % 60, 2))
 
     def authenticate_user(self, **kwargs):
         # TODO: make into class method

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime
 import logging
 import zipfile
@@ -62,10 +63,9 @@ def email(reason, user):
         token_url = os.path.join(settings.API_BASE_URL, "accounts/verify-user", str(user.id), user.get_activation_nonce())
         send_mail(
             'CaseLaw Access Project: Verify your email address',
-            f"""Please click here to verify your email address: {token_url}
-            If you believe you have received this message in error, please ignore it.
-            """,
+            f"Please click here to verify your email address: {token_url} If you believe you have received this message in error, please ignore it.",
             settings.API_EMAIL_ADDRESS,
             [user.email],
             fail_silently=False, )
         logger.info("sent new_signup email for %s" % user.email)
+

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -59,15 +59,12 @@ def email(reason, user):
         logger.info("sent new_registration email for %s" % user.email)
 
     if reason == 'new_signup':
-        token_url = "%saccounts/verify-user/%s/%s" % (
-            settings.API_BASE_URL, user.id, user.get_activation_nonce()
-        )
+        token_url = os.path.join(settings.API_BASE_URL, "accounts/verify-user", str(user.id), user.get_activation_nonce())
         send_mail(
             'CaseLaw Access Project: Verify your email address',
-            """
-                Please click here to verify your email address: %s
-                If you believe you have received this message in error, please ignore it.
-            """ % token_url,
+            f"""Please click here to verify your email address: {token_url}
+            If you believe you have received this message in error, please ignore it.
+            """,
             settings.API_EMAIL_ADDRESS,
             [user.email],
             fail_silently=False, )

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -42,8 +42,6 @@ def create_download_response(filename='', content=[]):
     # Reset file pointer
     tmp_file.seek(0)
 
-    # return open file handle
-    # return tmp_file
     response = FileResponse(FileWrapper(tmp_file), content_type='application/zip')
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
     return response
@@ -69,7 +67,7 @@ def email(reason, user):
         token_url = os.path.join(settings.API_BASE_URL, "accounts/verify-user", str(user.id), user.get_activation_nonce())
         send_mail(
             'CaseLaw Access Project: Verify your email address',
-            f"Please click here to verify your email address: {token_url} If you believe you have received this message in error, please ignore it.",
+            "Please click here to verify your email address: %s If you believe you have received this message in error, please ignore it." % token_url,
             settings.API_EMAIL_ADDRESS,
             [user.email],
             fail_silently=False, )

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -80,11 +80,6 @@ class CaseSerializer(serializers.HyperlinkedModelSerializer):
         )
 
 
-class AuthenticatedCaseSerializer(CaseSerializer):
-    class Meta(CaseSerializer.Meta):
-        fields = CaseSerializer.Meta.fields + ('casebody',)
-
-
 class JurisdictionSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Jurisdiction

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -126,6 +126,20 @@ class UserSerializer(serializers.ModelSerializer):
             found_user.authenticate_user(activation_nonce=activation_nonce)
         return found_user
 
+    def verify_case_allowance(self, user, case_count):
+        if case_count <= 0:
+            return user
+        user.update_case_allowance()
+
+        if not user.case_allowance >= case_count:
+            time_remaining = user.get_case_allowance_update_time_remaining()
+            raise serializers.ValidationError({
+                "error": "You have attempted to download more than your allowed number of cases. Your limit will reset to default again in %s." % time_remaining,
+                "case_allowance_remaining": user.case_allowance,
+            })
+        else:
+            return user
+
 
 class RegisterUserSerializer(serializers.Serializer):
     email = serializers.EmailField(required=True)

--- a/capstone/capapi/tests/conftest.py
+++ b/capstone/capapi/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from django.test import Client
 from django.conf import settings
 from django.core.management import call_command
-from rest_framework.test import RequestsClient
+from rest_framework.test import RequestsClient, APIRequestFactory
 
 from test_data import factories
 
@@ -54,4 +54,8 @@ def auth_client():
 def api_url():
     return "http://testserver" + settings.API_FULL_URL + "/"
 
+
+@pytest.fixture
+def api_request_factory():
+    return APIRequestFactory()
 

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -78,6 +78,12 @@ def test_many_case_download(auth_user, api_url, auth_client):
     auth_user.refresh_from_db()
     assert auth_user.case_allowance == settings.API_CASE_DAILY_ALLOWANCE - num_created
 
+    # test too low case allowance
+    auth_user.case_allowance = 1
+    auth_user.save()
+    response = auth_client.get(url, headers={'AUTHORIZATION': 'Token {}'.format(auth_user.get_api_key())})
+    check_response(response, status_code=403, format='')
+
 
 @pytest.mark.django_db(transaction=True)
 def test_max_number_case_download(auth_user, api_url, auth_client):

--- a/capstone/capapi/tests/test_serializers.py
+++ b/capstone/capapi/tests/test_serializers.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+from rest_framework.request import Request
+from test_data.factories import setup_case
+from capapi import serializers
+
+
+@pytest.mark.django_db(transaction=True)
+def test_MetaCaseSerializer(api_url, api_request_factory, auth_client, case):
+    # can get single case data
+    url = os.path.join(api_url, "cases")
+    request = api_request_factory.get(url)
+    serializer_context = {'request': Request(request)}
+
+    serializer = serializers.MetaCaseSerializer(data=case, context=serializer_context)
+    serializer.is_valid()
+    assert serializer.data['slug'] == case.slug
+    assert 'casebody' in serializer.data.keys()
+
+    # can get multiple cases' data
+    cases = []
+    for c in range(0, 3):
+        case = setup_case()
+        cases.append(case)
+
+    serializer = serializers.MetaCaseSerializer(data=cases, many=True, context=serializer_context)
+    serializer.is_valid()
+    assert len(serializer.data) == 3
+    for case in serializer.data:
+        assert 'casebody' in case.keys()

--- a/capstone/capapi/views.py
+++ b/capstone/capapi/views.py
@@ -3,7 +3,6 @@ import logging
 from wsgiref.util import FileWrapper
 
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
 from django_filters.rest_framework import DjangoFilterBackend
 from django.http import JsonResponse, FileResponse
 
@@ -13,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.decorators import api_view, list_route, renderer_classes
 from rest_framework.permissions import AllowAny
 from rest_framework.parsers import JSONParser, FormParser
+from rest_framework.exceptions import ValidationError
 
 from capapi import permissions, serializers, filters, resources, models as capapi_models
 from capdb import models
@@ -67,89 +67,68 @@ class CaseViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Lis
     filter_class = filters.CaseFilter
     lookup_field = 'slug'
 
-    def download_many(self):
-        cases = self.queryset.all().order_by('decision_date')
+    def download(self, **kwargs):
+        if kwargs.get(self.lookup_field):
+            try:
+                cases = [models.CaseMetadata.objects.get(**kwargs)]
+            except models.CaseMetadata.DoesNotExist as e:
+                return JsonResponse({
+                    'message': 'Unable to find case with matching slug: %s' % e
+                }, status=404, )
 
-        for backend in list(self.filter_backends):
-            cases = backend().filter_queryset(self.request, cases, self)
+        else:
+            cases = self.queryset.all().order_by('decision_date')
 
-        cases = cases.select_related('jurisdiction')
+            for backend in list(self.filter_backends):
+                cases = backend().filter_queryset(self.request, cases, self)
 
-        # user is requesting a zip but there is nothing to zip, so 404 is the right response.
-        # See https://stackoverflow.com/a/11760249/307769
-        if cases.count() == 0:
-            return JsonResponse({
-                'message': 'Request did not return any results.'
-            }, status=404, )
+            cases = cases.select_related('jurisdiction')
 
-        cases = self.paginate_queryset(cases)
+            # user is requesting a zip but there is nothing to zip, so 404 is the right response.
+            # See https://stackoverflow.com/a/11760249/307769
+            if cases.count() == 0:
+                return JsonResponse({
+                    'message': 'Request did not return any results.'
+                }, status=404, )
+
+            cases = self.paginate_queryset(cases)
 
         blacklisted_case_count = len(list((case for case in cases if not case.jurisdiction.whitelisted)))
-        case_allowance_sufficient = self.check_case_allowance(blacklisted_case_count)
 
-        response = self.create_download_response(cases, blacklisted_case_count, permitted=case_allowance_sufficient)
+        user_serializer = serializers.UserSerializer()
 
-        return response
-
-    def download_one(self, **kwargs):
-        """
-        If downloading a single case (using its lookup_field) explicitly
-        """
         try:
-            case = models.CaseMetadata.objects.get(**kwargs)
-        except ObjectDoesNotExist as e:
-            return JsonResponse({'message': 'Unable to find case with matching slug: %s' % e}, status=404, )
+            # check user's case allowance against blacklisted
+            user = user_serializer.verify_case_allowance(self.request.user, blacklisted_case_count)
+        except ValidationError as err:
+            return JsonResponse(err.detail, status=403)
 
-        # if whitelisted, count 0, else count 1
-        blacklisted_case_count = int(not case.jurisdiction.whitelisted)
-        case_allowance_sufficient = self.check_case_allowance(blacklisted_case_count)
-
-        response = self.create_download_response([case], blacklisted_case_count, permitted=case_allowance_sufficient)
+        response = self.create_download_response(cases, blacklisted_case_count)
+        user.update_case_allowance(case_count=blacklisted_case_count)
 
         return response
 
-    def create_download_response(self, case_list, blacklisted_case_count, permitted=False):
-        if permitted:
-            zip_filename = resources.create_zip_filename(case_list)
+    def create_download_response(self, case_list):
+        zip_filename = resources.create_zip_filename(case_list)
 
-            streamed_file = resources.create_zip(case_list)
-            response = FileResponse(FileWrapper(streamed_file), content_type='application/zip')
+        streamed_file = resources.create_zip(case_list)
+        response = FileResponse(FileWrapper(streamed_file), content_type='application/zip')
 
-            self.request.user.update_case_allowance(case_count=blacklisted_case_count)
-
-            response['Content-Disposition'] = 'attachment; filename="%s"' % zip_filename
-            return response
-        else:
-            case_allowance = self.request.user.case_allowance
-            time_remaining = self.request.user.get_case_allowance_update_time_remaining()
-            message = "You have reached your limit of allowed cases. Your limit will reset to default again in %s", time_remaining
-            details = """
-                      You attempted to download %s cases and your current remaining case limit is %s. 
-                      Use the max flag to return a specific number of cases: &max=%s
-                      """ % (
-                blacklisted_case_count,
-                case_allowance,
-                case_allowance)
-
-            return JsonResponse({'message': message, 'details': details}, status=403)
-
-    def check_case_allowance(self, case_count):
-        if case_count <= 0:
-            return True
-        self.request.user.update_case_allowance()
-        return self.request.user.case_allowance >= case_count
+        response['Content-Disposition'] = 'attachment; filename="%s"' % zip_filename
+        return response
 
     def list(self, *args, **kwargs):
         if not self.request.query_params.get('type') == 'download':
             return super(CaseViewSet, self).list(*args, **kwargs)
         else:
-            return self.download_many()
+            return self.download(**kwargs)
 
     def retrieve(self, *args, **kwargs):
         if not self.request.query_params.get('type') == 'download':
             return super(CaseViewSet, self).retrieve(*args, **kwargs)
         else:
-            return self.download_one(**kwargs)
+            return self.download(**kwargs)
+
 
 #   User specific views
 class UserViewSet(viewsets.ModelViewSet):

--- a/capstone/capapi/views.py
+++ b/capstone/capapi/views.py
@@ -103,7 +103,7 @@ class CaseViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Lis
         except ValidationError as err:
             return JsonResponse(err.detail, status=403)
 
-        response = self.create_download_response(cases, blacklisted_case_count)
+        response = self.create_download_response(cases)
         user.update_case_allowance(case_count=blacklisted_case_count)
 
         return response

--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -116,6 +116,7 @@ def read_file(path):
     with open(path) as in_file:
         return in_file.read()
 
+
 def parse_xml(xml):
     """
         Parse XML with PyQuery.
@@ -127,6 +128,7 @@ def parse_xml(xml):
         
     return PyQuery(xml, parser='xml', namespaces=nsmap)
 
+
 def copy_file(from_path, to_path, from_storage=None, to_storage=None):
     """
         Copy contents of from_path to to_path, optionally using storages instead of filesystem open().
@@ -136,3 +138,17 @@ def copy_file(from_path, to_path, from_storage=None, to_storage=None):
     with from_open(from_path, "rb") as in_file:
         with to_open(to_path, "wb") as out_file:
             shutil.copyfileobj(in_file, out_file)
+
+
+def extract_casebody(case_xml):
+    # strip soft hyphens from line endings
+    text = case_xml.replace(u'\xad', '')
+    case = parse_xml(text)
+
+    # strip labels from footnotes:
+    for footnote in case('casebody|footnote'):
+        label = footnote.attrib.get('label')
+        if label and footnote[0].text.startswith(label):
+            footnote[0].text = footnote[0].text[len(label):]
+
+    return case('casebody|casebody').html()

--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -21,7 +21,7 @@ def resolve_namespace(name):
     namespace, reference = name.split('|', 1)
     return '{%s}%s' % (nsmap[namespace], reference)
 
-jurisdiction_translation= {
+jurisdiction_translation = {
     '1': 'Ill.',
     'q': 'N.Y.',
     ' New York': 'N.Y.',


### PR DESCRIPTION
- Moved case allowance verification out of the view and into the UserSerializer
- Combined download logic for one and many cases under one method
- Added CaseXMLSerializer for getting only parts of the xml needed to serve to the user
- Added MetaCaseSerializer to combine CaseXMLSerialized and CaseMetadataSerialized data