### PR TITLE
Auto-register test factories as fixtures [easy review]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ db.sqlite3
 
 # pytest
 .cache
+.pytest_cache
 tracking_tool.sqlite
 .coverage

--- a/capstone/capapi/tests/test_admin.py
+++ b/capstone/capapi/tests/test_admin.py
@@ -24,38 +24,38 @@ def test_admin_user_create(admin_client):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_admin_user_authenticate(admin_client, user):
+def test_admin_user_authenticate(admin_client, api_user):
     """
     Test if we can authenticate user through the admin panel
     """
     data = {
         'action': 'authenticate_user',
-        '_selected_action': user.id,
+        '_selected_action': api_user.id,
     }
     response = admin_client.post('/admin/capapi/apiuser/', data, follow=True)
-    user.refresh_from_db()
+    api_user.refresh_from_db()
 
     assert response.status_code == 200
-    assert user.is_authenticated
-    assert user.get_api_key()
+    assert api_user.is_authenticated
+    assert api_user.get_api_key()
 
 
 @pytest.mark.django_db(transaction=True)
-def test_admin_user_authenticate_without_key_expires(admin_client, user):
+def test_admin_user_authenticate_without_key_expires(admin_client, api_user):
     """
     Test if we can authenticate even if key_expires is missing
     """
-    user.key_expires = None
-    user.save()
+    api_user.key_expires = None
+    api_user.save()
     data = {
         'action': 'authenticate_user',
-        '_selected_action': user.id,
+        '_selected_action': api_user.id,
     }
     response = admin_client.post('/admin/capapi/apiuser/', data, follow=True)
-    user.refresh_from_db()
+    api_user.refresh_from_db()
 
     assert response.status_code == 200
-    assert user.is_authenticated
-    assert user.get_api_key()
+    assert api_user.is_authenticated
+    assert api_user.get_api_key()
 
 

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -134,14 +134,14 @@ def test_max_number_case_download(auth_user, api_url, auth_client):
 
 
 @pytest.mark.django_db(transaction=True)
-def test_unauthorized_download(user, api_url, auth_client, case):
-    assert user.case_allowance_remaining == settings.API_CASE_DAILY_ALLOWANCE
+def test_unauthorized_download(api_user, api_url, auth_client, case):
+    assert api_user.case_allowance_remaining == settings.API_CASE_DAILY_ALLOWANCE
     url = "%scases/%s/?type=download" % (api_url, case.slug)
     response = auth_client.get(url, headers={'AUTHORIZATION': 'Token fake'})
     check_response(response, status_code=401, format='')
 
-    user.refresh_from_db()
-    assert user.case_allowance_remaining == settings.API_CASE_DAILY_ALLOWANCE
+    api_user.refresh_from_db()
+    assert api_user.case_allowance_remaining == settings.API_CASE_DAILY_ALLOWANCE
 
 
 @pytest.mark.django_db(transaction=True)

--- a/capstone/capapi/tests/test_models.py
+++ b/capstone/capapi/tests/test_models.py
@@ -8,30 +8,30 @@ from capapi.models import APIToken
 
 
 @pytest.mark.django_db
-def test_default_case_allowance(user):
-    assert user.total_case_allowance == settings.API_CASE_DAILY_ALLOWANCE - 0
-    user.save()
-    user.update_case_allowance(case_count=10)
-    assert user.case_allowance_remaining == settings.API_CASE_DAILY_ALLOWANCE - 10
+def test_default_case_allowance(api_user):
+    assert api_user.total_case_allowance == settings.API_CASE_DAILY_ALLOWANCE - 0
+    api_user.save()
+    api_user.update_case_allowance(case_count=10)
+    assert api_user.case_allowance_remaining == settings.API_CASE_DAILY_ALLOWANCE - 10
 
 @pytest.mark.django_db
-def test_custom_case_allowance(user):
-    user.total_case_allowance = 1000
-    user.case_allowance_remaining = 0
-    user.save()
+def test_custom_case_allowance(api_user):
+    api_user.total_case_allowance = 1000
+    api_user.case_allowance_remaining = 0
+    api_user.save()
     # set last_updated to yesterday
-    user.case_allowance_last_updated = timezone.now() - timedelta(days=1)
-    user.save()
-    user.update_case_allowance()
-    assert user.case_allowance_remaining == user.total_case_allowance
+    api_user.case_allowance_last_updated = timezone.now() - timedelta(days=1)
+    api_user.save()
+    api_user.update_case_allowance()
+    assert api_user.case_allowance_remaining == api_user.total_case_allowance
 
 @pytest.mark.django_db
-def test_authenticate_user(user):
-    user.activation_nonce = '123'
-    user.save()
-    assert user.get_api_key() is None
-    user.authenticate_user(activation_nonce=user.activation_nonce)
-    assert user.get_api_key() is not None
-    assert APIToken.objects.get(user=user)
+def test_authenticate_api_user(api_user):
+    api_user.activation_nonce = '123'
+    api_user.save()
+    assert api_user.get_api_key() is None
+    api_user.authenticate_user(activation_nonce=api_user.activation_nonce)
+    assert api_user.get_api_key() is not None
+    assert APIToken.objects.get(user=api_user)
 
 

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -39,6 +39,7 @@ pytest-redis        # redisdb fixture
 moto                # mocking s3 access
 flake8              # linting
 factory-boy         # mocking
