### PR TITLE
option to turn off related save and tests

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -495,7 +495,7 @@ class CaseXML(BaseXMLModel):
     tracker = FieldTracker()
 
     @transaction.atomic
-    def save(self, *args, **kwargs):
+    def save(self, update_related=True, *args, **kwargs):
         # allow disabling of create_or_update_metadata for testing
         create_or_update_metadata = kwargs.pop('create_or_update_metadata', True)
 
@@ -506,7 +506,7 @@ class CaseXML(BaseXMLModel):
                 self.create_or_update_metadata(update_existing=True, save_self=False)
 
             # Update related VolumeXML and PageXML contents
-            if self.xml_modified():
+            if self.xml_modified() and update_related:
                 self.process_updated_xml()
 
         # save that ish.

--- a/capstone/scripts/ingest_by_manifest.py
+++ b/capstone/scripts/ingest_by_manifest.py
@@ -279,7 +279,7 @@ def ingest_volume(volume_folder, full_sync):
                 )
 
             if case.tracker.changed():
-                case.save()
+                case.save(update_related=False)
 
         ### import pages
 
@@ -305,7 +305,7 @@ def ingest_volume(volume_folder, full_sync):
                 )
 
             if page.tracker.changed():
-                page.save()
+                page.save(save_case=False, save_volume=False)
 
         ### cleanup
 


### PR DESCRIPTION
modified:   capdb/models.py -- can turn off saving related models and examining XML when saving cases
modified:   capdb/tests/test_models.py -- tests to make sure it really doesn't save related cases
modified:   scripts/ingest_by_manifest.py -- modified so it won't try to update related cases, etc.