### PR TITLE
Xml fixes

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -133,6 +133,12 @@ class XMLField(models.TextField):
     """ Column type for Postgres XML columns. """
     def db_type(self, connection):
         return 'xml'
+    
+    def from_db_value(self, value, *args, **kwargs):
+        """ Make sure that XML returned from postgres includes XML declaration. """
+        if value and not value.startswith('<?'):
+            return "<?xml version='1.0' encoding='utf-8'?>\n" + value
+        return value
 
 
 class XMLQuerySet(models.QuerySet):

--- a/capstone/capdb/tests/test_ingest.py
+++ b/capstone/capdb/tests/test_ingest.py
@@ -5,35 +5,35 @@ from capdb.models import TrackingToolUser, BookRequest, ProcessStep, Reporter, T
 from scripts.helpers import parse_xml
 
 @pytest.mark.django_db
-def test_volume_metadata(volume_xml):
-    assert volume_xml.metadata.hollis_number == "005457617"
-    assert volume_xml.metadata.rare is False  # boolean conversion
+def test_volume_metadata(ingest_volume_xml):
+    assert ingest_volume_xml.metadata.hollis_number == "005457617"
+    assert ingest_volume_xml.metadata.rare is False  # boolean conversion
 
 @pytest.mark.django_db
-def test_tracking_tool_relationships(volume_xml):
-    assert volume_xml.metadata.reporter.full_name == "Illinois Appellate Court Reports"
-    assert volume_xml.metadata.tracking_tool_logs.first().pstep.pk == 'Prqu'
+def test_tracking_tool_relationships(ingest_volume_xml):
+    assert ingest_volume_xml.metadata.reporter.full_name == "Illinois Appellate Court Reports"
+    assert ingest_volume_xml.metadata.tracking_tool_logs.first().pstep.pk == 'Prqu'
 
 @pytest.mark.django_db
-def test_volume_xml(volume_xml):
-    assert '<reporter abbreviation="Ill. App." volnumber="23">Illinois Appellate Court Reports</reporter>' in volume_xml.orig_xml
+def test_volume_xml(ingest_volume_xml):
+    assert '<reporter abbreviation="Ill. App." volnumber="23">Illinois Appellate Court Reports</reporter>' in ingest_volume_xml.orig_xml
 
 @pytest.mark.django_db
-def test_case_and_page_xml(volume_xml):
-    assert volume_xml.case_xmls.count() == 1
-    assert volume_xml.page_xmls.count() == 6
-    case_xml = volume_xml.case_xmls.first()
+def test_case_and_page_xml(ingest_volume_xml):
+    assert ingest_volume_xml.case_xmls.count() == 1
+    assert ingest_volume_xml.page_xmls.count() == 6
+    case_xml = ingest_volume_xml.case_xmls.first()
     assert '<name abbreviation="Home Insurance Co. of New York v. Kirk">' in case_xml.orig_xml
     assert case_xml.pages.count() == 6
 
 @pytest.mark.django_db
-def test_duplicative_case_xml(duplicative_case_xml):
-    assert duplicative_case_xml.metadata.duplicative is True
-    assert duplicative_case_xml.metadata.first_page == "1"
-    assert duplicative_case_xml.metadata.last_page == "4"
+def test_duplicative_case_xml(ingest_duplicative_case_xml):
+    assert ingest_duplicative_case_xml.metadata.duplicative is True
+    assert ingest_duplicative_case_xml.metadata.first_page == "1"
+    assert ingest_duplicative_case_xml.metadata.last_page == "4"
 
 @pytest.mark.django_db
-def test_update_dup_checking(volume_xml, case_xml):
+def test_update_dup_checking(ingest_volume_xml, ingest_case_xml):
     fabfile.total_sync_with_s3()
  
     # change value in ALTO
@@ -45,34 +45,34 @@ def test_update_dup_checking(volume_xml, case_xml):
     page_xml.save()
 
     # change corresponding value in casemets
-    parsed_case = parse_xml(case_xml.orig_xml)
-    original_case_md5 = case_xml.md5
+    parsed_case = parse_xml(ingest_case_xml.orig_xml)
+    original_case_md5 = ingest_case_xml.md5
     parsed_case('casebody|parties[id="b15-4"]').text('The Home Inversion Company of New York v. John Kirk, for use of William Kirk.')
     parsed_case('mets|file[ID="alto_00008_0"]').attr["CHECKSUM"] = page_xml.md5
-    case_xml.orig_xml = str(parsed_case)
-    case_xml.save()
+    ingest_case_xml.orig_xml = str(parsed_case)
+    ingest_case_xml.save()
 
     # update checksums in volume mets
-    parsed_volume = parse_xml(volume_xml.orig_xml)
+    parsed_volume = parse_xml(ingest_volume_xml.orig_xml)
     parsed_volume('mets|file[ID="alto_00008_0"]').attr["CHECKSUM"] = page_xml.md5
-    parsed_volume('mets|file[ID="casemets_0001"]').attr["CHECKSUM"] = case_xml.md5
-    volume_xml.save()
+    parsed_volume('mets|file[ID="casemets_0001"]').attr["CHECKSUM"] = ingest_case_xml.md5
+    ingest_volume_xml.save()
 
     # make sure the writes worked. If they failed, the test would falsely pass
     assert original_page_md5 != page_xml.md5
-    assert original_case_md5 != case_xml.md5
-    assert 'Inversion' in case_xml.orig_xml
+    assert original_case_md5 != ingest_case_xml.md5
+    assert 'Inversion' in ingest_case_xml.orig_xml
     assert 'Inversion' in page_xml.orig_xml
 
     fabfile.total_sync_with_s3()
 
-    volume_xml.refresh_from_db()
-    case_xml.refresh_from_db()
+    ingest_volume_xml.refresh_from_db()
+    ingest_case_xml.refresh_from_db()
     page_xml.refresh_from_db()
 
     assert original_page_md5 == page_xml.md5
-    assert original_case_md5 == case_xml.md5
-    assert 'Inversion' not in case_xml.orig_xml
+    assert original_case_md5 == ingest_case_xml.md5
+    assert 'Inversion' not in ingest_case_xml.orig_xml
     assert 'Inversion' not in page_xml.orig_xml
 
 
@@ -100,3 +100,4 @@ def test_sync_metadata(ingest_metadata):
     # make sure deleted objects were restored
     new_counts = get_counts()
     assert new_counts == orig_counts
+

--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -7,16 +7,16 @@ from scripts.helpers import parse_xml, serialize_xml
 ### CaseMetadata ###
 
 @pytest.mark.django_db
-def test_create_or_update_metadata(case_xml):
+def test_create_or_update_metadata(ingest_case_xml):
     # fetch current metadata
-    case_metadata = case_xml.metadata
+    case_metadata = ingest_case_xml.metadata
 
     # change xml
-    parsed = parse_xml(case_xml.orig_xml)
+    parsed = parse_xml(ingest_case_xml.orig_xml)
     parsed('case|citation[category="official"]').text('123 Test 456')
-    case_xml.orig_xml = serialize_xml(parsed)
-    case_xml.save()
-    case_xml.create_or_update_metadata()
+    ingest_case_xml.orig_xml = serialize_xml(parsed)
+    ingest_case_xml.save()
+    ingest_case_xml.create_or_update_metadata()
 
     # fetch new metadata
     new_case_metadata = CaseMetadata.objects.get(pk=case_metadata.pk)
@@ -32,9 +32,9 @@ def test_create_or_update_metadata(case_xml):
 
     # testing calling without updating metadata
     old_case_metadata = new_case_metadata
-    case_xml.orig_xml = "Nothing to see here"
-    case_xml.save()
-    case_xml.refresh_from_db()
-    case_xml.create_or_update_metadata(update_existing=False)
+    ingest_case_xml.orig_xml = "Nothing to see here"
+    ingest_case_xml.save()
+    ingest_case_xml.refresh_from_db()
+    ingest_case_xml.create_or_update_metadata(update_existing=False)
     new_case_metadata = CaseMetadata.objects.get(pk=case_metadata.pk)
     assert new_case_metadata == old_case_metadata

--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -4,6 +4,18 @@ from capdb.models import CaseMetadata
 from scripts.helpers import parse_xml, serialize_xml
 
 
+### BaseXMLModel ###
+
+@pytest.mark.django_db
+def test_database_should_not_modify_xml(volume_xml, unaltered_alto_xml):
+    # make sure that XMLField.from_db_value is doing its job and putting the correct XML declaration back in:
+    volume_xml.orig_xml = unaltered_alto_xml
+    volume_xml.save()
+    volume_xml.refresh_from_db()
+    assert volume_xml.orig_xml == unaltered_alto_xml.decode()
+    assert volume_xml.md5 == volume_xml.get_md5()
+
+
 ### CaseMetadata ###
 
 @pytest.mark.django_db

--- a/capstone/capdb/tests/test_process_metadata.py
+++ b/capstone/capdb/tests/test_process_metadata.py
@@ -24,19 +24,19 @@ def test_get_case_metadata():
                     assert type(case_metadata["decision_date_original"]) is str
 
 @pytest.mark.django_db
-def test_create_case_metadata_from_all_vols(case_xml):
+def test_create_case_metadata_from_all_vols(ingest_case_xml):
     # get initial state
     metadata_count = CaseMetadata.objects.count()
-    case_id = case_xml.metadata.case_id
+    case_id = ingest_case_xml.metadata.case_id
 
     # delete case metadata
-    case_xml.metadata.delete()
+    ingest_case_xml.metadata.delete()
     assert CaseMetadata.objects.count() == metadata_count - 1
 
     # recreate case metadata
     create_case_metadata_from_all_vols()
 
     # check success
-    case_xml.refresh_from_db()
+    ingest_case_xml.refresh_from_db()
     assert CaseMetadata.objects.count() == metadata_count
-    assert case_xml.metadata.case_id == case_id
+    assert ingest_case_xml.metadata.case_id == case_id

--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -197,7 +197,7 @@ def serialize_xml(xml):
     """
         Write PyQuery object back to utf-8 bytestring.
     """
-    return b''.join([etree.tostring(e, encoding='utf-8', xml_declaration=True) for e in xml])
+    return b''.join([etree.tostring(e, encoding='utf-8', xml_declaration=True) for e in xml]) + b'\n'
 
 
 def copy_file(from_path, to_path, from_storage=None, to_storage=None):

--- a/capstone/scripts/tests/conftest.py
+++ b/capstone/scripts/tests/conftest.py
@@ -1,0 +1,1 @@
+from test_data.test_fixtures.fixtures import *  # noqa

--- a/capstone/scripts/tests/test_helpers.py
+++ b/capstone/scripts/tests/test_helpers.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+
+from django.conf import settings
+
+from scripts.helpers import serialize_xml, parse_xml
+
+
+def test_serialize_xml_should_not_modify_input_xml(unaltered_alto_xml):
+    parsed = parse_xml(unaltered_alto_xml)
+
+    # make a change
+    parsed('[ID="b17-15"]').attr('ID', 'replace_me')
+
+    # serialize parsed xml
+    new_xml = serialize_xml(parsed)
+
+    # undo the change for comparison
+    assert b'replace_me' in new_xml  # make sure modification worked
+    new_xml = new_xml.replace(b'replace_me', b'b17-15')
+
+    # serialized xml should be identical
+    assert unaltered_alto_xml == new_xml

--- a/capstone/scripts/tests/test_helpers.py
+++ b/capstone/scripts/tests/test_helpers.py
@@ -1,8 +1,3 @@
-import os
-import pytest
-
-from django.conf import settings
-
 from scripts.helpers import serialize_xml, parse_xml
 
 

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -103,13 +103,13 @@ def ingest_volumes(ingest_metadata, redis_patch):
     fabfile.total_sync_with_s3()
 
 @pytest.fixture
-def volume_xml(ingest_volumes):
+def ingest_volume_xml(ingest_volumes):
     return VolumeXML.objects.get(metadata__barcode='32044057892259')
 
 @pytest.fixture
-def case_xml(volume_xml):
-    return volume_xml.case_xmls.first()
+def ingest_case_xml(ingest_volume_xml):
+    return ingest_volume_xml.case_xmls.first()
 
 @pytest.fixture
-def duplicative_case_xml(ingest_volumes):
+def ingest_duplicative_case_xml(ingest_volumes):
     return CaseXML.objects.get(metadata__case_id='32044061407086_0001')

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from django.conf import settings
@@ -10,6 +11,15 @@ from capdb.models import VolumeXML, CaseXML, Jurisdiction, Court
 import capdb.storages
 
 from . import factories
+
+
+### file contents ###
+
+@pytest.fixture
+def unaltered_alto_xml():
+    """ XML from an alto file we haven't modified at all. """
+    with open(os.path.join(settings.BASE_DIR, 'test_data/unaltered_32044057891608_redacted_ALTO_00009_1.xml'), 'rb') as in_file:
+        return in_file.read()
 
 
 ### Django json fixtures ###
@@ -37,6 +47,10 @@ def user():
 @pytest.fixture
 def auth_user():
     return factories.setup_authenticated_user()
+
+@pytest.fixture
+def volume_xml():
+    return factories.VolumeXMLFactory()
 
 @pytest.fixture
 def case():