+pytest-factoryboy   # inject factory-boy factories into pytest fixtures
 
 # API
 beautifulsoup4

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -8,6 +8,7 @@
 amqp==2.2.2               # via kombu
 apipkg==1.4               # via execnet
 asn1crypto==0.22.0        # via cryptography
+attrs==17.4.0             # via pytest
 beautifulsoup4==4.6.0
 billiard==3.5.0.3         # via celery
 boto3==1.4.4
@@ -37,12 +38,13 @@ djangorestframework==3.7.7
 docutils==0.13.1          # via botocore
 execnet==1.4.1            # via pytest-xdist
 fabric3==1.13.1.post1
-factory-boy==2.9.2
+factory-boy==2.10.0
 faker==0.8.4              # via factory-boy
 first==2.0.1              # via pip-tools
 flake8==3.4.1
 futures==3.1.1            # via django-pipeline
 idna==2.5                 # via cryptography, requests
+inflection==0.3.1         # via pytest-factoryboy
 jinja2==2.9.6             # via moto
 jmespath==0.9.2           # via boto3, botocore
 kombu==4.1.0              # via celery
@@ -56,10 +58,11 @@ mysqlclient==1.3.10
 packaging==16.8           # via cryptography
 paramiko==2.1.2           # via fabric3
 pip-tools==1.11.0
+pluggy==0.6.0             # via pytest
 port-for==0.4             # via pytest-redis
 psutil==5.4.0             # via mirakuru
 psycopg2==2.7.1
-py==1.4.33                # via pytest, pytest-xdist
+py==1.5.2                 # via pytest, pytest-xdist
 pyaml==16.12.2            # via moto
 pyasn1==0.2.3             # via paramiko
 pycodestyle==2.3.1        # via flake8
@@ -70,9 +73,10 @@ pyparsing==2.2.0          # via packaging
 pyquery==1.2.17
 pytest-cov==2.5.1
 pytest-django==3.1.2
+pytest-factoryboy==2.0.1
 pytest-redis==1.3.2
 pytest-xdist==1.16.0
-pytest==3.1.0             # via pytest-cov, pytest-django, pytest-redis, pytest-xdist
+pytest==3.4.2             # via pytest-cov, pytest-django, pytest-factoryboy, pytest-redis, pytest-xdist
 python-dateutil==2.6.0    # via botocore, faker, moto
 pytz==2017.2              # via celery, django, moto
 pyyaml==3.12              # via pyaml
@@ -81,7 +85,7 @@ redis==2.10.6
 requests==2.16.4          # via moto
 rjsmin==1.0.12            # via django-compressor
 s3transfer==0.1.10        # via boto3
-six==1.10.0               # via cryptography, django-extensions, fabric3, faker, libsass, moto, packaging, pip-tools, python-dateutil
+six==1.10.0               # via cryptography, django-extensions, fabric3, faker, libsass, moto, packaging, pip-tools, pytest, python-dateutil
 tqdm==4.11.2
 urllib3==1.21.1           # via requests
 vine==1.1.4               # via amqp

--- a/capstone/test_data/test_fixtures/factories.py
+++ b/capstone/test_data/test_fixtures/factories.py
@@ -1,7 +1,7 @@
 import random
 import factory
+from pytest_factoryboy import register
 
-from django.utils import timezone
 from django.template.defaultfilters import slugify
 
 from capapi.models import *
@@ -25,46 +25,12 @@ def setup_case(**kwargs):
     return case
 
 
-def setup_casexml(**kwargs):
-    return CaseXMLFactory(**kwargs)
+### factories ###
 
+# Calling @pytest_factoryboy.register on each factory exposes it as a pytest fixture.
+# For example, APIUserFactory will be available as the fixture "api_user".
 
-def setup_jurisdiction(**kwargs):
-    return JurisdictionFactory(**kwargs)
-
-
-def setup_authenticated_user(**kwargs):
-    user = APIUserFactory.create(**kwargs)
-    token = APITokenFactory.build(user=user)
-    token.save()
-    return user
-
-
-def setup_user(**kwargs):
-    return APIUserFactory.create(**kwargs)
-
-
-def setup_court(**kwargs):
-    return CourtFactory(**kwargs)
-
-
-def setup_reporter(**kwargs):
-    return ReporterFactory(**kwargs)
-
-
-def setup_volume(**kwargs):
-    return VolumeMetadataFactory(**kwargs)
-
-
-def setup_volumexml(**kwargs):
-    return VolumeXMLFactory(**kwargs)
-
-
-def setup_citations(**kwargs):
-    return CitationFactory(**kwargs)
-
-
-#   factories
+@register
 class APIUserFactory(factory.DjangoModelFactory):
     class Meta:
         model = APIUser
@@ -80,15 +46,18 @@ class APIUserFactory(factory.DjangoModelFactory):
     key_expires = timezone.now() + timedelta(hours=24)
     activation_nonce = factory.Sequence(lambda n: '%08d' % n)
 
