### PR TITLE
Add nosniff header to responses

### DIFF
--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -282,3 +282,6 @@ CELERY_RESOURCE_LIMITS = [
         'kwargs': {'max_load': 0.8},
     },
 ]
+
+# security
+SECURE_CONTENT_TYPE_NOSNIFF = True


### PR DESCRIPTION
This makes it safer to reflect user-submitted data in API responses, by adding an `x-content-type-options:nosniff` header.