--- a/capstone/test_data/unaltered_32044057891608_redacted_ALTO_00009_1.xml
+++ b/capstone/test_data/unaltered_32044057891608_redacted_ALTO_00009_1.xml
@@ -1,0 +1,1115 @@
+<?xml version='1.0' encoding='utf-8'?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v3#">
+  <!--Created by Innodata R.E.D. RLI tool: 2016-03-18 11:42:44.679247-->
+  <Description>
+    <MeasurementUnit>pixel</MeasurementUnit>
+    <sourceImageInformation>
+      <fileName>32044057891608_00009_1.tif</fileName>
+    </sourceImageInformation>
+    <OCRProcessing ID="OP_1">
+      <ocrProcessingStep>
+        <processingStepDescription>Alto coordinates refer to the deskewed TIFF file. 
+		To convert point (x, y) to original image (TIFF or JP2) apply transformation matrix T=(m00, m01, m10, m11, b0, b1) using the rule:
+			T * (x,y) = (m00 * x + m01 * y + b0), (m10 * x + m11 * y + b1)</processingStepDescription>
+        <processingStepSettings>RED.transform=(1.0, -0.0, 0.0, 1.0, 0.0, -0.0)</processingStepSettings>
+      </ocrProcessingStep>
+    </OCRProcessing>
+  </Description>
+  <Styles>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="6.00" FONTSTYLE="italics" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_1"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="6.00" FONTSTYLE="italics smallcaps" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_2"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="7.50" FONTSTYLE="smallcaps" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_3"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="7.50" FONTSTYLE="italics" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_4"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="8.00" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_5"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="8.00" FONTSTYLE="smallcaps" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_6"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="8.00" FONTSTYLE="italics" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_7"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="10.00" FONTSTYLE="bold" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_8"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="10.00" FONTSTYLE="bold italics" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_9"/>
+    <TextStyle FONTFAMILY="Times New Roman" FONTSIZE="11.00" FONTSTYLE="bold" FONTTYPE="serif" FONTWIDTH="proportional" ID="Style_10"/>
+  </Styles>
+  <Tags>
+    <StructureTag ID="b17-15" LABEL="footnote"/>
+    <StructureTag ID="b18-11" LABEL="footnote"/>
+    <StructureTag ID="b18-12" LABEL="footnote"/>
+    <StructureTag ID="b18-13" LABEL="footnote"/>
+    <StructureTag ID="b18-1" LABEL="pagelabel"/>
+    <StructureTag ID="b18-2" LABEL="pagematter"/>
+    <StructureTag ID="b18-3" LABEL="pagematter"/>
+    <StructureTag ID="b18-4" LABEL="name"/>
+    <StructureTag ID="b18-5" LABEL="headnotes"/>
+    <StructureTag ID="b18-6" LABEL="headnotes"/>
+    <StructureTag ID="b18-7" LABEL="p"/>
+    <RoleTag ID="footnotemark0001" LABEL="footnotemark"/>
+    <StructureTag ID="b18-8" LABEL="p"/>
+    <RoleTag ID="footnotemark0002" LABEL="footnotemark"/>
+    <StructureTag ID="b18-9" LABEL="p"/>
+    <StructureTag ID="b18-14" LABEL="footnote"/>
+    <StructureTag ID="b18-15" LABEL="footnote"/>
+    <StructureTag ID="b18-16" LABEL="footnote"/>
+    <StructureTag ID="b18-17" LABEL="footnote"/>
+    <StructureTag ID="b18-18" LABEL="footnote"/>
+  </Tags>
+  <Layout>
+    <Page HEIGHT="2587" ID="PG_18" PHYSICAL_IMG_NR="18" WIDTH="1506">
+      <PrintSpace HEIGHT="2587" HPOS="0" ID="PS_18" VPOS="0" WIDTH="1506">
+        <TextBlock HEIGHT="99.0" HPOS="286.0" ID="BL_18.1" TAGREFS="b17-15" VPOS="1243.0" WIDTH="1131.0">
+          <TextLine HEIGHT="34" HPOS="294" ID="TL_18.1.1" VPOS="1243" WIDTH="1123">
+            <String CONTENT="Vanorsdale," HEIGHT="32" HPOS="294" ID="ST_18.1.1.1" STYLEREFS="Style_7" VPOS="1243" WIDTH="150" WC="0.69" CC="00900009000" TAGREFS=""/>
+            <SP HPOS="444" ID="SP_18.1.1.2" VPOS="1247" WIDTH="9"/>
+            <String CONTENT="post." HEIGHT="29" HPOS="453" ID="ST_18.1.1.3" STYLEREFS="Style_5" VPOS="1247" WIDTH="65" WC="0.58" CC="00000" TAGREFS=""/>
+            <SP HPOS="518" ID="SP_18.1.1.4" VPOS="1244" WIDTH="32"/>
+            <String CONTENT="Pool" HEIGHT="25" HPOS="550" ID="ST_18.1.1.5" STYLEREFS="Style_7" VPOS="1244" WIDTH="62" WC="0.49" CC="0000" TAGREFS=""/>
+            <SP HPOS="612" ID="SP_18.1.1.6" VPOS="1252" WIDTH="6"/>
+            <String CONTENT="v." HEIGHT="17" HPOS="618" ID="ST_18.1.1.7" STYLEREFS="Style_5" VPOS="1252" WIDTH="24" WC="0.61" CC="00" TAGREFS=""/>
+            <SP HPOS="642" ID="SP_18.1.1.8" VPOS="1243" WIDTH="14"/>
+            <String CONTENT="Vanlandingham," HEIGHT="34" HPOS="656" ID="ST_18.1.1.9" STYLEREFS="Style_7" VPOS="1243" WIDTH="212" WC="0.60" CC="00000000000009" TAGREFS=""/>
+            <SP HPOS="868" ID="SP_18.1.1.10" VPOS="1244" WIDTH="9"/>
+            <String CONTENT="id." HEIGHT="25" HPOS="877" ID="ST_18.1.1.11" STYLEREFS="Style_7" VPOS="1244" WIDTH="34" WC="0.88" CC="000" TAGREFS=""/>
+            <SP HPOS="911" ID="SP_18.1.1.12" VPOS="1244" WIDTH="32"/>
+            <String CONTENT="Bradshaw" HEIGHT="25" HPOS="943" ID="ST_18.1.1.13" STYLEREFS="Style_7" VPOS="1244" WIDTH="137" WC="0.56" CC="00000000" TAGREFS=""/>
+            <SP HPOS="1080" ID="SP_18.1.1.14" VPOS="1253" WIDTH="10"/>
+            <String CONTENT="v." HEIGHT="16" HPOS="1090" ID="ST_18.1.1.15" STYLEREFS="Style_5" VPOS="1253" WIDTH="25" WC="0.44" CC="00" TAGREFS=""/>
+            <SP HPOS="1115" ID="SP_18.1.1.16" VPOS="1243" WIDTH="7"/>
+            <String CONTENT="Newman," HEIGHT="32" HPOS="1122" ID="ST_18.1.1.17" STYLEREFS="Style_7" VPOS="1243" WIDTH="125" WC="0.55" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1247" ID="SP_18.1.1.18" VPOS="1244" WIDTH="8"/>
+            <String CONTENT="id." HEIGHT="25" HPOS="1255" ID="ST_18.1.1.19" STYLEREFS="Style_7" VPOS="1244" WIDTH="34" WC="0.74" CC="000" TAGREFS=""/>
+            <SP HPOS="1289" ID="SP_18.1.1.20" VPOS="1243" WIDTH="33"/>
+            <String CONTENT="Sims" HEIGHT="26" HPOS="1322" ID="ST_18.1.1.21" STYLEREFS="Style_7" VPOS="1243" WIDTH="65" WC="0.57" CC="0000" TAGREFS=""/>
+            <SP HPOS="1387" ID="SP_18.1.1.22" VPOS="1252" WIDTH="6"/>
+            <String CONTENT="v." HEIGHT="17" HPOS="1393" ID="ST_18.1.1.23" STYLEREFS="Style_5" VPOS="1252" WIDTH="24" WC="0.61" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="38" HPOS="286" ID="TL_18.1.2" VPOS="1271" WIDTH="1131">
+            <String CONTENT="Klein," HEIGHT="30" HPOS="286" ID="ST_18.1.2.1" STYLEREFS="Style_7" VPOS="1277" WIDTH="83" WC="0.47" CC="000000" TAGREFS=""/>
+            <SP HPOS="369" ID="SP_18.1.2.2" VPOS="1277" WIDTH="8"/>
+            <String CONTENT="id." HEIGHT="25" HPOS="377" ID="ST_18.1.2.3" STYLEREFS="Style_7" VPOS="1277" WIDTH="33" WC="0.88" CC="000" TAGREFS=""/>
+            <SP HPOS="410" ID="SP_18.1.2.4" VPOS="1277" WIDTH="34"/>
+            <String CONTENT="Swain" HEIGHT="25" HPOS="444" ID="ST_18.1.2.5" STYLEREFS="Style_7" VPOS="1277" WIDTH="83" WC="0.54" CC="00000" TAGREFS=""/>
+            <SP HPOS="527" ID="SP_18.1.2.6" VPOS="1285" WIDTH="10"/>
+            <String CONTENT="v." HEIGHT="16" HPOS="537" ID="ST_18.1.2.7" STYLEREFS="Style_5" VPOS="1285" WIDTH="24" WC="0.53" CC="09" TAGREFS=""/>
+            <SP HPOS="561" ID="SP_18.1.2.8" VPOS="1276" WIDTH="14"/>
+            <String CONTENT="Cawood," HEIGHT="32" HPOS="575" ID="ST_18.1.2.9" STYLEREFS="Style_7" VPOS="1276" WIDTH="107" WC="0.65" CC="0000000" TAGREFS=""/>
+            <SP HPOS="682" ID="SP_18.1.2.10" VPOS="1280" WIDTH="12"/>
+            <String CONTENT="2" HEIGHT="21" HPOS="694" ID="ST_18.1.2.11" STYLEREFS="Style_5" VPOS="1280" WIDTH="15" WC="0.31" CC="0" TAGREFS=""/>
+            <SP HPOS="709" ID="SP_18.1.2.12" VPOS="1278" WIDTH="18"/>
+            <String CONTENT="Scammon," HEIGHT="30" HPOS="727" ID="ST_18.1.2.13" STYLEREFS="Style_5" VPOS="1278" WIDTH="142" WC="0.50" CC="90000000" TAGREFS=""/>
+            <SP HPOS="869" ID="SP_18.1.2.14" VPOS="1279" WIDTH="14"/>
+            <String CONTENT="505." HEIGHT="22" HPOS="883" ID="ST_18.1.2.15" STYLEREFS="Style_5" VPOS="1279" WIDTH="54" WC="0.88" CC="0000" TAGREFS=""/>
+            <SP HPOS="937" ID="SP_18.1.2.16" VPOS="1276" WIDTH="39"/>
+            <String CONTENT="Vanlandingham" HEIGHT="33" HPOS="976" ID="ST_18.1.2.17" STYLEREFS="Style_7" VPOS="1276" WIDTH="204" WC="0.57" CC="0000000000000" TAGREFS=""/>
+            <SP HPOS="1180" ID="SP_18.1.2.18" VPOS="1285" WIDTH="14"/>
+            <String CONTENT="v." HEIGHT="17" HPOS="1194" ID="ST_18.1.2.19" STYLEREFS="Style_2" VPOS="1285" WIDTH="24" WC="1.0" CC="00" TAGREFS=""/>
+            <SP HPOS="1218" ID="SP_18.1.2.20" VPOS="1271" WIDTH="13"/>
+            <String CONTENT="Ryan," HEIGHT="38" HPOS="1231" ID="ST_18.1.2.21" STYLEREFS="Style_7" VPOS="1271" WIDTH="79" WC="0.35" CC="00000" TAGREFS=""/>
+            <SP HPOS="1310" ID="SP_18.1.2.22" VPOS="1278" WIDTH="15"/>
+            <String CONTENT="17" HEIGHT="23" HPOS="1325" ID="ST_18.1.2.23" STYLEREFS="Style_5" VPOS="1278" WIDTH="28" WC="0.43" CC="00" TAGREFS=""/>
+            <SP HPOS="1353" ID="SP_18.1.2.24" VPOS="1277" WIDTH="13"/>
+            <String CONTENT="Illi­" HEIGHT="24" HPOS="1366" ID="ST_18.1.2.25" STYLEREFS="Style_5" VPOS="1277" WIDTH="51" WC="1.0" CC="00000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="32" HPOS="288" ID="TL_18.1.3" VPOS="1310" WIDTH="192">
+            <String CONTENT="nois" HEIGHT="24" HPOS="288" ID="ST_18.1.3.1" STYLEREFS="Style_5" VPOS="1310" WIDTH="55" WC="0.69" CC="0000" TAGREFS=""/>
+            <SP HPOS="343" ID="SP_18.1.3.2" VPOS="1310" WIDTH="12"/>
+            <String CONTENT="Rep.," HEIGHT="32" HPOS="355" ID="ST_18.1.3.3" STYLEREFS="Style_5" VPOS="1310" WIDTH="73" WC="0.45" CC="00099" TAGREFS=""/>
+            <SP HPOS="428" ID="SP_18.1.3.4" VPOS="1312" WIDTH="12"/>
+            <String CONTENT="25." HEIGHT="22" HPOS="440" ID="ST_18.1.3.5" STYLEREFS="Style_5" VPOS="1312" WIDTH="40" WC="0.58" CC="000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="95.0" HPOS="286.0" ID="BL_18.2" TAGREFS="b18-11" VPOS="1341.0" WIDTH="1132.0">
+          <TextLine HEIGHT="33" HPOS="318" ID="TL_18.2.1" VPOS="1341" WIDTH="1100">
+            <String CONTENT="A" HEIGHT="24" HPOS="318" ID="ST_18.2.1.1" STYLEREFS="Style_5" VPOS="1342" WIDTH="27" WC="0.28" CC="0" TAGREFS=""/>
+            <SP HPOS="345" ID="SP_18.2.1.2" VPOS="1343" WIDTH="10"/>
+            <String CONTENT="plea" HEIGHT="31" HPOS="355" ID="ST_18.2.1.3" STYLEREFS="Style_5" VPOS="1343" WIDTH="57" WC="0.34" CC="0000" TAGREFS=""/>
+            <SP HPOS="412" ID="SP_18.2.1.4" VPOS="1342" WIDTH="11"/>
+            <String CONTENT="of" HEIGHT="24" HPOS="423" ID="ST_18.2.1.5" STYLEREFS="Style_5" VPOS="1342" WIDTH="28" WC="0.68" CC="00" TAGREFS=""/>
+            <SP HPOS="451" ID="SP_18.2.1.6" VPOS="1342" WIDTH="12"/>
+            <String CONTENT="failure" HEIGHT="24" HPOS="463" ID="ST_18.2.1.7" STYLEREFS="Style_5" VPOS="1342" WIDTH="87" WC="0.62" CC="0000000" TAGREFS=""/>
+            <SP HPOS="550" ID="SP_18.2.1.8" VPOS="1341" WIDTH="8"/>
+            <String CONTENT="of" HEIGHT="24" HPOS="558" ID="ST_18.2.1.9" STYLEREFS="Style_5" VPOS="1341" WIDTH="28" WC="0.75" CC="00" TAGREFS=""/>
+            <SP HPOS="586" ID="SP_18.2.1.10" VPOS="1341" WIDTH="14"/>
+            <String CONTENT="consideration" HEIGHT="25" HPOS="600" ID="ST_18.2.1.11" STYLEREFS="Style_5" VPOS="1341" WIDTH="180" WC="0.60" CC="0000000000000" TAGREFS=""/>
+            <SP HPOS="780" ID="SP_18.2.1.12" VPOS="1345" WIDTH="10"/>
+            <String CONTENT="to" HEIGHT="21" HPOS="790" ID="ST_18.2.1.13" STYLEREFS="Style_5" VPOS="1345" WIDTH="25" WC="1.00" CC="00" TAGREFS=""/>
+            <SP HPOS="815" ID="SP_18.2.1.14" VPOS="1349" WIDTH="13"/>
+            <String CONTENT="an" HEIGHT="16" HPOS="828" ID="ST_18.2.1.15" STYLEREFS="Style_5" VPOS="1349" WIDTH="33" WC="0.28" CC="00" TAGREFS=""/>
+            <SP HPOS="861" ID="SP_18.2.1.16" VPOS="1342" WIDTH="11"/>
+            <String CONTENT="action" HEIGHT="24" HPOS="872" ID="ST_18.2.1.17" STYLEREFS="Style_5" VPOS="1342" WIDTH="81" WC="0.81" CC="000000" TAGREFS=""/>
+            <SP HPOS="953" ID="SP_18.2.1.18" VPOS="1349" WIDTH="16"/>
+            <String CONTENT="upon" HEIGHT="24" HPOS="969" ID="ST_18.2.1.19" STYLEREFS="Style_5" VPOS="1349" WIDTH="69" WC="0.70" CC="0000" TAGREFS=""/>
+            <SP HPOS="1038" ID="SP_18.2.1.20" VPOS="1349" WIDTH="11"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="1049" ID="ST_18.2.1.21" STYLEREFS="Style_5" VPOS="1349" WIDTH="16" WC="0.37" CC="0" TAGREFS=""/>
+            <SP HPOS="1065" ID="SP_18.2.1.22" VPOS="1345" WIDTH="9"/>
+            <String CONTENT="note," HEIGHT="27" HPOS="1074" ID="ST_18.2.1.23" STYLEREFS="Style_5" VPOS="1345" WIDTH="67" WC="0.47" CC="00000" TAGREFS=""/>
+            <SP HPOS="1141" ID="SP_18.2.1.24" VPOS="1342" WIDTH="14"/>
+            <String CONTENT="should" HEIGHT="25" HPOS="1155" ID="ST_18.2.1.25" STYLEREFS="Style_5" VPOS="1342" WIDTH="92" WC="0.38" CC="000000" TAGREFS=""/>
+            <SP HPOS="1247" ID="SP_18.2.1.26" VPOS="1344" WIDTH="10"/>
+            <String CONTENT="state" HEIGHT="22" HPOS="1257" ID="ST_18.2.1.27" STYLEREFS="Style_5" VPOS="1344" WIDTH="63" WC="0.47" CC="00000" TAGREFS=""/>
+            <SP HPOS="1320" ID="SP_18.2.1.28" VPOS="1341" WIDTH="10"/>
+            <String CONTENT="partic-" HEIGHT="32" HPOS="1330" ID="ST_18.2.1.29" STYLEREFS="Style_5" VPOS="1341" WIDTH="88" WC="0.50" CC="0000000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="33" HPOS="286" ID="TL_18.2.2" VPOS="1372" WIDTH="1132">
+            <String CONTENT="ularly" HEIGHT="30" HPOS="286" ID="ST_18.2.2.1" STYLEREFS="Style_5" VPOS="1375" WIDTH="82" WC="0.42" CC="000000" TAGREFS=""/>
+            <SP HPOS="368" ID="SP_18.2.2.2" VPOS="1374" WIDTH="4"/>
+            <String CONTENT="in" HEIGHT="24" HPOS="372" ID="ST_18.2.2.3" STYLEREFS="Style_5" VPOS="1374" WIDTH="27" WC="0.52" CC="00" TAGREFS=""/>
+            <SP HPOS="399" ID="SP_18.2.2.4" VPOS="1374" WIDTH="9"/>
+            <String CONTENT="what" HEIGHT="24" HPOS="408" ID="ST_18.2.2.5" STYLEREFS="Style_5" VPOS="1374" WIDTH="68" WC="0.28" CC="0000" TAGREFS=""/>
+            <SP HPOS="476" ID="SP_18.2.2.6" VPOS="1374" WIDTH="7"/>
+            <String CONTENT="the" HEIGHT="23" HPOS="483" ID="ST_18.2.2.7" STYLEREFS="Style_5" VPOS="1374" WIDTH="42" WC="0.69" CC="000" TAGREFS=""/>
+            <SP HPOS="525" ID="SP_18.2.2.8" VPOS="1373" WIDTH="10"/>
+            <String CONTENT="failure" HEIGHT="25" HPOS="535" ID="ST_18.2.2.9" STYLEREFS="Style_5" VPOS="1373" WIDTH="88" WC="0.55" CC="0000000" TAGREFS=""/>
+            <SP HPOS="623" ID="SP_18.2.2.10" VPOS="1374" WIDTH="11"/>
+            <String CONTENT="consisted." HEIGHT="24" HPOS="634" ID="ST_18.2.2.11" STYLEREFS="Style_5" VPOS="1374" WIDTH="128" WC="0.74" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="762" ID="SP_18.2.2.12" VPOS="1373" WIDTH="36"/>
+            <String CONTENT="General" HEIGHT="25" HPOS="798" ID="ST_18.2.2.13" STYLEREFS="Style_5" VPOS="1373" WIDTH="105" WC="0.62" CC="0000000" TAGREFS=""/>
+            <SP HPOS="903" ID="SP_18.2.2.14" VPOS="1374" WIDTH="11"/>
+            <String CONTENT="allegations" HEIGHT="31" HPOS="914" ID="ST_18.2.2.15" STYLEREFS="Style_5" VPOS="1374" WIDTH="145" WC="0.67" CC="00000000000" TAGREFS=""/>
+            <SP HPOS="1059" ID="SP_18.2.2.16" VPOS="1381" WIDTH="9"/>
+            <String CONTENT="are" HEIGHT="17" HPOS="1068" ID="ST_18.2.2.17" STYLEREFS="Style_5" VPOS="1381" WIDTH="41" WC="0.34" CC="000" TAGREFS=""/>
+            <SP HPOS="1109" ID="SP_18.2.2.18" VPOS="1378" WIDTH="10"/>
+            <String CONTENT="not" HEIGHT="20" HPOS="1119" ID="ST_18.2.2.19" STYLEREFS="Style_5" VPOS="1378" WIDTH="45" WC="0.59" CC="000" TAGREFS=""/>
+            <SP HPOS="1164" ID="SP_18.2.2.20" VPOS="1374" WIDTH="10"/>
+            <String CONTENT="sufficient." HEIGHT="24" HPOS="1174" ID="ST_18.2.2.21" STYLEREFS="Style_5" VPOS="1374" WIDTH="128" WC="0.71" CC="00000000000" TAGREFS=""/>
+            <SP HPOS="1302" ID="SP_18.2.2.22" VPOS="1372" WIDTH="33"/>
+            <String CONTENT="Parks" HEIGHT="25" HPOS="1335" ID="ST_18.2.2.23" STYLEREFS="Style_7" VPOS="1372" WIDTH="83" WC="0.47" CC="00000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="31" HPOS="287" ID="TL_18.2.3" VPOS="1405" WIDTH="440">
+            <String CONTENT="v." HEIGHT="16" HPOS="287" ID="ST_18.2.3.1" STYLEREFS="Style_5" VPOS="1414" WIDTH="25" WC="0.67" CC="00" TAGREFS=""/>
+            <SP HPOS="312" ID="SP_18.2.3.2" VPOS="1405" WIDTH="13"/>
+            <String CONTENT="Holmes," HEIGHT="31" HPOS="325" ID="ST_18.2.3.3" STYLEREFS="Style_7" VPOS="1405" WIDTH="102" WC="0.70" CC="9000000" TAGREFS=""/>
+            <SP HPOS="427" ID="SP_18.2.3.4" VPOS="1409" WIDTH="10"/>
+            <String CONTENT="22" HEIGHT="20" HPOS="437" ID="ST_18.2.3.5" STYLEREFS="Style_5" VPOS="1409" WIDTH="31" WC="0.33" CC="00" TAGREFS=""/>
+            <SP HPOS="468" ID="SP_18.2.3.6" VPOS="1406" WIDTH="11"/>
+            <String CONTENT="Illinois" HEIGHT="23" HPOS="479" ID="ST_18.2.3.7" STYLEREFS="Style_5" VPOS="1406" WIDTH="96" WC="0.55" CC="00000000" TAGREFS=""/>
+            <SP HPOS="575" ID="SP_18.2.3.8" VPOS="1405" WIDTH="12"/>
+            <String CONTENT="Rep.," HEIGHT="31" HPOS="587" ID="ST_18.2.3.9" STYLEREFS="Style_5" VPOS="1405" WIDTH="72" WC="0.54" CC="00099" TAGREFS=""/>
+            <SP HPOS="659" ID="SP_18.2.3.10" VPOS="1408" WIDTH="14"/>
+            <String CONTENT="522." HEIGHT="21" HPOS="673" ID="ST_18.2.3.11" STYLEREFS="Style_5" VPOS="1408" WIDTH="54" WC="0.54" CC="0000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="63.0" HPOS="287.0" ID="BL_18.3" TAGREFS="b18-12" VPOS="1436.0" WIDTH="1133.0">
+          <TextLine HEIGHT="32" HPOS="318" ID="TL_18.3.1" VPOS="1436" WIDTH="1102">
+            <String CONTENT="Under" HEIGHT="25" HPOS="318" ID="ST_18.3.1.1" STYLEREFS="Style_5" VPOS="1437" WIDTH="87" WC="0.49" CC="00000" TAGREFS=""/>
+            <SP HPOS="405" ID="SP_18.3.1.2" VPOS="1438" WIDTH="10"/>
+            <String CONTENT="the" HEIGHT="23" HPOS="415" ID="ST_18.3.1.3" STYLEREFS="Style_5" VPOS="1438" WIDTH="42" WC="0.92" CC="000" TAGREFS=""/>
+            <SP HPOS="457" ID="SP_18.3.1.4" VPOS="1437" WIDTH="10"/>
+            <String CONTENT="general" HEIGHT="31" HPOS="467" ID="ST_18.3.1.5" STYLEREFS="Style_5" VPOS="1437" WIDTH="99" WC="0.58" CC="0000000" TAGREFS=""/>
+            <SP HPOS="566" ID="SP_18.3.1.6" VPOS="1438" WIDTH="13"/>
+            <String CONTENT="issue" HEIGHT="23" HPOS="579" ID="ST_18.3.1.7" STYLEREFS="Style_5" VPOS="1438" WIDTH="65" WC="0.63" CC="00000" TAGREFS=""/>
+            <SP HPOS="644" ID="SP_18.3.1.8" VPOS="1437" WIDTH="11"/>
+            <String CONTENT="it" HEIGHT="23" HPOS="655" ID="ST_18.3.1.9" STYLEREFS="Style_5" VPOS="1437" WIDTH="20" WC="0.46" CC="00" TAGREFS=""/>
+            <SP HPOS="675" ID="SP_18.3.1.10" VPOS="1437" WIDTH="11"/>
+            <String CONTENT="is" HEIGHT="23" HPOS="686" ID="ST_18.3.1.11" STYLEREFS="Style_5" VPOS="1437" WIDTH="20" WC="0.49" CC="00" TAGREFS=""/>
+            <SP HPOS="706" ID="SP_18.3.1.12" VPOS="1440" WIDTH="12"/>
+            <String CONTENT="not" HEIGHT="21" HPOS="718" ID="ST_18.3.1.13" STYLEREFS="Style_5" VPOS="1440" WIDTH="44" WC="0.74" CC="000" TAGREFS=""/>
+            <SP HPOS="762" ID="SP_18.3.1.14" VPOS="1440" WIDTH="11"/>
+            <String CONTENT="competent" HEIGHT="28" HPOS="773" ID="ST_18.3.1.15" STYLEREFS="Style_5" VPOS="1440" WIDTH="139" WC="0.68" CC="000000000" TAGREFS=""/>
+            <SP HPOS="912" ID="SP_18.3.1.16" VPOS="1440" WIDTH="16"/>
+            <String CONTENT="to" HEIGHT="20" HPOS="928" ID="ST_18.3.1.17" STYLEREFS="Style_5" VPOS="1440" WIDTH="25" WC="0.94" CC="00" TAGREFS=""/>
+            <SP HPOS="953" ID="SP_18.3.1.18" VPOS="1437" WIDTH="13"/>
+            <String CONTENT="show" HEIGHT="24" HPOS="966" ID="ST_18.3.1.19" STYLEREFS="Style_5" VPOS="1437" WIDTH="69" WC="0.48" CC="0000" TAGREFS=""/>
+            <SP HPOS="1035" ID="SP_18.3.1.20" VPOS="1444" WIDTH="11"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="1046" ID="ST_18.3.1.21" STYLEREFS="Style_5" VPOS="1444" WIDTH="16" WC="0.41" CC="0" TAGREFS=""/>
+            <SP HPOS="1062" ID="SP_18.3.1.22" VPOS="1437" WIDTH="10"/>
+            <String CONTENT="total" HEIGHT="24" HPOS="1072" ID="ST_18.3.1.23" STYLEREFS="Style_5" VPOS="1437" WIDTH="62" WC="0.75" CC="00000" TAGREFS=""/>
+            <SP HPOS="1134" ID="SP_18.3.1.24" VPOS="1444" WIDTH="15"/>
+            <String CONTENT="or" HEIGHT="17" HPOS="1149" ID="ST_18.3.1.25" STYLEREFS="Style_5" VPOS="1444" WIDTH="28" WC="0.65" CC="00" TAGREFS=""/>
+            <SP HPOS="1177" ID="SP_18.3.1.26" VPOS="1437" WIDTH="10"/>
+            <String CONTENT="partial" HEIGHT="31" HPOS="1187" ID="ST_18.3.1.27" STYLEREFS="Style_5" VPOS="1437" WIDTH="90" WC="0.40" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1277" ID="SP_18.3.1.28" VPOS="1436" WIDTH="10"/>
+            <String CONTENT="failure" HEIGHT="25" HPOS="1287" ID="ST_18.3.1.29" STYLEREFS="Style_5" VPOS="1436" WIDTH="88" WC="0.35" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1375" ID="SP_18.3.1.30" VPOS="1436" WIDTH="17"/>
+            <String CONTENT="of" HEIGHT="24" HPOS="1392" ID="ST_18.3.1.31" STYLEREFS="Style_5" VPOS="1436" WIDTH="28" WC="0.80" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="32" HPOS="287" ID="TL_18.3.2" VPOS="1467" WIDTH="1061">
+            <String CONTENT="consideration" HEIGHT="23" HPOS="287" ID="ST_18.3.2.1" STYLEREFS="Style_5" VPOS="1470" WIDTH="179" WC="0.65" CC="0000000000000" TAGREFS=""/>
+            <SP HPOS="466" ID="SP_18.3.2.2" VPOS="1468" WIDTH="10"/>
+            <String CONTENT="of" HEIGHT="24" HPOS="476" ID="ST_18.3.2.3" STYLEREFS="Style_5" VPOS="1468" WIDTH="29" WC="0.84" CC="00" TAGREFS=""/>
+            <SP HPOS="505" ID="SP_18.3.2.4" VPOS="1476" WIDTH="13"/>
+            <String CONTENT="a" HEIGHT="15" HPOS="518" ID="ST_18.3.2.5" STYLEREFS="Style_5" VPOS="1476" WIDTH="15" WC="0.39" CC="0" TAGREFS=""/>
+            <SP HPOS="533" ID="SP_18.3.2.6" VPOS="1469" WIDTH="10"/>
+            <String CONTENT="promissory" HEIGHT="30" HPOS="543" ID="ST_18.3.2.7" STYLEREFS="Style_5" VPOS="1469" WIDTH="151" WC="0.63" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="694" ID="SP_18.3.2.8" VPOS="1472" WIDTH="9"/>
+            <String CONTENT="note." HEIGHT="20" HPOS="703" ID="ST_18.3.2.9" STYLEREFS="Style_5" VPOS="1472" WIDTH="66" WC="0.73" CC="00000" TAGREFS=""/>
+            <SP HPOS="769" ID="SP_18.3.2.10" VPOS="1467" WIDTH="33"/>
+            <String CONTENT="Rose" HEIGHT="25" HPOS="802" ID="ST_18.3.2.11" STYLEREFS="Style_7" VPOS="1467" WIDTH="63" WC="0.28" CC="0000" TAGREFS=""/>
+            <SP HPOS="865" ID="SP_18.3.2.12" VPOS="1476" WIDTH="10"/>
+            <String CONTENT="v." HEIGHT="16" HPOS="875" ID="ST_18.3.2.13" STYLEREFS="Style_5" VPOS="1476" WIDTH="24" WC="0.61" CC="00" TAGREFS=""/>
+            <SP HPOS="899" ID="SP_18.3.2.14" VPOS="1467" WIDTH="12"/>
+            <String CONTENT="Mortimer," HEIGHT="31" HPOS="911" ID="ST_18.3.2.15" STYLEREFS="Style_7" VPOS="1467" WIDTH="132" WC="0.57" CC="000000000" TAGREFS=""/>
+            <SP HPOS="1043" ID="SP_18.3.2.16" VPOS="1470" WIDTH="14"/>
+            <String CONTENT="17" HEIGHT="22" HPOS="1057" ID="ST_18.3.2.17" STYLEREFS="Style_5" VPOS="1470" WIDTH="29" WC="1.00" CC="00" TAGREFS=""/>
+            <SP HPOS="1086" ID="SP_18.3.2.18" VPOS="1468" WIDTH="12"/>
+            <String CONTENT="Illinois" HEIGHT="24" HPOS="1098" ID="ST_18.3.2.19" STYLEREFS="Style_5" VPOS="1468" WIDTH="97" WC="0.64" CC="00000000" TAGREFS=""/>
+            <SP HPOS="1195" ID="SP_18.3.2.20" VPOS="1468" WIDTH="12"/>
+            <String CONTENT="Rep.," HEIGHT="31" HPOS="1207" ID="ST_18.3.2.21" STYLEREFS="Style_5" VPOS="1468" WIDTH="72" WC="0.46" CC="00099" TAGREFS=""/>
+            <SP HPOS="1279" ID="SP_18.3.2.22" VPOS="1469" WIDTH="13"/>
+            <String CONTENT="475." HEIGHT="23" HPOS="1292" ID="ST_18.3.2.23" STYLEREFS="Style_5" VPOS="1469" WIDTH="56" WC="0.69" CC="0000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="65.0" HPOS="288.0" ID="BL_18.4" TAGREFS="b18-13" VPOS="1499.0" WIDTH="1129.0">
+          <TextLine HEIGHT="32" HPOS="321" ID="TL_18.4.1" VPOS="1499" WIDTH="1096">
+            <String CONTENT="Under" HEIGHT="25" HPOS="321" ID="ST_18.4.1.1" STYLEREFS="Style_5" VPOS="1500" WIDTH="85" WC="0.47" CC="00000" TAGREFS=""/>
+            <SP HPOS="406" ID="SP_18.4.1.2" VPOS="1508" WIDTH="16"/>
+            <String CONTENT="a" HEIGHT="15" HPOS="422" ID="ST_18.4.1.3" STYLEREFS="Style_5" VPOS="1508" WIDTH="16" WC="0.28" CC="0" TAGREFS=""/>
+            <SP HPOS="438" ID="SP_18.4.1.4" VPOS="1501" WIDTH="17"/>
+            <String CONTENT="plea" HEIGHT="30" HPOS="455" ID="ST_18.4.1.5" STYLEREFS="Style_5" VPOS="1501" WIDTH="57" WC="0.72" CC="0000" TAGREFS=""/>
+            <SP HPOS="512" ID="SP_18.4.1.6" VPOS="1500" WIDTH="18"/>
+            <String CONTENT="of" HEIGHT="23" HPOS="530" ID="ST_18.4.1.7" STYLEREFS="Style_5" VPOS="1500" WIDTH="29" WC="0.69" CC="00" TAGREFS=""/>
+            <SP HPOS="559" ID="SP_18.4.1.8" VPOS="1507" WIDTH="13"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="572" ID="ST_18.4.1.9" STYLEREFS="Style_5" VPOS="1507" WIDTH="16" WC="0.21" CC="0" TAGREFS=""/>
+            <SP HPOS="588" ID="SP_18.4.1.10" VPOS="1499" WIDTH="14"/>
+            <String CONTENT="total" HEIGHT="24" HPOS="602" ID="ST_18.4.1.11" STYLEREFS="Style_7" VPOS="1499" WIDTH="56" WC="0.69" CC="00000" TAGREFS=""/>
+            <SP HPOS="658" ID="SP_18.4.1.12" VPOS="1500" WIDTH="10"/>
+            <String CONTENT="failure" HEIGHT="23" HPOS="668" ID="ST_18.4.1.13" STYLEREFS="Style_5" VPOS="1500" WIDTH="87" WC="0.48" CC="0000000" TAGREFS=""/>
+            <SP HPOS="755" ID="SP_18.4.1.14" VPOS="1499" WIDTH="17"/>
+            <String CONTENT="of" HEIGHT="25" HPOS="772" ID="ST_18.4.1.15" STYLEREFS="Style_5" VPOS="1499" WIDTH="29" WC="0.78" CC="00" TAGREFS=""/>
+            <SP HPOS="801" ID="SP_18.4.1.16" VPOS="1500" WIDTH="13"/>
+            <String CONTENT="consideration," HEIGHT="29" HPOS="814" ID="ST_18.4.1.17" STYLEREFS="Style_5" VPOS="1500" WIDTH="187" WC="0.67" CC="00000000000000" TAGREFS=""/>
+            <SP HPOS="1001" ID="SP_18.4.1.18" VPOS="1507" WIDTH="12"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="1013" ID="ST_18.4.1.19" STYLEREFS="Style_5" VPOS="1507" WIDTH="16" WC="0.28" CC="0" TAGREFS=""/>
+            <SP HPOS="1029" ID="SP_18.4.1.20" VPOS="1499" WIDTH="14"/>
+            <String CONTENT="partial" HEIGHT="32" HPOS="1043" ID="ST_18.4.1.21" STYLEREFS="Style_7" VPOS="1499" WIDTH="96" WC="0.65" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1139" ID="SP_18.4.1.22" VPOS="1500" WIDTH="17"/>
+            <String CONTENT="failure" HEIGHT="23" HPOS="1156" ID="ST_18.4.1.23" STYLEREFS="Style_5" VPOS="1500" WIDTH="87" WC="0.42" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1243" ID="SP_18.4.1.24" VPOS="1507" WIDTH="19"/>
+            <String CONTENT="can" HEIGHT="16" HPOS="1262" ID="ST_18.4.1.25" STYLEREFS="Style_5" VPOS="1507" WIDTH="47" WC="0.76" CC="000" TAGREFS=""/>
+            <SP HPOS="1309" ID="SP_18.4.1.26" VPOS="1502" WIDTH="16"/>
+            <String CONTENT="not" HEIGHT="21" HPOS="1325" ID="ST_18.4.1.27" STYLEREFS="Style_5" VPOS="1502" WIDTH="45" WC="0.62" CC="000" TAGREFS=""/>
+            <SP HPOS="1370" ID="SP_18.4.1.28" VPOS="1499" WIDTH="16"/>
+            <String CONTENT="be" HEIGHT="24" HPOS="1386" ID="ST_18.4.1.29" STYLEREFS="Style_5" VPOS="1499" WIDTH="31" WC="0.20" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="34" HPOS="288" ID="TL_18.4.2" VPOS="1530" WIDTH="1027">
+            <String CONTENT="given" HEIGHT="31" HPOS="288" ID="ST_18.4.2.1" STYLEREFS="Style_5" VPOS="1533" WIDTH="74" WC="0.51" CC="00000" TAGREFS=""/>
+            <SP HPOS="362" ID="SP_18.4.2.2" VPOS="1533" WIDTH="11"/>
+            <String CONTENT="in" HEIGHT="23" HPOS="373" ID="ST_18.4.2.3" STYLEREFS="Style_5" VPOS="1533" WIDTH="26" WC="0.55" CC="00" TAGREFS=""/>
+            <SP HPOS="399" ID="SP_18.4.2.4" VPOS="1532" WIDTH="10"/>
+            <String CONTENT="evidence." HEIGHT="24" HPOS="409" ID="ST_18.4.2.5" STYLEREFS="Style_5" VPOS="1532" WIDTH="122" WC="0.69" CC="000000000" TAGREFS=""/>
+            <SP HPOS="531" ID="SP_18.4.2.6" VPOS="1530" WIDTH="34"/>
+            <String CONTENT="Sims" HEIGHT="25" HPOS="565" ID="ST_18.4.2.7" STYLEREFS="Style_7" VPOS="1530" WIDTH="65" WC="0.59" CC="0000" TAGREFS=""/>
+            <SP HPOS="630" ID="SP_18.4.2.8" VPOS="1539" WIDTH="11"/>
+            <String CONTENT="v." HEIGHT="16" HPOS="641" ID="ST_18.4.2.9" STYLEREFS="Style_5" VPOS="1539" WIDTH="24" WC="0.64" CC="00" TAGREFS=""/>
+            <SP HPOS="665" ID="SP_18.4.2.10" VPOS="1530" WIDTH="12"/>
+            <String CONTENT="Klein," HEIGHT="31" HPOS="677" ID="ST_18.4.2.11" STYLEREFS="Style_7" VPOS="1530" WIDTH="82" WC="0.49" CC="000000" TAGREFS=""/>
+            <SP HPOS="759" ID="SP_18.4.2.12" VPOS="1535" WIDTH="12"/>
+            <String CONTENT="post." HEIGHT="27" HPOS="771" ID="ST_18.4.2.13" STYLEREFS="Style_5" VPOS="1535" WIDTH="64" WC="0.72" CC="00000" TAGREFS=""/>
+            <SP HPOS="835" ID="SP_18.4.2.14" VPOS="1530" WIDTH="34"/>
+            <String CONTENT="Swain" HEIGHT="25" HPOS="869" ID="ST_18.4.2.15" STYLEREFS="Style_7" VPOS="1530" WIDTH="86" WC="0.57" CC="00000" TAGREFS=""/>
+            <SP HPOS="955" ID="SP_18.4.2.16" VPOS="1539" WIDTH="10"/>
+            <String CONTENT="v." HEIGHT="15" HPOS="965" ID="ST_18.4.2.17" STYLEREFS="Style_5" VPOS="1539" WIDTH="25" WC="0.64" CC="00" TAGREFS=""/>
+            <SP HPOS="990" ID="SP_18.4.2.18" VPOS="1530" WIDTH="17"/>
+            <String CONTENT="Cawood," HEIGHT="30" HPOS="1007" ID="ST_18.4.2.19" STYLEREFS="Style_7" VPOS="1530" WIDTH="108" WC="0.81" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1115" ID="SP_18.4.2.20" VPOS="1533" WIDTH="12"/>
+            <String CONTENT="2" HEIGHT="21" HPOS="1127" ID="ST_18.4.2.21" STYLEREFS="Style_5" VPOS="1533" WIDTH="16" WC="0.54" CC="0" TAGREFS=""/>
+            <SP HPOS="1143" ID="SP_18.4.2.22" VPOS="1531" WIDTH="13"/>
+            <String CONTENT="Scam.," HEIGHT="29" HPOS="1156" ID="ST_18.4.2.23" STYLEREFS="Style_5" VPOS="1531" WIDTH="92" WC="0.56" CC="090999" TAGREFS=""/>
+            <SP HPOS="1248" ID="SP_18.4.2.24" VPOS="1533" WIDTH="14"/>
+            <String CONTENT="505." HEIGHT="21" HPOS="1262" ID="ST_18.4.2.25" STYLEREFS="Style_5" VPOS="1533" WIDTH="53" WC="0.90" CC="0000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="32.0" HPOS="285.0" ID="BL_18.5" TAGREFS="b18-1" VPOS="162.0" WIDTH="43.0">
+          <TextLine HEIGHT="32" HPOS="285" ID="TL_18.5.1" VPOS="162" WIDTH="43">
+            <String CONTENT="18" HEIGHT="32" HPOS="285" ID="ST_18.5.1.1" STYLEREFS="Style_10" VPOS="162" WIDTH="43" WC="0.49" CC="00" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="34.0" HPOS="714.0" ID="BL_18.6" TAGREFS="b18-2" VPOS="161.0" WIDTH="272.0">
+          <TextLine HEIGHT="34" HPOS="714" ID="TL_18.6.1" VPOS="161" WIDTH="272">
+            <String CONTENT="KASKASKIA." HEIGHT="34" HPOS="714" ID="ST_18.6.1.1" STYLEREFS="Style_8" VPOS="161" WIDTH="272" WC="0.43" CC="9000000000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="32.0" HPOS="723.0" ID="BL_18.7" TAGREFS="b18-3" VPOS="263.0" WIDTH="251.0">
+          <TextLine HEIGHT="32" HPOS="723" ID="TL_18.7.1" VPOS="263" WIDTH="251">
+            <String CONTENT="Smith" HEIGHT="25" HPOS="723" ID="ST_18.7.1.1" STYLEREFS="Style_5" VPOS="263" WIDTH="83" WC="0.40" CC="00000" TAGREFS=""/>
+            <SP HPOS="806" ID="SP_18.7.1.2" VPOS="272" WIDTH="15"/>
+            <String CONTENT="v." HEIGHT="16" HPOS="821" ID="ST_18.7.1.3" STYLEREFS="Style_4" VPOS="272" WIDTH="22" WC="0.69" CC="90" TAGREFS=""/>
+            <SP HPOS="843" ID="SP_18.7.1.4" VPOS="263" WIDTH="18"/>
+            <String CONTENT="Bridges." HEIGHT="32" HPOS="861" ID="ST_18.7.1.5" STYLEREFS="Style_5" VPOS="263" WIDTH="113" WC="0.67" CC="00000000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="87.0" HPOS="288.0" ID="BL_18.8" TAGREFS="b18-4" VPOS="381.0" WIDTH="1129.0">
+          <TextLine HEIGHT="42" HPOS="288" ID="TL_18.8.1" VPOS="381" WIDTH="1129">
+            <String CONTENT="Elijah" HEIGHT="32" HPOS="288" ID="ST_18.8.1.1" STYLEREFS="Style_6" VPOS="381" WIDTH="128" WC="0.51" CC="000000" TAGREFS=""/>
+            <SP HPOS="416" ID="SP_18.8.1.2" VPOS="381" WIDTH="22"/>
+            <String CONTENT="Smith" HEIGHT="33" HPOS="438" ID="ST_18.8.1.3" STYLEREFS="Style_6" VPOS="381" WIDTH="104" WC="0.33" CC="00000" TAGREFS=""/>
+            <SP HPOS="542" ID="SP_18.8.1.4" VPOS="390" WIDTH="21"/>
+            <String CONTENT="who" HEIGHT="23" HPOS="563" ID="ST_18.8.1.5" STYLEREFS="Style_6" VPOS="390" WIDTH="75" WC="0.49" CC="000" TAGREFS=""/>
+            <SP HPOS="638" ID="SP_18.8.1.6" VPOS="389" WIDTH="22"/>
+            <String CONTENT="sues" HEIGHT="25" HPOS="660" ID="ST_18.8.1.7" STYLEREFS="Style_6" VPOS="389" WIDTH="77" WC="0.27" CC="0000" TAGREFS=""/>
+            <SP HPOS="737" ID="SP_18.8.1.8" VPOS="390" WIDTH="21"/>
+            <String CONTENT="for" HEIGHT="23" HPOS="758" ID="ST_18.8.1.9" STYLEREFS="Style_6" VPOS="390" WIDTH="64" WC="0.50" CC="000" TAGREFS=""/>
+            <SP HPOS="822" ID="SP_18.8.1.10" VPOS="390" WIDTH="16"/>
+            <String CONTENT="the" HEIGHT="23" HPOS="838" ID="ST_18.8.1.11" STYLEREFS="Style_6" VPOS="390" WIDTH="64" WC="0.46" CC="009" TAGREFS=""/>
+            <SP HPOS="902" ID="SP_18.8.1.12" VPOS="389" WIDTH="22"/>
+            <String CONTENT="use" HEIGHT="24" HPOS="924" ID="ST_18.8.1.13" STYLEREFS="Style_6" VPOS="389" WIDTH="61" WC="0.26" CC="000" TAGREFS=""/>
+            <SP HPOS="985" ID="SP_18.8.1.14" VPOS="390" WIDTH="23"/>
+            <String CONTENT="of" HEIGHT="23" HPOS="1008" ID="ST_18.8.1.15" STYLEREFS="Style_6" VPOS="390" WIDTH="41" WC="0.68" CC="00" TAGREFS=""/>
+            <SP HPOS="1049" ID="SP_18.8.1.16" VPOS="382" WIDTH="22"/>
+            <String CONTENT="William" HEIGHT="32" HPOS="1071" ID="ST_18.8.1.17" STYLEREFS="Style_6" VPOS="382" WIDTH="159" WC="0.34" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1230" ID="SP_18.8.1.18" VPOS="382" WIDTH="21"/>
+            <String CONTENT="Johnson," HEIGHT="41" HPOS="1251" ID="ST_18.8.1.19" STYLEREFS="Style_6" VPOS="382" WIDTH="166" WC="0.54" CC="00000000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="43" HPOS="457" ID="TL_18.8.2" VPOS="425" WIDTH="788">
+            <String CONTENT="Appellant," HEIGHT="43" HPOS="457" ID="ST_18.8.2.1" STYLEREFS="Style_8" VPOS="425" WIDTH="186" WC="0.53" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="643" ID="SP_18.8.2.2" VPOS="436" WIDTH="22"/>
+            <String CONTENT="v." HEIGHT="21" HPOS="665" ID="ST_18.8.2.3" STYLEREFS="Style_9" VPOS="436" WIDTH="31" WC="0.94" CC="00" TAGREFS=""/>
+            <SP HPOS="696" ID="SP_18.8.2.4" VPOS="425" WIDTH="23"/>
+            <String CONTENT="William" HEIGHT="33" HPOS="719" ID="ST_18.8.2.5" STYLEREFS="Style_6" VPOS="425" WIDTH="159" WC="0.36" CC="0000000" TAGREFS=""/>
+            <SP HPOS="878" ID="SP_18.8.2.6" VPOS="426" WIDTH="22"/>
+            <String CONTENT="Bridges," HEIGHT="41" HPOS="900" ID="ST_18.8.2.7" STYLEREFS="Style_6" VPOS="426" WIDTH="155" WC="0.42" CC="00000000" TAGREFS=""/>
+            <SP HPOS="1055" ID="SP_18.8.2.8" VPOS="426" WIDTH="22"/>
+            <String CONTENT="Appellee." HEIGHT="42" HPOS="1077" ID="ST_18.8.2.9" STYLEREFS="Style_8" VPOS="426" WIDTH="168" WC="0.69" CC="000000000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="26.0" HPOS="622.0" ID="BL_18.9" TAGREFS="b18-5" VPOS="512.0" WIDTH="457.0">
+          <TextLine HEIGHT="26" HPOS="622" ID="TL_18.9.1" VPOS="512" WIDTH="457">
+            <String CONTENT="APPEAL" HEIGHT="26" HPOS="622" ID="ST_18.9.1.1" STYLEREFS="Style_5" VPOS="512" WIDTH="145" WC="0.26" CC="000000" TAGREFS=""/>
+            <SP HPOS="767" ID="SP_18.9.1.2" VPOS="512" WIDTH="16"/>
+            <String CONTENT="FROM" HEIGHT="26" HPOS="783" ID="ST_18.9.1.3" STYLEREFS="Style_5" VPOS="512" WIDTH="104" WC="1.0" CC="0000" TAGREFS=""/>
+            <SP HPOS="887" ID="SP_18.9.1.4" VPOS="512" WIDTH="15"/>
+            <String CONTENT="MADISON." HEIGHT="26" HPOS="902" ID="ST_18.9.1.5" STYLEREFS="Style_5" VPOS="512" WIDTH="177" WC="0.52" CC="00000000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="89.0" HPOS="287.0" ID="BL_18.10" TAGREFS="b18-6" VPOS="581.0" WIDTH="1131.0">
+          <TextLine HEIGHT="33" HPOS="287" ID="TL_18.10.1" VPOS="581" WIDTH="1131">
+            <String CONTENT="Although" HEIGHT="33" HPOS="287" ID="ST_18.10.1.1" STYLEREFS="Style_5" VPOS="581" WIDTH="135" WC="0.39" CC="00000000" TAGREFS=""/>
+            <SP HPOS="422" ID="SP_18.10.1.2" VPOS="589" WIDTH="9"/>
+            <String CONTENT="no" HEIGHT="17" HPOS="431" ID="ST_18.10.1.3" STYLEREFS="Style_5" VPOS="589" WIDTH="33" WC="0.65" CC="00" TAGREFS=""/>
+            <SP HPOS="464" ID="SP_18.10.1.4" VPOS="581" WIDTH="8"/>
+            <String CONTENT="particular" HEIGHT="32" HPOS="472" ID="ST_18.10.1.5" STYLEREFS="Style_5" VPOS="581" WIDTH="133" WC="0.53" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="605" ID="SP_18.10.1.6" VPOS="582" WIDTH="20"/>
+            <String CONTENT="form" HEIGHT="24" HPOS="625" ID="ST_18.10.1.7" STYLEREFS="Style_5" VPOS="582" WIDTH="65" WC="0.56" CC="0000" TAGREFS=""/>
+            <SP HPOS="690" ID="SP_18.10.1.8" VPOS="582" WIDTH="10"/>
+            <String CONTENT="is" HEIGHT="24" HPOS="700" ID="ST_18.10.1.9" STYLEREFS="Style_5" VPOS="582" WIDTH="20" WC="0.41" CC="00" TAGREFS=""/>
+            <SP HPOS="720" ID="SP_18.10.1.10" VPOS="589" WIDTH="12"/>
+            <String CONTENT="necessary" HEIGHT="24" HPOS="732" ID="ST_18.10.1.11" STYLEREFS="Style_5" VPOS="589" WIDTH="130" WC="0.59" CC="000000000" TAGREFS=""/>
+            <SP HPOS="862" ID="SP_18.10.1.12" VPOS="585" WIDTH="19"/>
+            <String CONTENT="to" HEIGHT="20" HPOS="881" ID="ST_18.10.1.13" STYLEREFS="Style_5" VPOS="585" WIDTH="26" WC="0.97" CC="00" TAGREFS=""/>
+            <SP HPOS="907" ID="SP_18.10.1.14" VPOS="581" WIDTH="11"/>
+            <String CONTENT="make" HEIGHT="24" HPOS="918" ID="ST_18.10.1.15" STYLEREFS="Style_5" VPOS="581" WIDTH="74" WC="0.43" CC="0000" TAGREFS=""/>
+            <SP HPOS="992" ID="SP_18.10.1.16" VPOS="589" WIDTH="16"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="1008" ID="ST_18.10.1.17" STYLEREFS="Style_5" VPOS="589" WIDTH="16" WC="0.84" CC="0" TAGREFS=""/>
+            <SP HPOS="1024" ID="SP_18.10.1.18" VPOS="584" WIDTH="15"/>
+            <String CONTENT="note," HEIGHT="28" HPOS="1039" ID="ST_18.10.1.19" STYLEREFS="Style_5" VPOS="584" WIDTH="66" WC="0.49" CC="00000" TAGREFS=""/>
+            <SP HPOS="1105" ID="SP_18.10.1.20" VPOS="584" WIDTH="17"/>
+            <String CONTENT="yet" HEIGHT="29" HPOS="1122" ID="ST_18.10.1.21" STYLEREFS="Style_5" VPOS="584" WIDTH="42" WC="0.39" CC="000" TAGREFS=""/>
+            <SP HPOS="1164" ID="SP_18.10.1.22" VPOS="581" WIDTH="21"/>
+            <String CONTENT="the" HEIGHT="24" HPOS="1185" ID="ST_18.10.1.23" STYLEREFS="Style_5" VPOS="581" WIDTH="42" WC="0.50" CC="000" TAGREFS=""/>
+            <SP HPOS="1227" ID="SP_18.10.1.24" VPOS="581" WIDTH="15"/>
+            <String CONTENT="writing" HEIGHT="32" HPOS="1242" ID="ST_18.10.1.25" STYLEREFS="Style_5" VPOS="581" WIDTH="98" WC="0.31" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1340" ID="SP_18.10.1.26" VPOS="584" WIDTH="9"/>
+            <String CONTENT="must" HEIGHT="22" HPOS="1349" ID="ST_18.10.1.27" STYLEREFS="Style_5" VPOS="584" WIDTH="69" WC="0.20" CC="0000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="31" HPOS="323" ID="TL_18.10.2" VPOS="614" WIDTH="1093">
+            <String CONTENT="show" HEIGHT="24" HPOS="323" ID="ST_18.10.2.1" STYLEREFS="Style_5" VPOS="614" WIDTH="70" WC="0.47" CC="0000" TAGREFS=""/>
+            <SP HPOS="393" ID="SP_18.10.2.2" VPOS="621" WIDTH="11"/>
+            <String CONTENT="an" HEIGHT="17" HPOS="404" ID="ST_18.10.2.3" STYLEREFS="Style_5" VPOS="621" WIDTH="33" WC="0.23" CC="00" TAGREFS=""/>
+            <SP HPOS="437" ID="SP_18.10.2.4" VPOS="614" WIDTH="10"/>
+            <String CONTENT="undertaking" HEIGHT="31" HPOS="447" ID="ST_18.10.2.5" STYLEREFS="Style_5" VPOS="614" WIDTH="165" WC="0.45" CC="00000000000" TAGREFS=""/>
+            <SP HPOS="612" ID="SP_18.10.2.6" VPOS="621" WIDTH="10"/>
+            <String CONTENT="or" HEIGHT="17" HPOS="622" ID="ST_18.10.2.7" STYLEREFS="Style_5" VPOS="621" WIDTH="28" WC="0.76" CC="00" TAGREFS=""/>
+            <SP HPOS="650" ID="SP_18.10.2.8" VPOS="617" WIDTH="11"/>
+            <String CONTENT="engagement" HEIGHT="28" HPOS="661" ID="ST_18.10.2.9" STYLEREFS="Style_5" VPOS="617" WIDTH="163" WC="0.61" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="824" ID="SP_18.10.2.10" VPOS="617" WIDTH="10"/>
+            <String CONTENT="to" HEIGHT="20" HPOS="834" ID="ST_18.10.2.11" STYLEREFS="Style_5" VPOS="617" WIDTH="26" WC="1.00" CC="00" TAGREFS=""/>
+            <SP HPOS="860" ID="SP_18.10.2.12" VPOS="621" WIDTH="22"/>
+            <String CONTENT="pay," HEIGHT="24" HPOS="882" ID="ST_18.10.2.13" STYLEREFS="Style_5" VPOS="621" WIDTH="57" WC="0.55" CC="0000" TAGREFS=""/>
+            <SP HPOS="939" ID="SP_18.10.2.14" VPOS="614" WIDTH="14"/>
+            <String CONTENT="and" HEIGHT="23" HPOS="953" ID="ST_18.10.2.15" STYLEREFS="Style_5" VPOS="614" WIDTH="50" WC="0.57" CC="000" TAGREFS=""/>
+            <SP HPOS="1003" ID="SP_18.10.2.16" VPOS="616" WIDTH="9"/>
+            <String CONTENT="to" HEIGHT="21" HPOS="1012" ID="ST_18.10.2.17" STYLEREFS="Style_5" VPOS="616" WIDTH="26" WC="0.79" CC="00" TAGREFS=""/>
+            <SP HPOS="1038" ID="SP_18.10.2.18" VPOS="621" WIDTH="12"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="1050" ID="ST_18.10.2.19" STYLEREFS="Style_5" VPOS="621" WIDTH="16" WC="0.27" CC="0" TAGREFS=""/>
+            <SP HPOS="1066" ID="SP_18.10.2.20" VPOS="621" WIDTH="9"/>
+            <String CONTENT="person" HEIGHT="24" HPOS="1075" ID="ST_18.10.2.21" STYLEREFS="Style_5" VPOS="621" WIDTH="91" WC="0.64" CC="000000" TAGREFS=""/>
+            <SP HPOS="1166" ID="SP_18.10.2.22" VPOS="614" WIDTH="10"/>
+            <String CONTENT="named" HEIGHT="24" HPOS="1176" ID="ST_18.10.2.23" STYLEREFS="Style_5" VPOS="614" WIDTH="92" WC="0.42" CC="00000" TAGREFS=""/>
+            <SP HPOS="1268" ID="SP_18.10.2.24" VPOS="614" WIDTH="9"/>
+            <String CONTENT="in" HEIGHT="24" HPOS="1277" ID="ST_18.10.2.25" STYLEREFS="Style_5" VPOS="614" WIDTH="27" WC="0.24" CC="00" TAGREFS=""/>
+            <SP HPOS="1304" ID="SP_18.10.2.26" VPOS="614" WIDTH="10"/>
+            <String CONTENT="it," HEIGHT="30" HPOS="1314" ID="ST_18.10.2.27" STYLEREFS="Style_5" VPOS="614" WIDTH="28" WC="0.41" CC="000" TAGREFS=""/>
+            <SP HPOS="1342" ID="SP_18.10.2.28" VPOS="621" WIDTH="11"/>
+            <String CONTENT="or" HEIGHT="17" HPOS="1353" ID="ST_18.10.2.29" STYLEREFS="Style_5" VPOS="621" WIDTH="28" WC="0.62" CC="00" TAGREFS=""/>
+            <SP HPOS="1381" ID="SP_18.10.2.30" VPOS="617" WIDTH="10"/>
+            <String CONTENT="to" HEIGHT="21" HPOS="1391" ID="ST_18.10.2.31" STYLEREFS="Style_5" VPOS="617" WIDTH="25" WC="0.75" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="25" HPOS="319" ID="TL_18.10.3" VPOS="645" WIDTH="475">
+            <String CONTENT="hearer" HEIGHT="24" HPOS="319" ID="ST_18.10.3.1" STYLEREFS="Style_5" VPOS="646" WIDTH="86" WC="0.70" CC="000000" TAGREFS=""/>
+            <SP HPOS="405" ID="SP_18.10.3.2" VPOS="653" WIDTH="10"/>
+            <String CONTENT="or" HEIGHT="17" HPOS="415" ID="ST_18.10.3.3" STYLEREFS="Style_5" VPOS="653" WIDTH="29" WC="0.63" CC="00" TAGREFS=""/>
+            <SP HPOS="444" ID="SP_18.10.3.4" VPOS="646" WIDTH="10"/>
+            <String CONTENT="holder" HEIGHT="24" HPOS="454" ID="ST_18.10.3.5" STYLEREFS="Style_5" VPOS="646" WIDTH="87" WC="0.48" CC="000000" TAGREFS=""/>
+            <SP HPOS="541" ID="SP_18.10.3.6" VPOS="645" WIDTH="10"/>
+            <String CONTENT="of" HEIGHT="24" HPOS="551" ID="ST_18.10.3.7" STYLEREFS="Style_5" VPOS="645" WIDTH="29" WC="0.79" CC="00" TAGREFS=""/>
+            <SP HPOS="580" ID="SP_18.10.3.8" VPOS="647" WIDTH="6"/>
+            <String CONTENT="the" HEIGHT="22" HPOS="586" ID="ST_18.10.3.9" STYLEREFS="Style_5" VPOS="647" WIDTH="42" WC="0.51" CC="000" TAGREFS=""/>
+            <SP HPOS="628" ID="SP_18.10.3.10" VPOS="646" WIDTH="10"/>
+            <String CONTENT="instrument." HEIGHT="24" HPOS="638" ID="ST_18.10.3.11" STYLEREFS="Style_5" VPOS="646" WIDTH="156" WC="0.49" CC="00000000000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="218.0" HPOS="287.0" ID="BL_18.11" TAGREFS="b18-7" VPOS="720.0" WIDTH="1131.0">
+          <TextLine HEIGHT="43" HPOS="341" ID="TL_18.11.1" VPOS="720" WIDTH="1075">
+            <String CONTENT="Opinion" HEIGHT="40" HPOS="341" ID="ST_18.11.1.1" STYLEREFS="Style_9" VPOS="721" WIDTH="141" WC="0.66" CC="0000000" TAGREFS=""/>
+            <SP HPOS="482" ID="SP_18.11.1.2" VPOS="723" WIDTH="13"/>
+            <String CONTENT="of" HEIGHT="39" HPOS="495" ID="ST_18.11.1.3" STYLEREFS="Style_9" VPOS="723" WIDTH="40" WC="1.00" CC="00" TAGREFS=""/>
+            <SP HPOS="535" ID="SP_18.11.1.4" VPOS="721" WIDTH="9"/>
+            <String CONTENT="the" HEIGHT="32" HPOS="544" ID="ST_18.11.1.5" STYLEREFS="Style_9" VPOS="721" WIDTH="51" WC="0.54" CC="000" TAGREFS=""/>
+            <SP HPOS="595" ID="SP_18.11.1.6" VPOS="720" WIDTH="24"/>
+            <String CONTENT="Court.­" HEIGHT="33" HPOS="619" ID="ST_18.11.1.7" STYLEREFS="Style_9" VPOS="720" WIDTH="109" WC="1.0" CC="0000000" TAGREFS=""/>
+            <SP HPOS="728" ID="SP_18.11.1.8" VPOS="721" WIDTH="3"/>
+            <String CONTENT="*" HEIGHT="15" HPOS="731" ID="ST_18.11.1.9" STYLEREFS="Style_9" VPOS="721" WIDTH="15" WC="1.0" CC="0" TAGREFS="footnotemark0001"/>
+            <SP HPOS="746" ID="SP_18.11.1.10" VPOS="722" WIDTH="55"/>
+            <String CONTENT="The" HEIGHT="31" HPOS="801" ID="ST_18.11.1.11" STYLEREFS="Style_8" VPOS="722" WIDTH="70" WC="0.80" CC="000" TAGREFS=""/>
+            <SP HPOS="871" ID="SP_18.11.1.12" VPOS="721" WIDTH="15"/>
+            <String CONTENT="plaintiff" HEIGHT="42" HPOS="886" ID="ST_18.11.1.13" STYLEREFS="Style_8" VPOS="721" WIDTH="144" WC="0.63" CC="000000000" TAGREFS=""/>
+            <SP HPOS="1030" ID="SP_18.11.1.14" VPOS="721" WIDTH="19"/>
+            <String CONTENT="below," HEIGHT="41" HPOS="1049" ID="ST_18.11.1.15" STYLEREFS="Style_8" VPOS="721" WIDTH="115" WC="0.50" CC="000000" TAGREFS=""/>
+            <SP HPOS="1164" ID="SP_18.11.1.16" VPOS="723" WIDTH="26"/>
+            <String CONTENT="states" HEIGHT="30" HPOS="1190" ID="ST_18.11.1.17" STYLEREFS="Style_8" VPOS="723" WIDTH="98" WC="0.48" CC="000000" TAGREFS=""/>
+            <SP HPOS="1288" ID="SP_18.11.1.18" VPOS="722" WIDTH="23"/>
+            <String CONTENT="in" HEIGHT="31" HPOS="1311" ID="ST_18.11.1.19" STYLEREFS="Style_8" VPOS="722" WIDTH="35" WC="0.85" CC="00" TAGREFS=""/>
+            <SP HPOS="1346" ID="SP_18.11.1.20" VPOS="722" WIDTH="19"/>
+            <String CONTENT="his" HEIGHT="31" HPOS="1365" ID="ST_18.11.1.21" STYLEREFS="Style_8" VPOS="722" WIDTH="51" WC="0.38" CC="000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="42" HPOS="288" ID="TL_18.11.2" VPOS="765" WIDTH="1129">
+            <String CONTENT="petition," HEIGHT="41" HPOS="288" ID="ST_18.11.2.1" STYLEREFS="Style_8" VPOS="766" WIDTH="148" WC="0.61" CC="000000000" TAGREFS=""/>
+            <SP HPOS="436" ID="SP_18.11.2.2" VPOS="766" WIDTH="16"/>
+            <String CONTENT="that" HEIGHT="31" HPOS="452" ID="ST_18.11.2.3" STYLEREFS="Style_8" VPOS="766" WIDTH="72" WC="0.33" CC="0000" TAGREFS=""/>
+            <SP HPOS="524" ID="SP_18.11.2.4" VPOS="766" WIDTH="13"/>
+            <String CONTENT="he" HEIGHT="31" HPOS="537" ID="ST_18.11.2.5" STYLEREFS="Style_8" VPOS="766" WIDTH="43" WC="0.58" CC="00" TAGREFS=""/>
+            <SP HPOS="580" ID="SP_18.11.2.6" VPOS="766" WIDTH="16"/>
+            <String CONTENT="“" HEIGHT="16" HPOS="596" ID="ST_18.11.2.7" STYLEREFS="Style_9" VPOS="766" WIDTH="20" WC="1.0" CC="9" TAGREFS=""/>
+            <SP HPOS="616" ID="SP_18.11.2.8" VPOS="765" WIDTH="13"/>
+            <String CONTENT="holds" HEIGHT="32" HPOS="629" ID="ST_18.11.2.9" STYLEREFS="Style_8" VPOS="765" WIDTH="94" WC="0.52" CC="00000" TAGREFS=""/>
+            <SP HPOS="723" ID="SP_18.11.2.10" VPOS="768" WIDTH="15"/>
+            <String CONTENT="notes" HEIGHT="29" HPOS="738" ID="ST_18.11.2.11" STYLEREFS="Style_8" VPOS="768" WIDTH="92" WC="0.72" CC="00000" TAGREFS=""/>
+            <SP HPOS="830" ID="SP_18.11.2.12" VPOS="775" WIDTH="16"/>
+            <String CONTENT="on," HEIGHT="31" HPOS="846" ID="ST_18.11.2.13" STYLEREFS="Style_8" VPOS="775" WIDTH="54" WC="0.69" CC="000" TAGREFS=""/>
+            <SP HPOS="900" ID="SP_18.11.2.14" VPOS="765" WIDTH="17"/>
+            <String CONTENT="&amp;o.”" HEIGHT="32" HPOS="917" ID="ST_18.11.2.15" STYLEREFS="Style_9" VPOS="765" WIDTH="81" WC="0.46" CC="9909" TAGREFS=""/>
+            <SP HPOS="998" ID="SP_18.11.2.16" VPOS="765" WIDTH="18"/>
+            <String CONTENT="and" HEIGHT="32" HPOS="1016" ID="ST_18.11.2.17" STYLEREFS="Style_8" VPOS="765" WIDTH="65" WC="0.37" CC="000" TAGREFS=""/>
+            <SP HPOS="1081" ID="SP_18.11.2.18" VPOS="766" WIDTH="12"/>
+            <String CONTENT="the" HEIGHT="31" HPOS="1093" ID="ST_18.11.2.19" STYLEREFS="Style_8" VPOS="766" WIDTH="56" WC="0.59" CC="000" TAGREFS=""/>
+            <SP HPOS="1149" ID="SP_18.11.2.20" VPOS="765" WIDTH="9"/>
+            <String CONTENT="instrument" HEIGHT="32" HPOS="1158" ID="ST_18.11.2.21" STYLEREFS="Style_8" VPOS="765" WIDTH="201" WC="0.49" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="1359" ID="SP_18.11.2.22" VPOS="776" WIDTH="15"/>
+            <String CONTENT="on" HEIGHT="21" HPOS="1374" ID="ST_18.11.2.23" STYLEREFS="Style_8" VPOS="776" WIDTH="43" WC="0.71" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="41" HPOS="287" ID="TL_18.11.3" VPOS="809" WIDTH="1131">
+            <String CONTENT="which" HEIGHT="31" HPOS="287" ID="ST_18.11.3.1" STYLEREFS="Style_8" VPOS="810" WIDTH="109" WC="0.63" CC="00000" TAGREFS=""/>
+            <SP HPOS="396" ID="SP_18.11.3.2" VPOS="809" WIDTH="15"/>
+            <String CONTENT="suit" HEIGHT="32" HPOS="411" ID="ST_18.11.3.3" STYLEREFS="Style_8" VPOS="809" WIDTH="66" WC="0.40" CC="0000" TAGREFS=""/>
+            <SP HPOS="477" ID="SP_18.11.3.4" VPOS="810" WIDTH="13"/>
+            <String CONTENT="is" HEIGHT="31" HPOS="490" ID="ST_18.11.3.5" STYLEREFS="Style_8" VPOS="810" WIDTH="28" WC="0.69" CC="00" TAGREFS=""/>
+            <SP HPOS="518" ID="SP_18.11.3.6" VPOS="809" WIDTH="11"/>
+            <String CONTENT="brought," HEIGHT="41" HPOS="529" ID="ST_18.11.3.7" STYLEREFS="Style_8" VPOS="809" WIDTH="154" WC="0.57" CC="00000000" TAGREFS=""/>
+            <SP HPOS="683" ID="SP_18.11.3.8" VPOS="809" WIDTH="16"/>
+            <String CONTENT="has" HEIGHT="32" HPOS="699" ID="ST_18.11.3.9" STYLEREFS="Style_8" VPOS="809" WIDTH="58" WC="0.78" CC="000" TAGREFS=""/>
+            <SP HPOS="757" ID="SP_18.11.3.10" VPOS="812" WIDTH="12"/>
+            <String CONTENT="not" HEIGHT="29" HPOS="769" ID="ST_18.11.3.11" STYLEREFS="Style_8" VPOS="812" WIDTH="59" WC="0.58" CC="000" TAGREFS=""/>
+            <SP HPOS="828" ID="SP_18.11.3.12" VPOS="819" WIDTH="15"/>
+            <String CONTENT="a" HEIGHT="21" HPOS="843" ID="ST_18.11.3.13" STYLEREFS="Style_8" VPOS="819" WIDTH="20" WC="0.89" CC="0" TAGREFS=""/>
+            <SP HPOS="863" ID="SP_18.11.3.14" VPOS="809" WIDTH="15"/>
+            <String CONTENT="single" HEIGHT="41" HPOS="878" ID="ST_18.11.3.15" STYLEREFS="Style_8" VPOS="809" WIDTH="104" WC="0.62" CC="000000" TAGREFS=""/>
+            <SP HPOS="982" ID="SP_18.11.3.16" VPOS="809" WIDTH="15"/>
+            <String CONTENT="feature" HEIGHT="31" HPOS="997" ID="ST_18.11.3.17" STYLEREFS="Style_8" VPOS="809" WIDTH="126" WC="0.60" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1123" ID="SP_18.11.3.18" VPOS="809" WIDTH="17"/>
+            <String CONTENT="of" HEIGHT="31" HPOS="1140" ID="ST_18.11.3.19" STYLEREFS="Style_8" VPOS="809" WIDTH="37" WC="0.61" CC="00" TAGREFS=""/>
+            <SP HPOS="1177" ID="SP_18.11.3.20" VPOS="819" WIDTH="11"/>
+            <String CONTENT="a" HEIGHT="21" HPOS="1188" ID="ST_18.11.3.21" STYLEREFS="Style_8" VPOS="819" WIDTH="19" WC="0.42" CC="0" TAGREFS=""/>
+            <SP HPOS="1207" ID="SP_18.11.3.22" VPOS="811" WIDTH="23"/>
+            <String CONTENT="note," HEIGHT="38" HPOS="1230" ID="ST_18.11.3.23" STYLEREFS="Style_8" VPOS="811" WIDTH="89" WC="0.67" CC="00000" TAGREFS=""/>
+            <SP HPOS="1319" ID="SP_18.11.3.24" VPOS="809" WIDTH="15"/>
+            <String CONTENT="inas-" HEIGHT="32" HPOS="1334" ID="ST_18.11.3.25" STYLEREFS="Style_8" VPOS="809" WIDTH="84" WC="0.70" CC="00000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="42" HPOS="288" ID="TL_18.11.4" VPOS="852" WIDTH="1129">
+            <String CONTENT="much" HEIGHT="31" HPOS="288" ID="ST_18.11.4.1" STYLEREFS="Style_8" VPOS="854" WIDTH="101" WC="0.55" CC="0000" TAGREFS=""/>
+            <SP HPOS="389" ID="SP_18.11.4.2" VPOS="863" WIDTH="15"/>
+            <String CONTENT="as" HEIGHT="21" HPOS="404" ID="ST_18.11.4.3" STYLEREFS="Style_8" VPOS="863" WIDTH="34" WC="0.92" CC="00" TAGREFS=""/>
+            <SP HPOS="438" ID="SP_18.11.4.4" VPOS="853" WIDTH="11"/>
+            <String CONTENT="it" HEIGHT="31" HPOS="449" ID="ST_18.11.4.5" STYLEREFS="Style_8" VPOS="853" WIDTH="27" WC="0.36" CC="00" TAGREFS=""/>
+            <SP HPOS="476" ID="SP_18.11.4.6" VPOS="853" WIDTH="15"/>
+            <String CONTENT="does" HEIGHT="32" HPOS="491" ID="ST_18.11.4.7" STYLEREFS="Style_8" VPOS="853" WIDTH="75" WC="0.72" CC="0000" TAGREFS=""/>
+            <SP HPOS="566" ID="SP_18.11.4.8" VPOS="856" WIDTH="14"/>
+            <String CONTENT="not" HEIGHT="28" HPOS="580" ID="ST_18.11.4.9" STYLEREFS="Style_8" VPOS="856" WIDTH="60" WC="0.46" CC="000" TAGREFS=""/>
+            <SP HPOS="640" ID="SP_18.11.4.10" VPOS="863" WIDTH="22"/>
+            <String CONTENT="appear" HEIGHT="31" HPOS="662" ID="ST_18.11.4.11" STYLEREFS="Style_8" VPOS="863" WIDTH="119" WC="0.73" CC="000000" TAGREFS=""/>
+            <SP HPOS="781" ID="SP_18.11.4.12" VPOS="853" WIDTH="11"/>
+            <String CONTENT="there" HEIGHT="31" HPOS="792" ID="ST_18.11.4.13" STYLEREFS="Style_8" VPOS="853" WIDTH="92" WC="0.65" CC="00000" TAGREFS=""/>
+            <SP HPOS="884" ID="SP_18.11.4.14" VPOS="863" WIDTH="16"/>
+            <String CONTENT="was" HEIGHT="21" HPOS="900" ID="ST_18.11.4.15" STYLEREFS="Style_8" VPOS="863" WIDTH="65" WC="0.46" CC="000" TAGREFS=""/>
+            <SP HPOS="965" ID="SP_18.11.4.16" VPOS="863" WIDTH="16"/>
+            <String CONTENT="any" HEIGHT="30" HPOS="981" ID="ST_18.11.4.17" STYLEREFS="Style_8" VPOS="863" WIDTH="64" WC="0.47" CC="000" TAGREFS=""/>
+            <SP HPOS="1045" ID="SP_18.11.4.18" VPOS="852" WIDTH="21"/>
+            <String CONTENT="undertaking" HEIGHT="42" HPOS="1066" ID="ST_18.11.4.19" STYLEREFS="Style_8" VPOS="852" WIDTH="224" WC="0.48" CC="00000000000" TAGREFS=""/>
+            <SP HPOS="1290" ID="SP_18.11.4.20" VPOS="853" WIDTH="13"/>
+            <String CONTENT="by" HEIGHT="40" HPOS="1303" ID="ST_18.11.4.21" STYLEREFS="Style_8" VPOS="853" WIDTH="43" WC="0.27" CC="00" TAGREFS=""/>
+            <SP HPOS="1346" ID="SP_18.11.4.22" VPOS="853" WIDTH="14"/>
+            <String CONTENT="the" HEIGHT="31" HPOS="1360" ID="ST_18.11.4.23" STYLEREFS="Style_8" VPOS="853" WIDTH="57" WC="0.62" CC="000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="42" HPOS="289" ID="TL_18.11.5" VPOS="896" WIDTH="632">
+            <String CONTENT="defendant" HEIGHT="32" HPOS="289" ID="ST_18.11.5.1" STYLEREFS="Style_8" VPOS="897" WIDTH="176" WC="0.61" CC="000000000" TAGREFS=""/>
+            <SP HPOS="465" ID="SP_18.11.5.2" VPOS="899" WIDTH="13"/>
+            <String CONTENT="to" HEIGHT="29" HPOS="478" ID="ST_18.11.5.3" STYLEREFS="Style_8" VPOS="899" WIDTH="34" WC="0.67" CC="00" TAGREFS=""/>
+            <SP HPOS="512" ID="SP_18.11.5.4" VPOS="907" WIDTH="15"/>
+            <String CONTENT="pay" HEIGHT="31" HPOS="527" ID="ST_18.11.5.5" STYLEREFS="Style_8" VPOS="907" WIDTH="64" WC="0.76" CC="000" TAGREFS=""/>
+            <SP HPOS="591" ID="SP_18.11.5.6" VPOS="906" WIDTH="16"/>
+            <String CONTENT="any" HEIGHT="31" HPOS="607" ID="ST_18.11.5.7" STYLEREFS="Style_8" VPOS="906" WIDTH="63" WC="0.63" CC="000" TAGREFS=""/>
+            <SP HPOS="670" ID="SP_18.11.5.8" VPOS="906" WIDTH="15"/>
+            <String CONTENT="person" HEIGHT="31" HPOS="685" ID="ST_18.11.5.9" STYLEREFS="Style_8" VPOS="906" WIDTH="117" WC="0.67" CC="000000" TAGREFS=""/>
+            <SP HPOS="802" ID="SP_18.11.5.10" VPOS="899" WIDTH="15"/>
+            <String CONTENT="at" HEIGHT="28" HPOS="817" ID="ST_18.11.5.11" STYLEREFS="Style_8" VPOS="899" WIDTH="34" WC="0.54" CC="00" TAGREFS=""/>
+            <SP HPOS="851" ID="SP_18.11.5.12" VPOS="896" WIDTH="15"/>
+            <String CONTENT="all." HEIGHT="31" HPOS="866" ID="ST_18.11.5.13" STYLEREFS="Style_8" VPOS="896" WIDTH="55" WC="0.66" CC="0000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="216.0" HPOS="285.0" ID="BL_18.12" TAGREFS="b18-8" VPOS="939.0" WIDTH="1137.0">
+          <TextLine HEIGHT="42" HPOS="328" ID="TL_18.12.1" VPOS="939" WIDTH="1088">
+            <String CONTENT="Although" HEIGHT="41" HPOS="328" ID="ST_18.12.1.1" STYLEREFS="Style_8" VPOS="940" WIDTH="171" WC="0.59" CC="00000000" TAGREFS=""/>
+            <SP HPOS="499" ID="SP_18.12.1.2" VPOS="950" WIDTH="29"/>
+            <String CONTENT="no" HEIGHT="21" HPOS="528" ID="ST_18.12.1.3" STYLEREFS="Style_8" VPOS="950" WIDTH="43" WC="0.69" CC="00" TAGREFS=""/>
+            <SP HPOS="571" ID="SP_18.12.1.4" VPOS="940" WIDTH="15"/>
+            <String CONTENT="particular" HEIGHT="41" HPOS="586" ID="ST_18.12.1.5" STYLEREFS="Style_8" VPOS="940" WIDTH="180" WC="0.48" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="766" ID="SP_18.12.1.6" VPOS="940" WIDTH="15"/>
+            <String CONTENT="form" HEIGHT="31" HPOS="781" ID="ST_18.12.1.7" STYLEREFS="Style_8" VPOS="940" WIDTH="85" WC="0.62" CC="0000" TAGREFS=""/>
+            <SP HPOS="866" ID="SP_18.12.1.8" VPOS="940" WIDTH="14"/>
+            <String CONTENT="is" HEIGHT="30" HPOS="880" ID="ST_18.12.1.9" STYLEREFS="Style_8" VPOS="940" WIDTH="28" WC="0.72" CC="00" TAGREFS=""/>
+            <SP HPOS="908" ID="SP_18.12.1.10" VPOS="949" WIDTH="15"/>
+            <String CONTENT="necessary" HEIGHT="31" HPOS="923" ID="ST_18.12.1.11" STYLEREFS="Style_8" VPOS="949" WIDTH="170" WC="0.63" CC="000000000" TAGREFS=""/>
+            <SP HPOS="1093" ID="SP_18.12.1.12" VPOS="942" WIDTH="15"/>
+            <String CONTENT="to" HEIGHT="29" HPOS="1108" ID="ST_18.12.1.13" STYLEREFS="Style_8" VPOS="942" WIDTH="34" WC="0.59" CC="00" TAGREFS=""/>
+            <SP HPOS="1142" ID="SP_18.12.1.14" VPOS="939" WIDTH="23"/>
+            <String CONTENT="make" HEIGHT="32" HPOS="1165" ID="ST_18.12.1.15" STYLEREFS="Style_8" VPOS="939" WIDTH="97" WC="0.46" CC="0000" TAGREFS=""/>
+            <SP HPOS="1262" ID="SP_18.12.1.16" VPOS="949" WIDTH="24"/>
+            <String CONTENT="a" HEIGHT="21" HPOS="1286" ID="ST_18.12.1.17" STYLEREFS="Style_8" VPOS="949" WIDTH="19" WC="0.42" CC="0" TAGREFS=""/>
+            <SP HPOS="1305" ID="SP_18.12.1.18" VPOS="942" WIDTH="22"/>
+            <String CONTENT="note," HEIGHT="36" HPOS="1327" ID="ST_18.12.1.19" STYLEREFS="Style_8" VPOS="942" WIDTH="89" WC="0.47" CC="00000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="42" HPOS="286" ID="TL_18.12.2" VPOS="982" WIDTH="1133">
+            <String CONTENT="yet" HEIGHT="38" HPOS="286" ID="ST_18.12.2.1" STYLEREFS="Style_8" VPOS="986" WIDTH="55" WC="0.48" CC="000" TAGREFS=""/>
+            <SP HPOS="341" ID="SP_18.12.2.2" VPOS="984" WIDTH="14"/>
+            <String CONTENT="the" HEIGHT="31" HPOS="355" ID="ST_18.12.2.3" STYLEREFS="Style_8" VPOS="984" WIDTH="57" WC="0.73" CC="000" TAGREFS=""/>
+            <SP HPOS="412" ID="SP_18.12.2.4" VPOS="983" WIDTH="23"/>
+            <String CONTENT="writing" HEIGHT="41" HPOS="435" ID="ST_18.12.2.5" STYLEREFS="Style_8" VPOS="983" WIDTH="133" WC="0.46" CC="0000000" TAGREFS=""/>
+            <SP HPOS="568" ID="SP_18.12.2.6" VPOS="985" WIDTH="24"/>
+            <String CONTENT="must" HEIGHT="30" HPOS="592" ID="ST_18.12.2.7" STYLEREFS="Style_8" VPOS="985" WIDTH="91" WC="0.28" CC="0000" TAGREFS=""/>
+            <SP HPOS="683" ID="SP_18.12.2.8" VPOS="984" WIDTH="28"/>
+            <String CONTENT="show" HEIGHT="31" HPOS="711" ID="ST_18.12.2.9" STYLEREFS="Style_8" VPOS="984" WIDTH="89" WC="0.42" CC="0000" TAGREFS=""/>
+            <SP HPOS="800" ID="SP_18.12.2.10" VPOS="993" WIDTH="15"/>
+            <String CONTENT="an" HEIGHT="21" HPOS="815" ID="ST_18.12.2.11" STYLEREFS="Style_8" VPOS="993" WIDTH="43" WC="0.78" CC="00" TAGREFS=""/>
+            <SP HPOS="858" ID="SP_18.12.2.12" VPOS="982" WIDTH="25"/>
+            <String CONTENT="undertaking" HEIGHT="41" HPOS="883" ID="ST_18.12.2.13" STYLEREFS="Style_8" VPOS="982" WIDTH="225" WC="0.48" CC="00000000000" TAGREFS=""/>
+            <SP HPOS="1108" ID="SP_18.12.2.14" VPOS="993" WIDTH="28"/>
+            <String CONTENT="or" HEIGHT="21" HPOS="1136" ID="ST_18.12.2.15" STYLEREFS="Style_8" VPOS="993" WIDTH="37" WC="0.63" CC="00" TAGREFS=""/>
+            <SP HPOS="1173" ID="SP_18.12.2.16" VPOS="986" WIDTH="30"/>
+            <String CONTENT="engagement" HEIGHT="38" HPOS="1203" ID="ST_18.12.2.17" STYLEREFS="Style_8" VPOS="986" WIDTH="216" WC="0.79" CC="0000000000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="43" HPOS="286" ID="TL_18.12.3" VPOS="1026" WIDTH="1136">
+            <String CONTENT="to" HEIGHT="28" HPOS="286" ID="ST_18.12.3.1" STYLEREFS="Style_8" VPOS="1030" WIDTH="33" WC="0.67" CC="00" TAGREFS=""/>
+            <SP HPOS="319" ID="SP_18.12.3.2" VPOS="1037" WIDTH="15"/>
+            <String CONTENT="pay," HEIGHT="32" HPOS="334" ID="ST_18.12.3.3" STYLEREFS="Style_8" VPOS="1037" WIDTH="74" WC="0.66" CC="0000" TAGREFS=""/>
+            <SP HPOS="408" ID="SP_18.12.3.4" VPOS="1027" WIDTH="18"/>
+            <String CONTENT="and" HEIGHT="31" HPOS="426" ID="ST_18.12.3.5" STYLEREFS="Style_8" VPOS="1027" WIDTH="65" WC="0.61" CC="000" TAGREFS=""/>
+            <SP HPOS="491" ID="SP_18.12.3.6" VPOS="1029" WIDTH="14"/>
+            <String CONTENT="to" HEIGHT="29" HPOS="505" ID="ST_18.12.3.7" STYLEREFS="Style_8" VPOS="1029" WIDTH="34" WC="0.74" CC="00" TAGREFS=""/>
+            <SP HPOS="539" ID="SP_18.12.3.8" VPOS="1037" WIDTH="17"/>
+            <String CONTENT="a" HEIGHT="20" HPOS="556" ID="ST_18.12.3.9" STYLEREFS="Style_8" VPOS="1037" WIDTH="19" WC="0.37" CC="0" TAGREFS=""/>
+            <SP HPOS="575" ID="SP_18.12.3.10" VPOS="1036" WIDTH="14"/>
+            <String CONTENT="person" HEIGHT="32" HPOS="589" ID="ST_18.12.3.11" STYLEREFS="Style_8" VPOS="1036" WIDTH="119" WC="0.58" CC="000000" TAGREFS=""/>
+            <SP HPOS="708" ID="SP_18.12.3.12" VPOS="1026" WIDTH="13"/>
+            <String CONTENT="named" HEIGHT="32" HPOS="721" ID="ST_18.12.3.13" STYLEREFS="Style_8" VPOS="1026" WIDTH="121" WC="0.38" CC="00000" TAGREFS=""/>
+            <SP HPOS="842" ID="SP_18.12.3.14" VPOS="1026" WIDTH="14"/>
+            <String CONTENT="in" HEIGHT="31" HPOS="856" ID="ST_18.12.3.15" STYLEREFS="Style_8" VPOS="1026" WIDTH="37" WC="0.42" CC="00" TAGREFS=""/>
+            <SP HPOS="893" ID="SP_18.12.3.16" VPOS="1027" WIDTH="13"/>
+            <String CONTENT="it," HEIGHT="40" HPOS="906" ID="ST_18.12.3.17" STYLEREFS="Style_8" VPOS="1027" WIDTH="38" WC="0.30" CC="000" TAGREFS=""/>
+            <SP HPOS="944" ID="SP_18.12.3.18" VPOS="1036" WIDTH="17"/>
+            <String CONTENT="or" HEIGHT="22" HPOS="961" ID="ST_18.12.3.19" STYLEREFS="Style_8" VPOS="1036" WIDTH="37" WC="0.61" CC="00" TAGREFS=""/>
+            <SP HPOS="998" ID="SP_18.12.3.20" VPOS="1029" WIDTH="14"/>
+            <String CONTENT="to" HEIGHT="29" HPOS="1012" ID="ST_18.12.3.21" STYLEREFS="Style_8" VPOS="1029" WIDTH="34" WC="0.64" CC="00" TAGREFS=""/>
+            <SP HPOS="1046" ID="SP_18.12.3.22" VPOS="1026" WIDTH="15"/>
+            <String CONTENT="bearer" HEIGHT="31" HPOS="1061" ID="ST_18.12.3.23" STYLEREFS="Style_8" VPOS="1026" WIDTH="116" WC="0.45" CC="000000" TAGREFS=""/>
+            <SP HPOS="1177" ID="SP_18.12.3.24" VPOS="1036" WIDTH="26"/>
+            <String CONTENT="or" HEIGHT="22" HPOS="1203" ID="ST_18.12.3.25" STYLEREFS="Style_8" VPOS="1036" WIDTH="37" WC="0.45" CC="00" TAGREFS=""/>
+            <SP HPOS="1240" ID="SP_18.12.3.26" VPOS="1026" WIDTH="14"/>
+            <String CONTENT="holder" HEIGHT="32" HPOS="1254" ID="ST_18.12.3.27" STYLEREFS="Style_8" VPOS="1026" WIDTH="115" WC="0.57" CC="000000" TAGREFS=""/>
+            <SP HPOS="1369" ID="SP_18.12.3.28" VPOS="1026" WIDTH="16"/>
+            <String CONTENT="of" HEIGHT="32" HPOS="1385" ID="ST_18.12.3.29" STYLEREFS="Style_8" VPOS="1026" WIDTH="37" WC="0.79" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="43" HPOS="285" ID="TL_18.12.4" VPOS="1069" WIDTH="1132">
+            <String CONTENT="the" HEIGHT="31" HPOS="285" ID="ST_18.12.4.1" STYLEREFS="Style_8" VPOS="1071" WIDTH="57" WC="0.43" CC="000" TAGREFS=""/>
+            <SP HPOS="342" ID="SP_18.12.4.2" VPOS="1072" WIDTH="30"/>
+            <String CONTENT="instrument." HEIGHT="30" HPOS="372" ID="ST_18.12.4.3" STYLEREFS="Style_8" VPOS="1072" WIDTH="211" WC="0.46" CC="00000000000" TAGREFS=""/>
+            <SP HPOS="583" ID="SP_18.12.4.4" VPOS="1070" WIDTH="46"/>
+            <String CONTENT="The" HEIGHT="32" HPOS="629" ID="ST_18.12.4.5" STYLEREFS="Style_8" VPOS="1070" WIDTH="71" WC="0.72" CC="000" TAGREFS=""/>
+            <SP HPOS="700" ID="SP_18.12.4.6" VPOS="1070" WIDTH="23"/>
+            <String CONTENT="judgment" HEIGHT="42" HPOS="723" ID="ST_18.12.4.7" STYLEREFS="Style_8" VPOS="1070" WIDTH="176" WC="0.37" CC="00000000" TAGREFS=""/>
+            <SP HPOS="899" ID="SP_18.12.4.8" VPOS="1070" WIDTH="25"/>
+            <String CONTENT="of" HEIGHT="32" HPOS="924" ID="ST_18.12.4.9" STYLEREFS="Style_8" VPOS="1070" WIDTH="35" WC="0.62" CC="00" TAGREFS=""/>
+            <SP HPOS="959" ID="SP_18.12.4.10" VPOS="1071" WIDTH="18"/>
+            <String CONTENT="the" HEIGHT="30" HPOS="977" ID="ST_18.12.4.11" STYLEREFS="Style_8" VPOS="1071" WIDTH="56" WC="0.64" CC="000" TAGREFS=""/>
+            <SP HPOS="1033" ID="SP_18.12.4.12" VPOS="1072" WIDTH="28"/>
+            <String CONTENT="court" HEIGHT="29" HPOS="1061" ID="ST_18.12.4.13" STYLEREFS="Style_8" VPOS="1072" WIDTH="94" WC="0.58" CC="00000" TAGREFS=""/>
+            <SP HPOS="1155" ID="SP_18.12.4.14" VPOS="1069" WIDTH="28"/>
+            <String CONTENT="below" HEIGHT="32" HPOS="1183" ID="ST_18.12.4.15" STYLEREFS="Style_8" VPOS="1069" WIDTH="104" WC="0.54" CC="00000" TAGREFS=""/>
+            <SP HPOS="1287" ID="SP_18.12.4.16" VPOS="1070" WIDTH="24"/>
+            <String CONTENT="is" HEIGHT="31" HPOS="1311" ID="ST_18.12.4.17" STYLEREFS="Style_8" VPOS="1070" WIDTH="29" WC="0.37" CC="00" TAGREFS=""/>
+            <SP HPOS="1340" ID="SP_18.12.4.18" VPOS="1080" WIDTH="28"/>
+            <String CONTENT="re­" HEIGHT="21" HPOS="1368" ID="ST_18.12.4.19" STYLEREFS="Style_8" VPOS="1080" WIDTH="49" WC="1.0" CC="000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="43" HPOS="287" ID="TL_18.12.5" VPOS="1112" WIDTH="1037">
+            <String CONTENT="versed," HEIGHT="41" HPOS="287" ID="ST_18.12.5.1" STYLEREFS="Style_8" VPOS="1114" WIDTH="127" WC="0.46" CC="0000000" TAGREFS=""/>
+            <SP HPOS="414" ID="SP_18.12.5.2" VPOS="1114" WIDTH="17"/>
+            <String CONTENT="and" HEIGHT="32" HPOS="431" ID="ST_18.12.5.3" STYLEREFS="Style_8" VPOS="1114" WIDTH="66" WC="0.45" CC="000" TAGREFS=""/>
+            <SP HPOS="497" ID="SP_18.12.5.4" VPOS="1115" WIDTH="14"/>
+            <String CONTENT="the" HEIGHT="31" HPOS="511" ID="ST_18.12.5.5" STYLEREFS="Style_8" VPOS="1115" WIDTH="57" WC="0.39" CC="000" TAGREFS=""/>
+            <SP HPOS="568" ID="SP_18.12.5.6" VPOS="1124" WIDTH="17"/>
+            <String CONTENT="cause" HEIGHT="22" HPOS="585" ID="ST_18.12.5.7" STYLEREFS="Style_8" VPOS="1124" WIDTH="97" WC="0.54" CC="00000" TAGREFS=""/>
+            <SP HPOS="682" ID="SP_18.12.5.8" VPOS="1113" WIDTH="15"/>
+            <String CONTENT="remanded" HEIGHT="33" HPOS="697" ID="ST_18.12.5.9" STYLEREFS="Style_8" VPOS="1113" WIDTH="180" WC="0.47" CC="00000000" TAGREFS=""/>
+            <SP HPOS="877" ID="SP_18.12.5.10" VPOS="1116" WIDTH="15"/>
+            <String CONTENT="to" HEIGHT="30" HPOS="892" ID="ST_18.12.5.11" STYLEREFS="Style_8" VPOS="1116" WIDTH="35" WC="0.60" CC="00" TAGREFS=""/>
+            <SP HPOS="927" ID="SP_18.12.5.12" VPOS="1114" WIDTH="15"/>
+            <String CONTENT="the" HEIGHT="32" HPOS="942" ID="ST_18.12.5.13" STYLEREFS="Style_8" VPOS="1114" WIDTH="57" WC="0.46" CC="000" TAGREFS=""/>
+            <SP HPOS="999" ID="SP_18.12.5.14" VPOS="1116" WIDTH="16"/>
+            <String CONTENT="court" HEIGHT="29" HPOS="1015" ID="ST_18.12.5.15" STYLEREFS="Style_8" VPOS="1116" WIDTH="96" WC="0.53" CC="00000" TAGREFS=""/>
+            <SP HPOS="1111" ID="SP_18.12.5.16" VPOS="1113" WIDTH="13"/>
+            <String CONTENT="below." HEIGHT="33" HPOS="1124" ID="ST_18.12.5.17" STYLEREFS="Style_8" VPOS="1113" WIDTH="114" WC="0.67" CC="000000" TAGREFS=""/>
+            <SP HPOS="1238" ID="SP_18.12.5.18" VPOS="1112" WIDTH="28"/>
+            <String CONTENT="(1)" HEIGHT="43" HPOS="1266" ID="ST_18.12.5.19" STYLEREFS="Style_8" VPOS="1112" WIDTH="58" WC="1.0" CC="000" TAGREFS="footnotemark0002"/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="42.0" HPOS="1025.0" ID="BL_18.13" TAGREFS="b18-9" VPOS="1156.0" WIDTH="348.0">
+          <TextLine HEIGHT="42" HPOS="1025" ID="TL_18.13.1" VPOS="1156" WIDTH="348">
+            <String CONTENT="Judgment" HEIGHT="41" HPOS="1025" ID="ST_18.13.1.1" STYLEREFS="Style_9" VPOS="1157" WIDTH="173" WC="0.49" CC="00000000" TAGREFS=""/>
+            <SP HPOS="1198" ID="SP_18.13.1.2" VPOS="1156" WIDTH="13"/>
+            <String CONTENT="reversed." HEIGHT="33" HPOS="1211" ID="ST_18.13.1.3" STYLEREFS="Style_9" VPOS="1156" WIDTH="162" WC="0.29" CC="000000000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="64.0" HPOS="289.0" ID="BL_18.14" TAGREFS="b18-14" VPOS="1573.0" WIDTH="1127.0">
+          <TextLine HEIGHT="33" HPOS="318" ID="TL_18.14.1" VPOS="1573" WIDTH="1098">
+            <String CONTENT="*" HEIGHT="19" HPOS="318" ID="ST_18.14.1.1" STYLEREFS="Style_5" VPOS="1574" WIDTH="17" WC="0.21" CC="9" TAGREFS=""/>
+            <SP HPOS="335" ID="SP_18.14.1.2" VPOS="1574" WIDTH="8"/>
+            <String CONTENT="Justice" HEIGHT="24" HPOS="343" ID="ST_18.14.1.3" STYLEREFS="Style_5" VPOS="1574" WIDTH="93" WC="0.55" CC="0000000" TAGREFS=""/>
+            <SP HPOS="436" ID="SP_18.14.1.4" VPOS="1573" WIDTH="10"/>
+            <String CONTENT="Reynolds" HEIGHT="25" HPOS="446" ID="ST_18.14.1.5" STYLEREFS="Style_3" VPOS="1573" WIDTH="153" WC="0.23" CC="00090000" TAGREFS=""/>
+            <SP HPOS="599" ID="SP_18.14.1.6" VPOS="1573" WIDTH="11"/>
+            <String CONTENT="having" HEIGHT="32" HPOS="610" ID="ST_18.14.1.7" STYLEREFS="Style_5" VPOS="1573" WIDTH="94" WC="0.32" CC="000000" TAGREFS=""/>
+            <SP HPOS="704" ID="SP_18.14.1.8" VPOS="1573" WIDTH="11"/>
+            <String CONTENT="been" HEIGHT="24" HPOS="715" ID="ST_18.14.1.9" STYLEREFS="Style_5" VPOS="1573" WIDTH="60" WC="0.75" CC="0000" TAGREFS=""/>
+            <SP HPOS="775" ID="SP_18.14.1.10" VPOS="1573" WIDTH="12"/>
+            <String CONTENT="counsel" HEIGHT="24" HPOS="787" ID="ST_18.14.1.11" STYLEREFS="Style_5" VPOS="1573" WIDTH="101" WC="0.60" CC="0000000" TAGREFS=""/>
+            <SP HPOS="888" ID="SP_18.14.1.12" VPOS="1574" WIDTH="10"/>
+            <String CONTENT="in" HEIGHT="23" HPOS="898" ID="ST_18.14.1.13" STYLEREFS="Style_5" VPOS="1574" WIDTH="27" WC="0.47" CC="00" TAGREFS=""/>
+            <SP HPOS="925" ID="SP_18.14.1.14" VPOS="1573" WIDTH="11"/>
+            <String CONTENT="this" HEIGHT="24" HPOS="936" ID="ST_18.14.1.15" STYLEREFS="Style_5" VPOS="1573" WIDTH="49" WC="0.55" CC="0000" TAGREFS=""/>
+            <SP HPOS="985" ID="SP_18.14.1.16" VPOS="1581" WIDTH="11"/>
+            <String CONTENT="cause," HEIGHT="23" HPOS="996" ID="ST_18.14.1.17" STYLEREFS="Style_5" VPOS="1581" WIDTH="80" WC="0.54" CC="000000" TAGREFS=""/>
+            <SP HPOS="1076" ID="SP_18.14.1.18" VPOS="1574" WIDTH="12"/>
+            <String CONTENT="in" HEIGHT="23" HPOS="1088" ID="ST_18.14.1.19" STYLEREFS="Style_5" VPOS="1574" WIDTH="27" WC="0.67" CC="00" TAGREFS=""/>
+            <SP HPOS="1115" ID="SP_18.14.1.20" VPOS="1573" WIDTH="8"/>
+            <String CONTENT="the" HEIGHT="24" HPOS="1123" ID="ST_18.14.1.21" STYLEREFS="Style_5" VPOS="1573" WIDTH="42" WC="0.59" CC="000" TAGREFS=""/>
+            <SP HPOS="1165" ID="SP_18.14.1.22" VPOS="1577" WIDTH="8"/>
+            <String CONTENT="court" HEIGHT="21" HPOS="1173" ID="ST_18.14.1.23" STYLEREFS="Style_5" VPOS="1577" WIDTH="70" WC="0.55" CC="00000" TAGREFS=""/>
+            <SP HPOS="1243" ID="SP_18.14.1.24" VPOS="1573" WIDTH="10"/>
+            <String CONTENT="below," HEIGHT="31" HPOS="1253" ID="ST_18.14.1.25" STYLEREFS="Style_5" VPOS="1573" WIDTH="87" WC="0.52" CC="000000" TAGREFS=""/>
+            <SP HPOS="1340" ID="SP_18.14.1.26" VPOS="1581" WIDTH="12"/>
+            <String CONTENT="gave" HEIGHT="25" HPOS="1352" ID="ST_18.14.1.27" STYLEREFS="Style_5" VPOS="1581" WIDTH="64" WC="0.39" CC="0000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="31" HPOS="289" ID="TL_18.14.2" VPOS="1606" WIDTH="153">
+            <String CONTENT="no" HEIGHT="16" HPOS="289" ID="ST_18.14.2.1" STYLEREFS="Style_5" VPOS="1614" WIDTH="32" WC="0.79" CC="00" TAGREFS=""/>
+            <SP HPOS="321" ID="SP_18.14.2.2" VPOS="1606" WIDTH="12"/>
+            <String CONTENT="opinion." HEIGHT="31" HPOS="333" ID="ST_18.14.2.3" STYLEREFS="Style_5" VPOS="1606" WIDTH="109" WC="0.84" CC="00000000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="161.0" HPOS="287.0" ID="BL_18.15" TAGREFS="b18-15" VPOS="1645.0" WIDTH="1131.0">
+          <TextLine HEIGHT="33" HPOS="322" ID="TL_18.15.1" VPOS="1645" WIDTH="1095">
+            <String CONTENT="(1.)" HEIGHT="33" HPOS="322" ID="ST_18.15.1.1" STYLEREFS="Style_5" VPOS="1645" WIDTH="47" WC="0.82" CC="0900" TAGREFS=""/>
+            <SP HPOS="369" ID="SP_18.15.1.2" VPOS="1645" WIDTH="19"/>
+            <String CONTENT="A" HEIGHT="25" HPOS="388" ID="ST_18.15.1.3" STYLEREFS="Style_5" VPOS="1645" WIDTH="25" WC="0.29" CC="0" TAGREFS=""/>
+            <SP HPOS="413" ID="SP_18.15.1.4" VPOS="1646" WIDTH="8"/>
+            <String CONTENT="promissory" HEIGHT="31" HPOS="421" ID="ST_18.15.1.5" STYLEREFS="Style_5" VPOS="1646" WIDTH="151" WC="0.64" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="572" ID="SP_18.15.1.6" VPOS="1649" WIDTH="10"/>
+            <String CONTENT="note" HEIGHT="21" HPOS="582" ID="ST_18.15.1.7" STYLEREFS="Style_5" VPOS="1649" WIDTH="58" WC="0.84" CC="0000" TAGREFS=""/>
+            <SP HPOS="640" ID="SP_18.15.1.8" VPOS="1645" WIDTH="16"/>
+            <String CONTENT="is" HEIGHT="24" HPOS="656" ID="ST_18.15.1.9" STYLEREFS="Style_5" VPOS="1645" WIDTH="21" WC="0.41" CC="00" TAGREFS=""/>
+            <SP HPOS="677" ID="SP_18.15.1.10" VPOS="1645" WIDTH="13"/>
+            <String CONTENT="defined" HEIGHT="24" HPOS="690" ID="ST_18.15.1.11" STYLEREFS="Style_5" VPOS="1645" WIDTH="96" WC="0.57" CC="0000000" TAGREFS=""/>
+            <SP HPOS="786" ID="SP_18.15.1.12" VPOS="1649" WIDTH="9"/>
+            <String CONTENT="to" HEIGHT="21" HPOS="795" ID="ST_18.15.1.13" STYLEREFS="Style_5" VPOS="1649" WIDTH="27" WC="0.64" CC="00" TAGREFS=""/>
+            <SP HPOS="822" ID="SP_18.15.1.14" VPOS="1645" WIDTH="9"/>
+            <String CONTENT="be" HEIGHT="25" HPOS="831" ID="ST_18.15.1.15" STYLEREFS="Style_5" VPOS="1645" WIDTH="31" WC="0.61" CC="00" TAGREFS=""/>
+            <SP HPOS="862" ID="SP_18.15.1.16" VPOS="1647" WIDTH="19"/>
+            <String CONTENT="“a" HEIGHT="22" HPOS="881" ID="ST_18.15.1.17" STYLEREFS="Style_5" VPOS="1647" WIDTH="39" WC="0.13" CC="99" TAGREFS=""/>
+            <SP HPOS="920" ID="SP_18.15.1.18" VPOS="1646" WIDTH="9"/>
+            <String CONTENT="promise" HEIGHT="32" HPOS="929" ID="ST_18.15.1.19" STYLEREFS="Style_5" VPOS="1646" WIDTH="108" WC="0.55" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1037" ID="SP_18.15.1.20" VPOS="1654" WIDTH="9"/>
+            <String CONTENT="or" HEIGHT="16" HPOS="1046" ID="ST_18.15.1.21" STYLEREFS="Style_5" VPOS="1654" WIDTH="28" WC="0.66" CC="00" TAGREFS=""/>
+            <SP HPOS="1074" ID="SP_18.15.1.22" VPOS="1650" WIDTH="16"/>
+            <String CONTENT="agreement" HEIGHT="28" HPOS="1090" ID="ST_18.15.1.23" STYLEREFS="Style_5" VPOS="1650" WIDTH="141" WC="0.37" CC="000090000" TAGREFS=""/>
+            <SP HPOS="1231" ID="SP_18.15.1.24" VPOS="1646" WIDTH="16"/>
+            <String CONTENT="in" HEIGHT="24" HPOS="1247" ID="ST_18.15.1.25" STYLEREFS="Style_5" VPOS="1646" WIDTH="28" WC="0.23" CC="00" TAGREFS=""/>
+            <SP HPOS="1275" ID="SP_18.15.1.26" VPOS="1647" WIDTH="8"/>
+            <String CONTENT="writing" HEIGHT="31" HPOS="1283" ID="ST_18.15.1.27" STYLEREFS="Style_5" VPOS="1647" WIDTH="98" WC="0.53" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1381" ID="SP_18.15.1.28" VPOS="1649" WIDTH="11"/>
+            <String CONTENT="to" HEIGHT="22" HPOS="1392" ID="ST_18.15.1.29" STYLEREFS="Style_5" VPOS="1649" WIDTH="25" WC="0.81" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="32" HPOS="288" ID="TL_18.15.2" VPOS="1678" WIDTH="1130">
+            <String CONTENT="pay" HEIGHT="24" HPOS="288" ID="ST_18.15.2.1" STYLEREFS="Style_5" VPOS="1686" WIDTH="50" WC="0.38" CC="000" TAGREFS=""/>
+            <SP HPOS="338" ID="SP_18.15.2.2" VPOS="1686" WIDTH="11"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="349" ID="ST_18.15.2.3" STYLEREFS="Style_5" VPOS="1686" WIDTH="16" WC="0.63" CC="0" TAGREFS=""/>
+            <SP HPOS="365" ID="SP_18.15.2.4" VPOS="1678" WIDTH="10"/>
+            <String CONTENT="specified" HEIGHT="31" HPOS="375" ID="ST_18.15.2.5" STYLEREFS="Style_5" VPOS="1678" WIDTH="115" WC="0.76" CC="000000000" TAGREFS=""/>
+            <SP HPOS="490" ID="SP_18.15.2.6" VPOS="1685" WIDTH="8"/>
+            <String CONTENT="sum," HEIGHT="23" HPOS="498" ID="ST_18.15.2.7" STYLEREFS="Style_5" VPOS="1685" WIDTH="63" WC="0.52" CC="0000" TAGREFS=""/>
+            <SP HPOS="561" ID="SP_18.15.2.8" VPOS="1681" WIDTH="13"/>
+            <String CONTENT="at" HEIGHT="20" HPOS="574" ID="ST_18.15.2.9" STYLEREFS="Style_5" VPOS="1681" WIDTH="26" WC="0.28" CC="00" TAGREFS=""/>
+            <SP HPOS="600" ID="SP_18.15.2.10" VPOS="1685" WIDTH="11"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="611" ID="ST_18.15.2.11" STYLEREFS="Style_5" VPOS="1685" WIDTH="15" WC="0.34" CC="0" TAGREFS=""/>
+            <SP HPOS="626" ID="SP_18.15.2.12" VPOS="1678" WIDTH="11"/>
+            <String CONTENT="time" HEIGHT="24" HPOS="637" ID="ST_18.15.2.13" STYLEREFS="Style_5" VPOS="1678" WIDTH="58" WC="0.66" CC="0000" TAGREFS=""/>
+            <SP HPOS="695" ID="SP_18.15.2.14" VPOS="1678" WIDTH="6"/>
+            <String CONTENT="therein" HEIGHT="23" HPOS="701" ID="ST_18.15.2.15" STYLEREFS="Style_5" VPOS="1678" WIDTH="94" WC="0.57" CC="0000000" TAGREFS=""/>
+            <SP HPOS="795" ID="SP_18.15.2.16" VPOS="1678" WIDTH="7"/>
+            <String CONTENT="limited," HEIGHT="30" HPOS="802" ID="ST_18.15.2.17" STYLEREFS="Style_5" VPOS="1678" WIDTH="103" WC="0.64" CC="00000000" TAGREFS=""/>
+            <SP HPOS="905" ID="SP_18.15.2.18" VPOS="1686" WIDTH="13"/>
+            <String CONTENT="or" HEIGHT="16" HPOS="918" ID="ST_18.15.2.19" STYLEREFS="Style_5" VPOS="1686" WIDTH="27" WC="0.66" CC="00" TAGREFS=""/>
+            <SP HPOS="945" ID="SP_18.15.2.20" VPOS="1686" WIDTH="9"/>
+            <String CONTENT="on" HEIGHT="16" HPOS="954" ID="ST_18.15.2.21" STYLEREFS="Style_5" VPOS="1686" WIDTH="32" WC="0.84" CC="00" TAGREFS=""/>
+            <SP HPOS="986" ID="SP_18.15.2.22" VPOS="1678" WIDTH="12"/>
+            <String CONTENT="demand," HEIGHT="30" HPOS="998" ID="ST_18.15.2.23" STYLEREFS="Style_5" VPOS="1678" WIDTH="114" WC="0.34" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1112" ID="SP_18.15.2.24" VPOS="1686" WIDTH="13"/>
+            <String CONTENT="or" HEIGHT="17" HPOS="1125" ID="ST_18.15.2.25" STYLEREFS="Style_5" VPOS="1686" WIDTH="28" WC="0.62" CC="00" TAGREFS=""/>
+            <SP HPOS="1153" ID="SP_18.15.2.26" VPOS="1682" WIDTH="10"/>
+            <String CONTENT="at" HEIGHT="20" HPOS="1163" ID="ST_18.15.2.27" STYLEREFS="Style_5" VPOS="1682" WIDTH="26" WC="0.37" CC="00" TAGREFS=""/>
+            <SP HPOS="1189" ID="SP_18.15.2.28" VPOS="1678" WIDTH="11"/>
+            <String CONTENT="sight," HEIGHT="32" HPOS="1200" ID="ST_18.15.2.29" STYLEREFS="Style_5" VPOS="1678" WIDTH="73" WC="0.29" CC="000000" TAGREFS=""/>
+            <SP HPOS="1273" ID="SP_18.15.2.30" VPOS="1682" WIDTH="9"/>
+            <String CONTENT="to" HEIGHT="20" HPOS="1282" ID="ST_18.15.2.31" STYLEREFS="Style_7" VPOS="1682" WIDTH="22" WC="0.91" CC="00" TAGREFS=""/>
+            <SP HPOS="1304" ID="SP_18.15.2.32" VPOS="1686" WIDTH="7"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="1311" ID="ST_18.15.2.33" STYLEREFS="Style_7" VPOS="1686" WIDTH="17" WC="0.54" CC="0" TAGREFS=""/>
+            <SP HPOS="1328" ID="SP_18.15.2.34" VPOS="1686" WIDTH="6"/>
+            <String CONTENT="person" HEIGHT="24" HPOS="1334" ID="ST_18.15.2.35" STYLEREFS="Style_7" VPOS="1686" WIDTH="84" WC="0.51" CC="000000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="33" HPOS="289" ID="TL_18.15.3" VPOS="1709" WIDTH="1128">
+            <String CONTENT="therein" HEIGHT="25" HPOS="289" ID="ST_18.15.3.1" STYLEREFS="Style_7" VPOS="1710" WIDTH="85" WC="0.48" CC="0000000" TAGREFS=""/>
+            <SP HPOS="374" ID="SP_18.15.3.2" VPOS="1709" WIDTH="11"/>
+            <String CONTENT="named" HEIGHT="25" HPOS="385" ID="ST_18.15.3.3" STYLEREFS="Style_7" VPOS="1709" WIDTH="84" WC="0.62" CC="00000" TAGREFS=""/>
+            <SP HPOS="469" ID="SP_18.15.3.4" VPOS="1718" WIDTH="10"/>
+            <String CONTENT="or" HEIGHT="15" HPOS="479" ID="ST_18.15.3.5" STYLEREFS="Style_7" VPOS="1718" WIDTH="25" WC="0.65" CC="00" TAGREFS=""/>
+            <SP HPOS="504" ID="SP_18.15.3.6" VPOS="1709" WIDTH="11"/>
+            <String CONTENT="his" HEIGHT="25" HPOS="515" ID="ST_18.15.3.7" STYLEREFS="Style_7" VPOS="1709" WIDTH="35" WC="0.51" CC="000" TAGREFS=""/>
+            <SP HPOS="550" ID="SP_18.15.3.8" VPOS="1709" WIDTH="11"/>
+            <String CONTENT="order," HEIGHT="31" HPOS="561" ID="ST_18.15.3.9" STYLEREFS="Style_7" VPOS="1709" WIDTH="74" WC="0.47" CC="000000" TAGREFS=""/>
+            <SP HPOS="635" ID="SP_18.15.3.10" VPOS="1718" WIDTH="12"/>
+            <String CONTENT="or" HEIGHT="16" HPOS="647" ID="ST_18.15.3.11" STYLEREFS="Style_7" VPOS="1718" WIDTH="26" WC="0.34" CC="00" TAGREFS=""/>
+            <SP HPOS="673" ID="SP_18.15.3.12" VPOS="1713" WIDTH="10"/>
+            <String CONTENT="to" HEIGHT="20" HPOS="683" ID="ST_18.15.3.13" STYLEREFS="Style_7" VPOS="1713" WIDTH="23" WC="0.25" CC="00" TAGREFS=""/>
+            <SP HPOS="706" ID="SP_18.15.3.14" VPOS="1710" WIDTH="18"/>
+            <String CONTENT="bearer.”" HEIGHT="24" HPOS="724" ID="ST_18.15.3.15" STYLEREFS="Style_7" VPOS="1710" WIDTH="103" WC="0.37" CC="00000009" TAGREFS=""/>
+            <SP HPOS="827" ID="SP_18.15.3.16" VPOS="1710" WIDTH="36"/>
+            <String CONTENT="Chitty" HEIGHT="32" HPOS="863" ID="ST_18.15.3.17" STYLEREFS="Style_5" VPOS="1710" WIDTH="84" WC="0.49" CC="900000" TAGREFS=""/>
+            <SP HPOS="947" ID="SP_18.15.3.18" VPOS="1717" WIDTH="20"/>
+            <String CONTENT="on" HEIGHT="17" HPOS="967" ID="ST_18.15.3.19" STYLEREFS="Style_5" VPOS="1717" WIDTH="32" WC="1.00" CC="00" TAGREFS=""/>
+            <SP HPOS="999" ID="SP_18.15.3.20" VPOS="1710" WIDTH="11"/>
+            <String CONTENT="Bills," HEIGHT="30" HPOS="1010" ID="ST_18.15.3.21" STYLEREFS="Style_5" VPOS="1710" WIDTH="73" WC="0.43" CC="000000" TAGREFS=""/>
+            <SP HPOS="1083" ID="SP_18.15.3.22" VPOS="1712" WIDTH="13"/>
+            <String CONTENT="516." HEIGHT="22" HPOS="1096" ID="ST_18.15.3.23" STYLEREFS="Style_5" VPOS="1712" WIDTH="55" WC="0.89" CC="0000" TAGREFS=""/>
+            <SP HPOS="1151" ID="SP_18.15.3.24" VPOS="1709" WIDTH="39"/>
+            <String CONTENT="Walters" HEIGHT="27" HPOS="1190" ID="ST_18.15.3.25" STYLEREFS="Style_7" VPOS="1709" WIDTH="100" WC="0.71" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1290" ID="SP_18.15.3.26" VPOS="1718" WIDTH="10"/>
+            <String CONTENT="v." HEIGHT="17" HPOS="1300" ID="ST_18.15.3.27" STYLEREFS="Style_1" VPOS="1718" WIDTH="25" WC="1.0" CC="00" TAGREFS=""/>
+            <SP HPOS="1325" ID="SP_18.15.3.28" VPOS="1709" WIDTH="13"/>
+            <String CONTENT="Short," HEIGHT="32" HPOS="1338" ID="ST_18.15.3.29" STYLEREFS="Style_7" VPOS="1709" WIDTH="79" WC="0.65" CC="000000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="33" HPOS="290" ID="TL_18.15.4" VPOS="1742" WIDTH="1128">
+            <String CONTENT="5" HEIGHT="22" HPOS="290" ID="ST_18.15.4.1" STYLEREFS="Style_4" VPOS="1745" WIDTH="13" WC="0.45" CC="0" TAGREFS=""/>
+            <SP HPOS="303" ID="SP_18.15.4.2" VPOS="1742" WIDTH="15"/>
+            <String CONTENT="Gilm.," HEIGHT="31" HPOS="318" ID="ST_18.15.4.3" STYLEREFS="Style_5" VPOS="1742" WIDTH="85" WC="0.61" CC="009999" TAGREFS=""/>
+            <SP HPOS="403" ID="SP_18.15.4.4" VPOS="1743" WIDTH="12"/>
+            <String CONTENT="259." HEIGHT="23" HPOS="415" ID="ST_18.15.4.5" STYLEREFS="Style_5" VPOS="1743" WIDTH="55" WC="0.67" CC="0009" TAGREFS=""/>
+            <SP HPOS="470" ID="SP_18.15.4.6" VPOS="1742" WIDTH="45"/>
+            <String CONTENT="All" HEIGHT="24" HPOS="515" ID="ST_18.15.4.7" STYLEREFS="Style_5" VPOS="1742" WIDTH="46" WC="0.53" CC="000" TAGREFS=""/>
+            <SP HPOS="561" ID="SP_18.15.4.8" VPOS="1745" WIDTH="10"/>
+            <String CONTENT="notes" HEIGHT="21" HPOS="571" ID="ST_18.15.4.9" STYLEREFS="Style_5" VPOS="1745" WIDTH="70" WC="0.80" CC="00000" TAGREFS=""/>
+            <SP HPOS="641" ID="SP_18.15.4.10" VPOS="1745" WIDTH="11"/>
+            <String CONTENT="must" HEIGHT="21" HPOS="652" ID="ST_18.15.4.11" STYLEREFS="Style_5" VPOS="1745" WIDTH="68" WC="0.38" CC="0000" TAGREFS=""/>
+            <SP HPOS="720" ID="SP_18.15.4.12" VPOS="1742" WIDTH="12"/>
+            <String CONTENT="contain" HEIGHT="24" HPOS="732" ID="ST_18.15.4.13" STYLEREFS="Style_5" VPOS="1742" WIDTH="99" WC="0.72" CC="0000000" TAGREFS=""/>
+            <SP HPOS="831" ID="SP_18.15.4.14" VPOS="1743" WIDTH="10"/>
+            <String CONTENT="the" HEIGHT="24" HPOS="841" ID="ST_18.15.4.15" STYLEREFS="Style_5" VPOS="1743" WIDTH="42" WC="0.62" CC="000" TAGREFS=""/>
+            <SP HPOS="883" ID="SP_18.15.4.16" VPOS="1750" WIDTH="11"/>
+            <String CONTENT="name" HEIGHT="16" HPOS="894" ID="ST_18.15.4.17" STYLEREFS="Style_5" VPOS="1750" WIDTH="74" WC="0.72" CC="0000" TAGREFS=""/>
+            <SP HPOS="968" ID="SP_18.15.4.18" VPOS="1742" WIDTH="12"/>
+            <String CONTENT="of" HEIGHT="25" HPOS="980" ID="ST_18.15.4.19" STYLEREFS="Style_5" VPOS="1742" WIDTH="28" WC="0.83" CC="00" TAGREFS=""/>
+            <SP HPOS="1008" ID="SP_18.15.4.20" VPOS="1742" WIDTH="14"/>
+            <String CONTENT="the" HEIGHT="25" HPOS="1022" ID="ST_18.15.4.21" STYLEREFS="Style_5" VPOS="1742" WIDTH="41" WC="0.90" CC="000" TAGREFS=""/>
+            <SP HPOS="1063" ID="SP_18.15.4.22" VPOS="1750" WIDTH="11"/>
+            <String CONTENT="payee," HEIGHT="24" HPOS="1074" ID="ST_18.15.4.23" STYLEREFS="Style_5" VPOS="1750" WIDTH="84" WC="0.48" CC="000000" TAGREFS=""/>
+            <SP HPOS="1158" ID="SP_18.15.4.24" VPOS="1743" WIDTH="12"/>
+            <String CONTENT="unless" HEIGHT="24" HPOS="1170" ID="ST_18.15.4.25" STYLEREFS="Style_5" VPOS="1743" WIDTH="84" WC="0.41" CC="000000" TAGREFS=""/>
+            <SP HPOS="1254" ID="SP_18.15.4.26" VPOS="1743" WIDTH="18"/>
+            <String CONTENT="payable" HEIGHT="32" HPOS="1272" ID="ST_18.15.4.27" STYLEREFS="Style_5" VPOS="1743" WIDTH="105" WC="0.39" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1377" ID="SP_18.15.4.28" VPOS="1746" WIDTH="16"/>
+            <String CONTENT="to" HEIGHT="21" HPOS="1393" ID="ST_18.15.4.29" STYLEREFS="Style_5" VPOS="1746" WIDTH="25" WC="0.72" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="32" HPOS="287" ID="TL_18.15.5" VPOS="1774" WIDTH="389">
+            <String CONTENT="bearer." HEIGHT="24" HPOS="287" ID="ST_18.15.5.1" STYLEREFS="Style_5" VPOS="1775" WIDTH="93" WC="0.65" CC="0000000" TAGREFS=""/>
+            <SP HPOS="380" ID="SP_18.15.5.2" VPOS="1774" WIDTH="33"/>
+            <String CONTENT="Bailey" HEIGHT="32" HPOS="413" ID="ST_18.15.5.3" STYLEREFS="Style_5" VPOS="1774" WIDTH="90" WC="0.58" CC="000000" TAGREFS=""/>
+            <SP HPOS="503" ID="SP_18.15.5.4" VPOS="1782" WIDTH="10"/>
+            <String CONTENT="on" HEIGHT="16" HPOS="513" ID="ST_18.15.5.5" STYLEREFS="Style_5" VPOS="1782" WIDTH="34" WC="0.61" CC="00" TAGREFS=""/>
+            <SP HPOS="547" ID="SP_18.15.5.6" VPOS="1774" WIDTH="10"/>
+            <String CONTENT="Bills," HEIGHT="30" HPOS="557" ID="ST_18.15.5.7" STYLEREFS="Style_5" VPOS="1774" WIDTH="71" WC="0.80" CC="000000" TAGREFS=""/>
+            <SP HPOS="628" ID="SP_18.15.5.8" VPOS="1777" WIDTH="10"/>
+            <String CONTENT="22." HEIGHT="21" HPOS="638" ID="ST_18.15.5.9" STYLEREFS="Style_5" VPOS="1777" WIDTH="38" WC="0.58" CC="000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="96.0" HPOS="286.0" ID="BL_18.16" TAGREFS="b18-16" VPOS="1806.0" WIDTH="1135.0">
+          <TextLine HEIGHT="33" HPOS="319" ID="TL_18.16.1" VPOS="1806" WIDTH="1102">
+            <String CONTENT="No" HEIGHT="24" HPOS="319" ID="ST_18.16.1.1" STYLEREFS="Style_5" VPOS="1807" WIDTH="42" WC="0.58" CC="00" TAGREFS=""/>
+            <SP HPOS="361" ID="SP_18.16.1.2" VPOS="1807" WIDTH="12"/>
+            <String CONTENT="action" HEIGHT="24" HPOS="373" ID="ST_18.16.1.3" STYLEREFS="Style_5" VPOS="1807" WIDTH="82" WC="0.79" CC="000000" TAGREFS=""/>
+            <SP HPOS="455" ID="SP_18.16.1.4" VPOS="1814" WIDTH="12"/>
+            <String CONTENT="can" HEIGHT="16" HPOS="467" ID="ST_18.16.1.5" STYLEREFS="Style_5" VPOS="1814" WIDTH="46" WC="0.65" CC="000" TAGREFS=""/>
+            <SP HPOS="513" ID="SP_18.16.1.6" VPOS="1806" WIDTH="11"/>
+            <String CONTENT="be" HEIGHT="24" HPOS="524" ID="ST_18.16.1.7" STYLEREFS="Style_5" VPOS="1806" WIDTH="29" WC="0.71" CC="00" TAGREFS=""/>
+            <SP HPOS="553" ID="SP_18.16.1.8" VPOS="1806" WIDTH="11"/>
+            <String CONTENT="maintained" HEIGHT="24" HPOS="564" ID="ST_18.16.1.9" STYLEREFS="Style_5" VPOS="1806" WIDTH="151" WC="0.58" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="715" ID="SP_18.16.1.10" VPOS="1814" WIDTH="11"/>
+            <String CONTENT="on" HEIGHT="16" HPOS="726" ID="ST_18.16.1.11" STYLEREFS="Style_5" VPOS="1814" WIDTH="34" WC="0.71" CC="00" TAGREFS=""/>
+            <SP HPOS="760" ID="SP_18.16.1.12" VPOS="1814" WIDTH="16"/>
+            <String CONTENT="an" HEIGHT="16" HPOS="776" ID="ST_18.16.1.13" STYLEREFS="Style_5" VPOS="1814" WIDTH="33" WC="0.70" CC="00" TAGREFS=""/>
+            <SP HPOS="809" ID="SP_18.16.1.14" VPOS="1807" WIDTH="18"/>
+            <String CONTENT="instrument" HEIGHT="24" HPOS="827" ID="ST_18.16.1.15" STYLEREFS="Style_5" VPOS="1807" WIDTH="148" WC="0.46" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="975" ID="SP_18.16.1.16" VPOS="1807" WIDTH="21"/>
+            <String CONTENT="in" HEIGHT="23" HPOS="996" ID="ST_18.16.1.17" STYLEREFS="Style_5" VPOS="1807" WIDTH="26" WC="0.66" CC="00" TAGREFS=""/>
+            <SP HPOS="1022" ID="SP_18.16.1.18" VPOS="1807" WIDTH="11"/>
+            <String CONTENT="writing" HEIGHT="31" HPOS="1033" ID="ST_18.16.1.19" STYLEREFS="Style_5" VPOS="1807" WIDTH="99" WC="0.51" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1132" ID="SP_18.16.1.20" VPOS="1806" WIDTH="15"/>
+            <String CONTENT="for" HEIGHT="25" HPOS="1147" ID="ST_18.16.1.21" STYLEREFS="Style_5" VPOS="1806" WIDTH="39" WC="0.47" CC="000" TAGREFS=""/>
+            <SP HPOS="1186" ID="SP_18.16.1.22" VPOS="1807" WIDTH="21"/>
+            <String CONTENT="the" HEIGHT="24" HPOS="1207" ID="ST_18.16.1.23" STYLEREFS="Style_5" VPOS="1807" WIDTH="42" WC="0.29" CC="000" TAGREFS=""/>
+            <SP HPOS="1249" ID="SP_18.16.1.24" VPOS="1810" WIDTH="14"/>
+            <String CONTENT="payment" HEIGHT="29" HPOS="1263" ID="ST_18.16.1.25" STYLEREFS="Style_5" VPOS="1810" WIDTH="119" WC="0.44" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1382" ID="SP_18.16.1.26" VPOS="1807" WIDTH="11"/>
+            <String CONTENT="of" HEIGHT="24" HPOS="1393" ID="ST_18.16.1.27" STYLEREFS="Style_5" VPOS="1807" WIDTH="28" WC="0.73" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="33" HPOS="286" ID="TL_18.16.2" VPOS="1838" WIDTH="1130">
+            <String CONTENT="money," HEIGHT="24" HPOS="286" ID="ST_18.16.2.1" STYLEREFS="Style_5" VPOS="1846" WIDTH="100" WC="0.64" CC="000000" TAGREFS=""/>
+            <SP HPOS="386" ID="SP_18.16.2.2" VPOS="1839" WIDTH="9"/>
+            <String CONTENT="unless" HEIGHT="23" HPOS="395" ID="ST_18.16.2.3" STYLEREFS="Style_5" VPOS="1839" WIDTH="84" WC="0.68" CC="000000" TAGREFS=""/>
+            <SP HPOS="479" ID="SP_18.16.2.4" VPOS="1838" WIDTH="10"/>
+            <String CONTENT="the" HEIGHT="24" HPOS="489" ID="ST_18.16.2.5" STYLEREFS="Style_5" VPOS="1838" WIDTH="42" WC="0.57" CC="000" TAGREFS=""/>
+            <SP HPOS="531" ID="SP_18.16.2.6" VPOS="1839" WIDTH="10"/>
+            <String CONTENT="instrument" HEIGHT="24" HPOS="541" ID="ST_18.16.2.7" STYLEREFS="Style_5" VPOS="1839" WIDTH="150" WC="0.48" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="691" ID="SP_18.16.2.8" VPOS="1838" WIDTH="10"/>
+            <String CONTENT="shows" HEIGHT="25" HPOS="701" ID="ST_18.16.2.9" STYLEREFS="Style_5" VPOS="1838" WIDTH="80" WC="0.47" CC="00000" TAGREFS=""/>
+            <SP HPOS="781" ID="SP_18.16.2.10" VPOS="1846" WIDTH="12"/>
+            <String CONTENT="on" HEIGHT="17" HPOS="793" ID="ST_18.16.2.11" STYLEREFS="Style_5" VPOS="1846" WIDTH="33" WC="0.69" CC="00" TAGREFS=""/>
+            <SP HPOS="826" ID="SP_18.16.2.12" VPOS="1839" WIDTH="11"/>
+            <String CONTENT="its" HEIGHT="24" HPOS="837" ID="ST_18.16.2.13" STYLEREFS="Style_5" VPOS="1839" WIDTH="31" WC="0.80" CC="000" TAGREFS=""/>
+            <SP HPOS="868" ID="SP_18.16.2.14" VPOS="1839" WIDTH="12"/>
+            <String CONTENT="face" HEIGHT="24" HPOS="880" ID="ST_18.16.2.15" STYLEREFS="Style_5" VPOS="1839" WIDTH="53" WC="0.46" CC="0000" TAGREFS=""/>
+            <SP HPOS="933" ID="SP_18.16.2.16" VPOS="1842" WIDTH="11"/>
+            <String CONTENT="to" HEIGHT="21" HPOS="944" ID="ST_18.16.2.17" STYLEREFS="Style_5" VPOS="1842" WIDTH="25" WC="1.00" CC="00" TAGREFS=""/>
+            <SP HPOS="969" ID="SP_18.16.2.18" VPOS="1839" WIDTH="11"/>
+            <String CONTENT="whom" HEIGHT="24" HPOS="980" ID="ST_18.16.2.19" STYLEREFS="Style_5" VPOS="1839" WIDTH="84" WC="0.46" CC="0000" TAGREFS=""/>
+            <SP HPOS="1064" ID="SP_18.16.2.20" VPOS="1839" WIDTH="21"/>
+            <String CONTENT="it" HEIGHT="24" HPOS="1085" ID="ST_18.16.2.21" STYLEREFS="Style_5" VPOS="1839" WIDTH="20" WC="0.61" CC="00" TAGREFS=""/>
+            <SP HPOS="1105" ID="SP_18.16.2.22" VPOS="1839" WIDTH="20"/>
+            <String CONTENT="is" HEIGHT="24" HPOS="1125" ID="ST_18.16.2.23" STYLEREFS="Style_5" VPOS="1839" WIDTH="20" WC="0.64" CC="00" TAGREFS=""/>
+            <SP HPOS="1145" ID="SP_18.16.2.24" VPOS="1839" WIDTH="17"/>
+            <String CONTENT="payable." HEIGHT="32" HPOS="1162" ID="ST_18.16.2.25" STYLEREFS="Style_5" VPOS="1839" WIDTH="113" WC="0.39" CC="00000000" TAGREFS=""/>
+            <SP HPOS="1275" ID="SP_18.16.2.26" VPOS="1838" WIDTH="33"/>
+            <String CONTENT="Mayo" HEIGHT="33" HPOS="1308" ID="ST_18.16.2.27" STYLEREFS="Style_7" VPOS="1838" WIDTH="74" WC="0.38" CC="0000" TAGREFS=""/>
+            <SP HPOS="1382" ID="SP_18.16.2.28" VPOS="1847" WIDTH="10"/>
+            <String CONTENT="v." HEIGHT="17" HPOS="1392" ID="ST_18.16.2.29" STYLEREFS="Style_5" VPOS="1847" WIDTH="24" WC="0.66" CC="00" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="32" HPOS="292" ID="TL_18.16.3" VPOS="1870" WIDTH="217">
+            <String CONTENT="Chenoweth," HEIGHT="31" HPOS="292" ID="ST_18.16.3.1" STYLEREFS="Style_7" VPOS="1870" WIDTH="140" WC="0.51" CC="0900000000" TAGREFS=""/>
+            <SP HPOS="432" ID="SP_18.16.3.2" VPOS="1874" WIDTH="12"/>
+            <String CONTENT="post." HEIGHT="28" HPOS="444" ID="ST_18.16.3.3" STYLEREFS="Style_5" VPOS="1874" WIDTH="65" WC="0.74" CC="00000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="128.0" HPOS="285.0" ID="BL_18.17" TAGREFS="b18-17" VPOS="1903.0" WIDTH="1133.0">
+          <TextLine HEIGHT="32" HPOS="318" ID="TL_18.17.1" VPOS="1903" WIDTH="1099">
+            <String CONTENT="Bills" HEIGHT="24" HPOS="318" ID="ST_18.17.1.1" STYLEREFS="Style_5" VPOS="1904" WIDTH="65" WC="0.68" CC="00000" TAGREFS=""/>
+            <SP HPOS="383" ID="SP_18.17.1.2" VPOS="1903" WIDTH="12"/>
+            <String CONTENT="of" HEIGHT="24" HPOS="395" ID="ST_18.17.1.3" STYLEREFS="Style_5" VPOS="1903" WIDTH="28" WC="0.62" CC="00" TAGREFS=""/>
+            <SP HPOS="423" ID="SP_18.17.1.4" VPOS="1903" WIDTH="8"/>
+            <String CONTENT="exchange" HEIGHT="32" HPOS="431" ID="ST_18.17.1.5" STYLEREFS="Style_5" VPOS="1903" WIDTH="128" WC="0.61" CC="00000000" TAGREFS=""/>
+            <SP HPOS="559" ID="SP_18.17.1.6" VPOS="1903" WIDTH="11"/>
+            <String CONTENT="and" HEIGHT="24" HPOS="570" ID="ST_18.17.1.7" STYLEREFS="Style_5" VPOS="1903" WIDTH="50" WC="0.36" CC="000" TAGREFS=""/>
+            <SP HPOS="620" ID="SP_18.17.1.8" VPOS="1903" WIDTH="10"/>
+            <String CONTENT="promissory" HEIGHT="32" HPOS="630" ID="ST_18.17.1.9" STYLEREFS="Style_5" VPOS="1903" WIDTH="152" WC="0.51" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="782" ID="SP_18.17.1.10" VPOS="1907" WIDTH="5"/>
+            <String CONTENT="notes" HEIGHT="21" HPOS="787" ID="ST_18.17.1.11" STYLEREFS="Style_5" VPOS="1907" WIDTH="71" WC="0.59" CC="00000" TAGREFS=""/>
+            <SP HPOS="858" ID="SP_18.17.1.12" VPOS="1903" WIDTH="12"/>
+            <String CONTENT="should" HEIGHT="25" HPOS="870" ID="ST_18.17.1.13" STYLEREFS="Style_5" VPOS="1903" WIDTH="90" WC="0.55" CC="000000" TAGREFS=""/>
+            <SP HPOS="960" ID="SP_18.17.1.14" VPOS="1903" WIDTH="10"/>
+            <String CONTENT="be" HEIGHT="25" HPOS="970" ID="ST_18.17.1.15" STYLEREFS="Style_5" VPOS="1903" WIDTH="30" WC="0.29" CC="00" TAGREFS=""/>
+            <SP HPOS="1000" ID="SP_18.17.1.16" VPOS="1903" WIDTH="10"/>
+            <String CONTENT="made" HEIGHT="24" HPOS="1010" ID="ST_18.17.1.17" STYLEREFS="Style_5" VPOS="1903" WIDTH="73" WC="0.44" CC="0000" TAGREFS=""/>
+            <SP HPOS="1083" ID="SP_18.17.1.18" VPOS="1903" WIDTH="6"/>
+            <String CONTENT="payable" HEIGHT="32" HPOS="1089" ID="ST_18.17.1.19" STYLEREFS="Style_5" VPOS="1903" WIDTH="106" WC="0.55" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1195" ID="SP_18.17.1.20" VPOS="1906" WIDTH="17"/>
+            <String CONTENT="to" HEIGHT="21" HPOS="1212" ID="ST_18.17.1.21" STYLEREFS="Style_5" VPOS="1906" WIDTH="25" WC="0.65" CC="00" TAGREFS=""/>
+            <SP HPOS="1237" ID="SP_18.17.1.22" VPOS="1910" WIDTH="12"/>
+            <String CONTENT="some" HEIGHT="18" HPOS="1249" ID="ST_18.17.1.23" STYLEREFS="Style_5" VPOS="1910" WIDTH="68" WC="0.61" CC="0000" TAGREFS=""/>
+            <SP HPOS="1317" ID="SP_18.17.1.24" VPOS="1911" WIDTH="11"/>
+            <String CONTENT="person" HEIGHT="24" HPOS="1328" ID="ST_18.17.1.25" STYLEREFS="Style_5" VPOS="1911" WIDTH="89" WC="0.60" CC="000000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="33" HPOS="287" ID="TL_18.17.2" VPOS="1935" WIDTH="1131">
+            <String CONTENT="specified," HEIGHT="31" HPOS="287" ID="ST_18.17.2.1" STYLEREFS="Style_5" VPOS="1936" WIDTH="124" WC="0.76" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="411" ID="SP_18.17.2.2" VPOS="1935" WIDTH="13"/>
+            <String CONTENT="but" HEIGHT="24" HPOS="424" ID="ST_18.17.2.3" STYLEREFS="Style_5" VPOS="1935" WIDTH="45" WC="0.31" CC="000" TAGREFS=""/>
+            <SP HPOS="469" ID="SP_18.17.2.4" VPOS="1935" WIDTH="10"/>
+            <String CONTENT="this" HEIGHT="24" HPOS="479" ID="ST_18.17.2.5" STYLEREFS="Style_5" VPOS="1935" WIDTH="48" WC="0.49" CC="0000" TAGREFS=""/>
+            <SP HPOS="527" ID="SP_18.17.2.6" VPOS="1942" WIDTH="8"/>
+            <String CONTENT="may" HEIGHT="25" HPOS="535" ID="ST_18.17.2.7" STYLEREFS="Style_5" VPOS="1942" WIDTH="60" WC="0.38" CC="000" TAGREFS=""/>
+            <SP HPOS="595" ID="SP_18.17.2.8" VPOS="1935" WIDTH="8"/>
+            <String CONTENT="be" HEIGHT="24" HPOS="603" ID="ST_18.17.2.9" STYLEREFS="Style_5" VPOS="1935" WIDTH="32" WC="0.16" CC="00" TAGREFS=""/>
+            <SP HPOS="635" ID="SP_18.17.2.10" VPOS="1935" WIDTH="11"/>
+            <String CONTENT="done" HEIGHT="25" HPOS="646" ID="ST_18.17.2.11" STYLEREFS="Style_5" VPOS="1935" WIDTH="63" WC="0.57" CC="0000" TAGREFS=""/>
+            <SP HPOS="709" ID="SP_18.17.2.12" VPOS="1935" WIDTH="10"/>
+            <String CONTENT="without" HEIGHT="25" HPOS="719" ID="ST_18.17.2.13" STYLEREFS="Style_5" VPOS="1935" WIDTH="104" WC="0.44" CC="0000000" TAGREFS=""/>
+            <SP HPOS="823" ID="SP_18.17.2.14" VPOS="1936" WIDTH="10"/>
+            <String CONTENT="inserting" HEIGHT="32" HPOS="833" ID="ST_18.17.2.15" STYLEREFS="Style_5" VPOS="1936" WIDTH="120" WC="0.54" CC="000000000" TAGREFS=""/>
+            <SP HPOS="953" ID="SP_18.17.2.16" VPOS="1936" WIDTH="11"/>
+            <String CONTENT="the" HEIGHT="24" HPOS="964" ID="ST_18.17.2.17" STYLEREFS="Style_5" VPOS="1936" WIDTH="42" WC="0.62" CC="000" TAGREFS=""/>
+            <SP HPOS="1006" ID="SP_18.17.2.18" VPOS="1943" WIDTH="12"/>
+            <String CONTENT="name," HEIGHT="23" HPOS="1018" ID="ST_18.17.2.19" STYLEREFS="Style_5" VPOS="1943" WIDTH="82" WC="0.31" CC="00000" TAGREFS=""/>
+            <SP HPOS="1100" ID="SP_18.17.2.20" VPOS="1935" WIDTH="12"/>
+            <String CONTENT="if" HEIGHT="24" HPOS="1112" ID="ST_18.17.2.21" STYLEREFS="Style_5" VPOS="1935" WIDTH="22" WC="0.56" CC="00" TAGREFS=""/>
+            <SP HPOS="1134" ID="SP_18.17.2.22" VPOS="1935" WIDTH="13"/>
+            <String CONTENT="the" HEIGHT="25" HPOS="1147" ID="ST_18.17.2.23" STYLEREFS="Style_5" VPOS="1935" WIDTH="43" WC="0.46" CC="000" TAGREFS=""/>
+            <SP HPOS="1190" ID="SP_18.17.2.24" VPOS="1943" WIDTH="15"/>
+            <String CONTENT="payee" HEIGHT="25" HPOS="1205" ID="ST_18.17.2.25" STYLEREFS="Style_5" VPOS="1943" WIDTH="78" WC="0.69" CC="00000" TAGREFS=""/>
+            <SP HPOS="1283" ID="SP_18.17.2.26" VPOS="1936" WIDTH="10"/>
+            <String CONTENT="be" HEIGHT="24" HPOS="1293" ID="ST_18.17.2.27" STYLEREFS="Style_5" VPOS="1936" WIDTH="30" WC="0.36" CC="00" TAGREFS=""/>
+            <SP HPOS="1323" ID="SP_18.17.2.28" VPOS="1944" WIDTH="11"/>
+            <String CONTENT="so" HEIGHT="17" HPOS="1334" ID="ST_18.17.2.29" STYLEREFS="Style_5" VPOS="1944" WIDTH="27" WC="0.79" CC="00" TAGREFS=""/>
+            <SP HPOS="1361" ID="SP_18.17.2.30" VPOS="1943" WIDTH="8"/>
+            <String CONTENT="cer-" HEIGHT="18" HPOS="1369" ID="ST_18.17.2.31" STYLEREFS="Style_5" VPOS="1943" WIDTH="49" WC="0.73" CC="0000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="33" HPOS="286" ID="TL_18.17.3" VPOS="1967" WIDTH="1130">
+            <String CONTENT="tainly" HEIGHT="31" HPOS="286" ID="ST_18.17.3.1" STYLEREFS="Style_5" VPOS="1969" WIDTH="81" WC="0.47" CC="000000" TAGREFS=""/>
+            <SP HPOS="367" ID="SP_18.17.3.2" VPOS="1968" WIDTH="11"/>
+            <String CONTENT="specified" HEIGHT="31" HPOS="378" ID="ST_18.17.3.3" STYLEREFS="Style_5" VPOS="1968" WIDTH="116" WC="0.69" CC="000000000" TAGREFS=""/>
+            <SP HPOS="494" ID="SP_18.17.3.4" VPOS="1975" WIDTH="21"/>
+            <String CONTENT="or" HEIGHT="17" HPOS="515" ID="ST_18.17.3.5" STYLEREFS="Style_5" VPOS="1975" WIDTH="27" WC="0.62" CC="00" TAGREFS=""/>
+            <SP HPOS="542" ID="SP_18.17.3.6" VPOS="1968" WIDTH="10"/>
+            <String CONTENT="referred" HEIGHT="24" HPOS="552" ID="ST_18.17.3.7" STYLEREFS="Style_5" VPOS="1968" WIDTH="105" WC="0.55" CC="00000000" TAGREFS=""/>
+            <SP HPOS="657" ID="SP_18.17.3.8" VPOS="1971" WIDTH="20"/>
+            <String CONTENT="to," HEIGHT="26" HPOS="677" ID="ST_18.17.3.9" STYLEREFS="Style_5" VPOS="1971" WIDTH="35" WC="0.78" CC="000" TAGREFS=""/>
+            <SP HPOS="712" ID="SP_18.17.3.10" VPOS="1975" WIDTH="21"/>
+            <String CONTENT="as" HEIGHT="16" HPOS="733" ID="ST_18.17.3.11" STYLEREFS="Style_5" VPOS="1975" WIDTH="26" WC="0.56" CC="00" TAGREFS=""/>
+            <SP HPOS="759" ID="SP_18.17.3.12" VPOS="1971" WIDTH="18"/>
+            <String CONTENT="to" HEIGHT="20" HPOS="777" ID="ST_18.17.3.13" STYLEREFS="Style_5" VPOS="1971" WIDTH="27" WC="0.93" CC="00" TAGREFS=""/>
+            <SP HPOS="804" ID="SP_18.17.3.14" VPOS="1968" WIDTH="16"/>
+            <String CONTENT="be" HEIGHT="24" HPOS="820" ID="ST_18.17.3.15" STYLEREFS="Style_5" VPOS="1968" WIDTH="31" WC="0.43" CC="00" TAGREFS=""/>
+            <SP HPOS="851" ID="SP_18.17.3.16" VPOS="1968" WIDTH="19"/>
+            <String CONTENT="ascertained" HEIGHT="24" HPOS="870" ID="ST_18.17.3.17" STYLEREFS="Style_5" VPOS="1968" WIDTH="153" WC="0.65" CC="00000000000" TAGREFS=""/>
+            <SP HPOS="1023" ID="SP_18.17.3.18" VPOS="1968" WIDTH="21"/>
+            <String CONTENT="by" HEIGHT="32" HPOS="1044" ID="ST_18.17.3.19" STYLEREFS="Style_5" VPOS="1968" WIDTH="34" WC="0.26" CC="00" TAGREFS=""/>
+            <SP HPOS="1078" ID="SP_18.17.3.20" VPOS="1968" WIDTH="10"/>
+            <String CONTENT="allegations" HEIGHT="32" HPOS="1088" ID="ST_18.17.3.21" STYLEREFS="Style_5" VPOS="1968" WIDTH="146" WC="0.58" CC="00000000000" TAGREFS=""/>
+            <SP HPOS="1234" ID="SP_18.17.3.22" VPOS="1967" WIDTH="23"/>
+            <String CONTENT="and" HEIGHT="25" HPOS="1257" ID="ST_18.17.3.23" STYLEREFS="Style_5" VPOS="1967" WIDTH="49" WC="0.21" CC="000" TAGREFS=""/>
+            <SP HPOS="1306" ID="SP_18.17.3.24" VPOS="1968" WIDTH="18"/>
+            <String CONTENT="proofs." HEIGHT="32" HPOS="1324" ID="ST_18.17.3.25" STYLEREFS="Style_5" VPOS="1968" WIDTH="92" WC="0.54" CC="0000000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="32" HPOS="285" ID="TL_18.17.4" VPOS="1999" WIDTH="621">
+            <String CONTENT="Adams" HEIGHT="24" HPOS="285" ID="ST_18.17.4.1" STYLEREFS="Style_7" VPOS="2000" WIDTH="95" WC="0.37" CC="00000" TAGREFS=""/>
+            <SP HPOS="380" ID="SP_18.17.4.2" VPOS="2003" WIDTH="11"/>
+            <String CONTENT="et" HEIGHT="20" HPOS="391" ID="ST_18.17.4.3" STYLEREFS="Style_7" VPOS="2003" WIDTH="21" WC="0.52" CC="00" TAGREFS=""/>
+            <SP HPOS="412" ID="SP_18.17.4.4" VPOS="1999" WIDTH="10"/>
+            <String CONTENT="al." HEIGHT="24" HPOS="422" ID="ST_18.17.4.5" STYLEREFS="Style_7" VPOS="1999" WIDTH="33" WC="0.72" CC="000" TAGREFS=""/>
+            <SP HPOS="455" ID="SP_18.17.4.6" VPOS="2008" WIDTH="12"/>
+            <String CONTENT="v." HEIGHT="15" HPOS="467" ID="ST_18.17.4.7" STYLEREFS="Style_5" VPOS="2008" WIDTH="25" WC="0.47" CC="09" TAGREFS=""/>
+            <SP HPOS="492" ID="SP_18.17.4.8" VPOS="1999" WIDTH="11"/>
+            <String CONTENT="King" HEIGHT="32" HPOS="503" ID="ST_18.17.4.9" STYLEREFS="Style_7" VPOS="1999" WIDTH="68" WC="0.47" CC="0000" TAGREFS=""/>
+            <SP HPOS="571" ID="SP_18.17.4.10" VPOS="2003" WIDTH="11"/>
+            <String CONTENT="et" HEIGHT="20" HPOS="582" ID="ST_18.17.4.11" STYLEREFS="Style_7" VPOS="2003" WIDTH="21" WC="1.00" CC="00" TAGREFS=""/>
+            <SP HPOS="603" ID="SP_18.17.4.12" VPOS="1999" WIDTH="9"/>
+            <String CONTENT="al.," HEIGHT="30" HPOS="612" ID="ST_18.17.4.13" STYLEREFS="Style_7" VPOS="1999" WIDTH="40" WC="0.56" CC="0099" TAGREFS=""/>
+            <SP HPOS="652" ID="SP_18.17.4.14" VPOS="2002" WIDTH="14"/>
+            <String CONTENT="16" HEIGHT="21" HPOS="666" ID="ST_18.17.4.15" STYLEREFS="Style_5" VPOS="2002" WIDTH="29" WC="0.63" CC="00" TAGREFS=""/>
+            <SP HPOS="695" ID="SP_18.17.4.16" VPOS="1999" WIDTH="8"/>
+            <String CONTENT="Ills." HEIGHT="24" HPOS="703" ID="ST_18.17.4.17" STYLEREFS="Style_5" VPOS="1999" WIDTH="54" WC="0.59" CC="00000" TAGREFS=""/>
+            <SP HPOS="757" ID="SP_18.17.4.18" VPOS="1999" WIDTH="9"/>
+            <String CONTENT="Rep.," HEIGHT="32" HPOS="766" ID="ST_18.17.4.19" STYLEREFS="Style_5" VPOS="1999" WIDTH="73" WC="0.50" CC="00099" TAGREFS=""/>
+            <SP HPOS="839" ID="SP_18.17.4.20" VPOS="2002" WIDTH="14"/>
+            <String CONTENT="169." HEIGHT="22" HPOS="853" ID="ST_18.17.4.21" STYLEREFS="Style_5" VPOS="2002" WIDTH="53" WC="0.70" CC="9000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+        <TextBlock HEIGHT="94.0" HPOS="286.0" ID="BL_18.18" TAGREFS="b18-18" VPOS="2032.0" WIDTH="1132.0">
+          <TextLine HEIGHT="31" HPOS="317" ID="TL_18.18.1" VPOS="2032" WIDTH="1101">
+            <String CONTENT="An" HEIGHT="23" HPOS="317" ID="ST_18.18.1.1" STYLEREFS="Style_5" VPOS="2032" WIDTH="46" WC="0.35" CC="00" TAGREFS=""/>
+            <SP HPOS="363" ID="SP_18.18.1.2" VPOS="2032" WIDTH="7"/>
+            <String CONTENT="instrument" HEIGHT="24" HPOS="370" ID="ST_18.18.1.3" STYLEREFS="Style_5" VPOS="2032" WIDTH="151" WC="0.44" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="521" ID="SP_18.18.1.4" VPOS="2032" WIDTH="18"/>
+            <String CONTENT="purporting" HEIGHT="31" HPOS="539" ID="ST_18.18.1.5" STYLEREFS="Style_5" VPOS="2032" WIDTH="147" WC="0.53" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="686" ID="SP_18.18.1.6" VPOS="2035" WIDTH="10"/>
+            <String CONTENT="to" HEIGHT="20" HPOS="696" ID="ST_18.18.1.7" STYLEREFS="Style_5" VPOS="2035" WIDTH="26" WC="0.93" CC="00" TAGREFS=""/>
+            <SP HPOS="722" ID="SP_18.18.1.8" VPOS="2032" WIDTH="11"/>
+            <String CONTENT="be" HEIGHT="23" HPOS="733" ID="ST_18.18.1.9" STYLEREFS="Style_5" VPOS="2032" WIDTH="30" WC="0.27" CC="00" TAGREFS=""/>
+            <SP HPOS="763" ID="SP_18.18.1.10" VPOS="2039" WIDTH="12"/>
+            <String CONTENT="a" HEIGHT="16" HPOS="775" ID="ST_18.18.1.11" STYLEREFS="Style_5" VPOS="2039" WIDTH="15" WC="1.00" CC="0" TAGREFS=""/>
+            <SP HPOS="790" ID="SP_18.18.1.12" VPOS="2032" WIDTH="10"/>
+            <String CONTENT="promissory" HEIGHT="31" HPOS="800" ID="ST_18.18.1.13" STYLEREFS="Style_5" VPOS="2032" WIDTH="152" WC="0.60" CC="0000000000" TAGREFS=""/>
+            <SP HPOS="952" ID="SP_18.18.1.14" VPOS="2035" WIDTH="10"/>
+            <String CONTENT="note," HEIGHT="27" HPOS="962" ID="ST_18.18.1.15" STYLEREFS="Style_5" VPOS="2035" WIDTH="65" WC="0.77" CC="00000" TAGREFS=""/>
+            <SP HPOS="1027" ID="SP_18.18.1.16" VPOS="2032" WIDTH="22"/>
+            <String CONTENT="payable" HEIGHT="31" HPOS="1049" ID="ST_18.18.1.17" STYLEREFS="Style_5" VPOS="2032" WIDTH="106" WC="0.56" CC="0000000" TAGREFS=""/>
+            <SP HPOS="1155" ID="SP_18.18.1.18" VPOS="2035" WIDTH="11"/>
+            <String CONTENT="to" HEIGHT="20" HPOS="1166" ID="ST_18.18.1.19" STYLEREFS="Style_5" VPOS="2035" WIDTH="25" WC="1.00" CC="00" TAGREFS=""/>
+            <SP HPOS="1191" ID="SP_18.18.1.20" VPOS="2039" WIDTH="14"/>
+            <String CONTENT="one" HEIGHT="16" HPOS="1205" ID="ST_18.18.1.21" STYLEREFS="Style_5" VPOS="2039" WIDTH="47" WC="0.72" CC="000" TAGREFS=""/>
+            <SP HPOS="1252" ID="SP_18.18.1.22" VPOS="2032" WIDTH="11"/>
+            <String CONTENT="of" HEIGHT="24" HPOS="1263" ID="ST_18.18.1.23" STYLEREFS="Style_5" VPOS="2032" WIDTH="28" WC="0.60" CC="00" TAGREFS=""/>
+            <SP HPOS="1291" ID="SP_18.18.1.24" VPOS="2036" WIDTH="9"/>
+            <String CONTENT="two" HEIGHT="20" HPOS="1300" ID="ST_18.18.1.25" STYLEREFS="Style_5" VPOS="2036" WIDTH="47" WC="0.52" CC="000" TAGREFS=""/>
+            <SP HPOS="1347" ID="SP_18.18.1.26" VPOS="2039" WIDTH="19"/>
+            <String CONTENT="per-" HEIGHT="23" HPOS="1366" ID="ST_18.18.1.27" STYLEREFS="Style_5" VPOS="2039" WIDTH="52" WC="0.77" CC="0000" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="37" HPOS="286" ID="TL_18.18.2" VPOS="2057" WIDTH="1130">
+            <String CONTENT="sons" HEIGHT="17" HPOS="286" ID="ST_18.18.2.1" STYLEREFS="Style_5" VPOS="2071" WIDTH="57" WC="0.52" CC="0000" TAGREFS=""/>
+            <SP HPOS="343" ID="SP_18.18.2.2" VPOS="2064" WIDTH="11"/>
+            <String CONTENT="in" HEIGHT="22" HPOS="354" ID="ST_18.18.2.3" STYLEREFS="Style_5" VPOS="2064" WIDTH="27" WC="0.49" CC="00" TAGREFS=""/>
+            <SP HPOS="381" ID="SP_18.18.2.4" VPOS="2063" WIDTH="10"/>
+            <String CONTENT="the" HEIGHT="24" HPOS="391" ID="ST_18.18.2.5" STYLEREFS="Style_5" VPOS="2063" WIDTH="42" WC="0.59" CC="000" TAGREFS=""/>
+            <SP HPOS="433" ID="SP_18.18.2.6" VPOS="2063" WIDTH="12"/>
+            <String CONTENT="alternative," HEIGHT="31" HPOS="445" ID="ST_18.18.2.7" STYLEREFS="Style_5" VPOS="2063" WIDTH="153" WC="0.69" CC="000000000000" TAGREFS=""/>
+            <SP HPOS="598" ID="SP_18.18.2.8" VPOS="2070" WIDTH="13"/>
+            <String CONTENT="can" HEIGHT="17" HPOS="611" ID="ST_18.18.2.9" STYLEREFS="Style_5" VPOS="2070" WIDTH="46" WC="0.65" CC="000" TAGREFS=""/>
+            <SP HPOS="657" ID="SP_18.18.2.10" VPOS="2067" WIDTH="10"/>
+            <String CONTENT="not" HEIGHT="20" HPOS="667" ID="ST_18.18.2.11" STYLEREFS="Style_5" VPOS="2067" WIDTH="44" WC="0.70" CC="000" TAGREFS=""/>
+            <SP HPOS="711" ID="SP_18.18.2.12" VPOS="2063" WIDTH="10"/>
+            <String CONTENT="be" HEIGHT="24" HPOS="721" ID="ST_18.18.2.13" STYLEREFS="Style_5" VPOS="2063" WIDTH="31" WC="0.41" CC="00" TAGREFS=""/>
+            <SP HPOS="752" ID="SP_18.18.2.14" VPOS="2064" WIDTH="12"/>
+            <String CONTENT="sued" HEIGHT="23" HPOS="764" ID="ST_18.18.2.15" STYLEREFS="Style_5" VPOS="2064" WIDTH="61" WC="0.55" CC="0000" TAGREFS=""/>
+            <SP HPOS="825" ID="SP_18.18.2.16" VPOS="2071" WIDTH="10"/>
+            <String CONTENT="on" HEIGHT="16" HPOS="835" ID="ST_18.18.2.17" STYLEREFS="Style_5" VPOS="2071" WIDTH="34" WC="0.60" CC="00" TAGREFS=""/>
+            <SP HPOS="869" ID="SP_18.18.2.18" VPOS="2070" WIDTH="18"/>
+            <String CONTENT="as" HEIGHT="17" HPOS="887" ID="ST_18.18.2.19" STYLEREFS="Style_5" VPOS="2070" WIDTH="27" WC="0.53" CC="00" TAGREFS=""/>
+            <SP HPOS="914" ID="SP_18.18.2.20" VPOS="2064" WIDTH="14"/>
+            <String CONTENT="such." HEIGHT="23" HPOS="928" ID="ST_18.18.2.21" STYLEREFS="Style_5" VPOS="2064" WIDTH="68" WC="0.55" CC="00000" TAGREFS=""/>
+            <SP HPOS="996" ID="SP_18.18.2.22" VPOS="2057" WIDTH="33"/>
+            <String CONTENT="Musselman" HEIGHT="30" HPOS="1029" ID="ST_18.18.2.23" STYLEREFS="Style_7" VPOS="2057" WIDTH="147" WC="0.54" CC="090000900" TAGREFS=""/>
+            <SP HPOS="1176" ID="SP_18.18.2.24" VPOS="2071" WIDTH="10"/>
+            <String CONTENT="v." HEIGHT="16" HPOS="1186" ID="ST_18.18.2.25" STYLEREFS="Style_5" VPOS="2071" WIDTH="25" WC="0.63" CC="00" TAGREFS=""/>
+            <SP HPOS="1211" ID="SP_18.18.2.26" VPOS="2062" WIDTH="13"/>
+            <String CONTENT="Oakes," HEIGHT="32" HPOS="1224" ID="ST_18.18.2.27" STYLEREFS="Style_7" VPOS="2062" WIDTH="83" WC="0.58" CC="000000" TAGREFS=""/>
+            <SP HPOS="1307" ID="SP_18.18.2.28" VPOS="2066" WIDTH="14"/>
+            <String CONTENT="19" HEIGHT="21" HPOS="1321" ID="ST_18.18.2.29" STYLEREFS="Style_5" VPOS="2066" WIDTH="28" WC="0.68" CC="99" TAGREFS=""/>
+            <SP HPOS="1349" ID="SP_18.18.2.30" VPOS="2063" WIDTH="13"/>
+            <String CONTENT="Ills." HEIGHT="25" HPOS="1362" ID="ST_18.18.2.31" STYLEREFS="Style_5" VPOS="2063" WIDTH="54" WC="0.39" CC="00009" TAGREFS=""/>
+          </TextLine>
+          <TextLine HEIGHT="30" HPOS="286" ID="TL_18.18.3" VPOS="2096" WIDTH="125">
+            <String CONTENT="Rep.," HEIGHT="30" HPOS="286" ID="ST_18.18.3.1" STYLEREFS="Style_5" VPOS="2096" WIDTH="73" WC="0.64" CC="00099" TAGREFS=""/>
+            <SP HPOS="359" ID="SP_18.18.3.2" VPOS="2097" WIDTH="13"/>
+            <String CONTENT="81." HEIGHT="22" HPOS="372" ID="ST_18.18.3.3" STYLEREFS="Style_5" VPOS="2097" WIDTH="39" WC="0.87" CC="000" TAGREFS=""/>
+          </TextLine>
+        </TextBlock>
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>


### PR DESCRIPTION
The xml md5 adventure revealed a couple of ways we're accidentally modifying xml formatting. In this pull request:

- `serialize_xml(parse_xml())` should no longer remove the final newline from the file (and in general should identical to the input).
- XML returned from postgres will have the XML declaration added back in if it's missing.
- Tests to confirm the above two things.
- Rename some test fixtures: `volume_xml` -> `ingest_volume_xml`, `case_xml` -> `ingest_case_xml`, `duplicative_case_xml` -> `ingest_duplicative_case_xml`. This differentiates the slower fixtures that import actual files on disk, from the faster ones that use factories. Added in this PR because I wanted to add a proper `volume_xml` fixture using the factory.