+
+@register
 class APITokenFactory(factory.DjangoModelFactory):
     class Meta:
         model = APIToken
 
     user = factory.SubFactory(APIUserFactory)
-    key = binascii.hexlify(os.urandom(20)).decode()
+    key = factory.Sequence(lambda n: binascii.hexlify(os.urandom(20)).decode())
     created = timezone.now()
 
 
+@register
 class TrackingToolUserFactory(factory.DjangoModelFactory):
     class Meta:
         model = TrackingToolUser
@@ -99,6 +68,7 @@ class TrackingToolUserFactory(factory.DjangoModelFactory):
     updated_at = timezone.now()
 
 
+@register
 class JurisdictionFactory(factory.DjangoModelFactory):
     class Meta:
         model = Jurisdiction
@@ -107,6 +77,8 @@ class JurisdictionFactory(factory.DjangoModelFactory):
     name_long = factory.Faker('sentence', nb_words=4)
     slug = factory.Sequence(lambda n: '%08d' % n)
 
+
+@register
 class ReporterFactory(factory.DjangoModelFactory):
     class Meta:
         model = Reporter
@@ -120,6 +92,7 @@ class ReporterFactory(factory.DjangoModelFactory):
     jurisdiction = factory.RelatedFactory(JurisdictionFactory)
 
 
+@register
 class VolumeMetadataFactory(factory.DjangoModelFactory):
     class Meta:
         model = VolumeMetadata
@@ -128,6 +101,7 @@ class VolumeMetadataFactory(factory.DjangoModelFactory):
     reporter = factory.SubFactory(ReporterFactory)
 
 
+@register
 class VolumeXMLFactory(factory.DjangoModelFactory):
     class Meta:
         model = VolumeXML
@@ -135,6 +109,7 @@ class VolumeXMLFactory(factory.DjangoModelFactory):
     metadata = factory.SubFactory(VolumeMetadataFactory)
 
 
+@register
 class CitationFactory(factory.DjangoModelFactory):
     class Meta:
         model = Citation
@@ -146,6 +121,7 @@ class CitationFactory(factory.DjangoModelFactory):
     cite = factory.Faker('sentence', nb_words=5)
 
 
+@register
 class CourtFactory(factory.DjangoModelFactory):
     class Meta:
         model = Court
@@ -155,6 +131,7 @@ class CourtFactory(factory.DjangoModelFactory):
     jurisdiction = factory.SubFactory(JurisdictionFactory)
 
 
+@register
 class CaseMetadataFactory(factory.DjangoModelFactory):
     class Meta:
         model = CaseMetadata
@@ -170,22 +147,11 @@ class CaseMetadataFactory(factory.DjangoModelFactory):
     volume = factory.SubFactory(VolumeMetadataFactory)
     reporter = factory.SubFactory(ReporterFactory)
 
+
+@register
 class CaseXMLFactory(factory.DjangoModelFactory):
     class Meta:
         model = CaseXML
 
     orig_xml = xml_str
     volume = factory.SubFactory(VolumeXMLFactory)
-
-
-class ReporterFactory(factory.DjangoModelFactory):
-    class Meta:
-        model = Reporter
-
-    full_name = factory.Faker('sentence', nb_words=5)
-    short_name = factory.Faker('sentence', nb_words=3)
-    start_year = timezone.now().timestamp()
-    created_at = timezone.now()
-    updated_at = timezone.now()
-    hollis = []
-    jurisdiction = factory.RelatedFactory(JurisdictionFactory)

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -7,10 +7,9 @@ from django.core.management import call_command
 from rest_framework.test import RequestsClient, APIRequestFactory
 
 import fabfile
-from capdb.models import VolumeXML, CaseXML, Jurisdiction, Court
 import capdb.storages
 
-from . import factories
+from .factories import *
 
 ### One-time database setup ###
 
@@ -49,32 +48,14 @@ def load_tracking_tool_database():
 ### Factory fixtures ###
 
 @pytest.fixture
-def user():
-    return factories.setup_user()
-
-@pytest.fixture
-def auth_user():
-    return factories.setup_authenticated_user()
-
-@pytest.fixture
-def volume_xml():
-    return factories.VolumeXMLFactory()
+def auth_user(api_token):
+    user = APIUserFactory()
+    token = APITokenFactory(user=user)
+    return user
 
 @pytest.fixture
 def case():
-    return factories.setup_case()
-
-@pytest.fixture
-def jurisdiction():
-    return factories.setup_jurisdiction()
-
-@pytest.fixture
-def court():
-    return factories.setup_court()
-
-@pytest.fixture
-def reporter():
-    return factories.setup_reporter()
+    return setup_case()
 
 @pytest.fixture
 def client():


### PR DESCRIPTION
This doesn't touch code, just tests. The idea is to add `pytest-factoryboy` so you can register factories like this:

```
@register
class APIUserFactory(factory.DjangoModelFactory):
```

And then the factory automatically become available to tests:

```
def test_foo(api_user):
    api_user.whatever()
```

Which allows us to delete a bunch of boilerplate from factories.py and fixtures.py.