### PR TITLE
Turn off related save options

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -495,7 +495,7 @@ class CaseXML(BaseXMLModel):
     tracker = FieldTracker()
 
     @transaction.atomic
-    def save(self, *args, **kwargs):
+    def save(self, update_related=True, *args, **kwargs):
         # allow disabling of create_or_update_metadata for testing
         create_or_update_metadata = kwargs.pop('create_or_update_metadata', True)
 
@@ -506,7 +506,7 @@ class CaseXML(BaseXMLModel):
                 self.create_or_update_metadata(update_existing=True, save_self=False)
 
             # Update related VolumeXML and PageXML contents
-            if self.xml_modified():
+            if self.xml_modified() and update_related:
                 self.process_updated_xml()
 
         # save that ish.

--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -129,13 +129,10 @@ def test_checksums_update_casebody_modify_word(ingest_case_xml):
 @pytest.mark.django_db
 def test_save_related_update_disabled(ingest_case_xml):
 
-    parsed_volume_xml = parse_xml(ingest_case_xml.volume.orig_xml)
     parsed_case_xml = parse_xml(ingest_case_xml.orig_xml)
     alto = ingest_case_xml.pages.get(barcode="32044057892259_00009_0")
 
     # get ALTO
-    short_alto_identifier = 'alto_00009_0'
-    short_case_identifier = 'casemets_0001'
 
     # change a word in the case XML
     updated_text = parsed_case_xml('casebody|p[id="b17-6"]').text().replace('argument', '4rgUm3nt')
@@ -147,7 +144,6 @@ def test_save_related_update_disabled(ingest_case_xml):
     # make sure the change was saved in the case_xml
     ingest_case_xml.refresh_from_db()
     parsed_case_xml = parse_xml(ingest_case_xml.orig_xml)
-    parsed_volume_xml = parse_xml(ingest_case_xml.volume.orig_xml)
     assert '4rgUm3nt' in parsed_case_xml('casebody|p[id="b17-6"]').text()
 
     # make sure the change shows up in the ALTO

--- a/capstone/scripts/ingest_by_manifest.py
+++ b/capstone/scripts/ingest_by_manifest.py
@@ -279,7 +279,7 @@ def ingest_volume(volume_folder, full_sync):
                 )
 
             if case.tracker.changed():
-                case.save()
+                case.save(update_related=False)
 
         ### import pages
 
@@ -305,7 +305,7 @@ def ingest_volume(volume_folder, full_sync):
                 )
 
             if page.tracker.changed():
-                page.save()
+                page.save(save_case=False, save_volume=False)
 
         ### cleanup
 


### PR DESCRIPTION

option to turn off related save and tests

modified:   capdb/models.py -- can turn off saving related models and examining XML when saving cases
modified:   capdb/tests/test_models.py -- tests to make sure it really doesn't save related cases
modified:   scripts/ingest_by_manifest.py -- modified so it won't try to update related cases, etc.