### PR TITLE
small fixes

### DIFF
--- a/capstone/capapi/fixtures/groups.yaml
+++ b/capstone/capapi/fixtures/groups.yaml
@@ -1,0 +1,16 @@
+- model: auth.group
+  pk: 1
+  fields:
+    name: api_token
+    permissions:
+    - [add_apitoken, capapi, apitoken]
+    - [change_apitoken, capapi, apitoken]
+    - [delete_apitoken, capapi, apitoken]
+- model: auth.group
+  pk: 2
+  fields:
+    name: api_user
+    permissions:
+    - [add_apiuser, capapi, apiuser]
+    - [change_apiuser, capapi, apiuser]
+    - [delete_apiuser, capapi, apiuser]

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -55,7 +55,7 @@ class CaseSerializer(serializers.HyperlinkedModelSerializer):
     reporter = serializers.ReadOnlyField(source='reporter.full_name')
     reporter_url = serializers.HyperlinkedRelatedField(source='reporter', view_name='reporter-detail', read_only=True)
     citations = CitationSerializer(many=True)
-    volume = serializers.ReadOnlyField(source='volume.title')
+    volume = serializers.ReadOnlyField(source='volume.volume_number')
     volume_url = serializers.HyperlinkedRelatedField(source='volume', view_name='volumemetadata-detail', read_only=True)
 
     class Meta:

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -102,6 +102,15 @@ def load_test_data():
     ingest_jurisdiction()
     total_sync_with_s3()
 
+
+@task
+def add_permissions_groups():
+    """
+    Add permissions groups for admin panel
+    """
+    # add capapi groups
+    local("python manage.py loaddata capapi/fixtures/groups.yaml")
+
 @task
 def add_test_case(*barcodes):
     """


### PR DESCRIPTION
- showing volume number in api instead of volume title (which is often null)

- added api_token and api_user groups, so that we can give not-superuser staff members the ability to make changes in api models (users, tokens only for now).