### PR TITLE
Case metadata tweaks

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -528,7 +528,7 @@ class CaseXML(BaseXMLModel):
 class Citation(AutoSlugMixin, models.Model):
     type = models.CharField(max_length=100,
                             choices=(("official", "official"), ("parallel", "parallel")))
-    cite = models.CharField(max_length=255, db_index=True)
+    cite = models.CharField(max_length=10000, db_index=True)
     duplicative = models.BooleanField(default=False)
     slug = models.SlugField(max_length=255, unique=True)
 
@@ -536,7 +536,7 @@ class Citation(AutoSlugMixin, models.Model):
         return self.slug
 
     def get_slug(self):
-        return self.cite
+        return self.cite[:100]
 
 class PageXML(BaseXMLModel):
     barcode = models.CharField(max_length=255, unique=True, db_index=True)

--- a/capstone/scripts/process_metadata.py
+++ b/capstone/scripts/process_metadata.py
@@ -62,9 +62,18 @@ def get_case_metadata(case_xml):
 
 def decision_datetime(decision_date_text):
     try:
-        return datetime.strptime(decision_date_text, '%Y-%m-%d')
-    except ValueError:
         try:
-            return datetime.strptime(decision_date_text, '%Y-%m')
-        except ValueError:
-            return datetime.strptime(decision_date_text, '%Y')
+            return datetime.strptime(decision_date_text, '%Y-%m-%d')
+        except ValueError as e:
+
+            # if court used an invalid day of month (typically Feb. 29), strip day from date
+            if e.args[0] == 'day is out of range for month':
+                decision_date_text = decision_date_text.rsplit('-', 1)[0]
+
+            try:
+                return datetime.strptime(decision_date_text, '%Y-%m')
+            except ValueError:
+                return datetime.strptime(decision_date_text, '%Y')
+    except Exception as e:
+        # if for some reason we can't parse the date, just store None
+        return None


### PR DESCRIPTION
Fixes the remaining two case metadata errors that showed up in our last run:

- Some citations (probably due to coding errors) are very long. Increase the max size so we can import and find those.
- Some cases are published on fake made-up dates like Feb. 29, 1911. Strip the day-of-month from those for now. (Later we can find them by searching decision_date_original if we want to do something better with them.) Also catch unexpected errors in date parsing (again, later we can check decision_date_original where `decision_date=None` to find and correct those).