### PR TITLE
Track field changes on CaseXML model

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -2,6 +2,7 @@ import hashlib
 from django.contrib.postgres.fields import JSONField, ArrayField
 from django.db import models, IntegrityError, transaction
 from django.utils.text import slugify
+from model_utils import FieldTracker
 
 from scripts.process_metadata import get_case_metadata
 from scripts.helpers import *
@@ -425,6 +426,7 @@ class CaseXML(BaseXMLModel):
                                      on_delete=models.DO_NOTHING)
     s3_key = models.CharField(max_length=1024, blank=True, help_text="s3 path")
 
+    tracker = FieldTracker()
 
     def __str__(self):
         return str(self.pk)

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -23,6 +23,7 @@ Django
 django-storages     # abstract file access
 boto3               # for django-storages to talk to s3
 django-bulk-update  # bulk update of models
+django-model-utils  # FieldTracker for tracking changed fields on model instances
 
 # Admin stuff
 pip-tools           # freeze requirements.txt

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -29,6 +29,7 @@ django-compressor==2.1.1  # via django-libsass
 django-extensions==1.8.1
 django-filter==1.0.4
 django-libsass==0.7
+django-model-utils==3.0.0
 django-pipeline==1.6.13
 django-storages==1.5.2
 django==1.11.1


### PR DESCRIPTION
Add `django-model-utils` plugin, so we can check whether fields have been updated with `self.tracker.has_changed('orig_xml')`. See http://django-model-utils.readthedocs.io/en/latest/utilities.html#field-tracker .

Models should have `tracker = FieldTracker()` added if they need to use tracking. This seems to have to go on concrete models (e.g. CaseXML) rather than base classes.