### PR TITLE
Xml lazy load

### DIFF
--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -1,25 +1,22 @@
 from celery import shared_task
 
 from capdb.models import VolumeXML, CaseXML
-from scripts.helpers import chunked_iterator
 
 
 def create_case_metadata_from_all_vols(update_existing=False):
     """
         iterate through all volumes, call celery task for each volume
     """
-    volumes = VolumeXML.objects.all().order_by('id')
-    for volume in chunked_iterator(volumes, chunk_size=200):
-        create_case_metadata_from_vol.delay(volume.barcode, update_existing=update_existing)
+    for volume_id in VolumeXML.objects.values_list('pk', flat=True):
+        create_case_metadata_from_vol.delay(volume_id, update_existing=update_existing)
 
 
 @shared_task
-def create_case_metadata_from_vol(volume_barcode, update_existing=False):
+def create_case_metadata_from_vol(volume_id, update_existing=False):
     """
         create or update cases for each volume
     """
-    casexmls = CaseXML.objects.filter(volume__barcode=volume_barcode).order_by('id')
-    for casexml in chunked_iterator(casexmls, chunk_size=200):
+    for casexml in CaseXML.objects.filter(volume_id=volume_id).defer_xml():
         casexml.create_or_update_metadata(update_existing=update_existing)
 
 

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -49,10 +49,6 @@ def ingest_volumes():
     ingest_files.ingest_volumes()
 
 @task
-def update_case_metadata():
-    ingest_files.update_case_metadata()
-
-@task
 def ingest_jurisdiction():
     ingest_tt_data.populate_jurisdiction()
 

--- a/capstone/scripts/ingest_files.py
+++ b/capstone/scripts/ingest_files.py
@@ -3,15 +3,12 @@ import re
 import time
 from collections import defaultdict
 from multiprocessing import Pool
-from tqdm import tqdm
 
 from django.conf import settings
 from django.db import transaction, IntegrityError
 
 from capdb.models import VolumeXML, PageXML, CaseXML
 from capdb.storages import ingest_storage
-
-from scripts.helpers import chunked_iterator
 
 ### helpers ###
 

--- a/capstone/scripts/ingest_files.py
+++ b/capstone/scripts/ingest_files.py
@@ -178,11 +178,3 @@ def all_volumes():
             return volumes
     return volumes
 
-
-def update_case_metadata():
-    casexmls = CaseXML.objects.all().order_by('id')
-    for case in tqdm(chunked_iterator(casexmls)):
-        try:
-            case.create_or_update_metadata()
-        except Exception as e:
-            print(e, case.case_id)

--- a/capstone/scripts/process_ingested_xml.py
+++ b/capstone/scripts/process_ingested_xml.py
@@ -1,6 +1,6 @@
 from django.db import connection
 
-from cap.models import VolumeXML
+from capdb.models import VolumeXML
 
 
 def build_case_page_join_table(volume_id=None):
@@ -35,6 +35,6 @@ def build_case_page_join_table(volume_id=None):
 
 def fill_case_page_join_table():
     """ Call build_case_page_join_table for each volume ID. """
-    for volume in VolumeXML.objects.all():
-        print("Indexing", volume)
-        build_case_page_join_table(volume.id)
+    for volume_id in VolumeXML.objects.values_list('pk', flat=True):
+        print("Indexing", volume_id)
+        build_case_page_join_table(volume_id)

--- a/capstone/setup.cfg
+++ b/capstone/setup.cfg
@@ -12,7 +12,7 @@ ignore = E12,
          E4,
          E501,
          F403,F405
-exclude = static
+exclude = static,test_data,.git
 
 
 ## http://coverage.readthedocs.io/en/latest/config.html


### PR DESCRIPTION
- Abstract common functionality from VolumeXML/PageXML/CaseXML into BaseXMLModel.
- Add BaseXML.objects.defer_xml() function, which is equivalent to BaseXML.objects.defer('orig_xml'). (This isn't a huge win, but it's a bit handy I guess.)
- Use memory-efficient queries in a couple of places where we iterate over XML tables.
- Drop the old unused update_case_metadata.
