### PR TITLE
Add django-debug-toolbar as optional dev tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,14 @@ Running Command Line Scripts
 Command line scripts are defined in `fabfile.py`. You can list all available commands using `fab -l`, and run a
 command with `fab command_name`.
 
+Local debugging tools
+---------------------
+
+[django-extensions](https://github.com/django-extensions/django-extensions) is enabled by default, including the very
+handy `./manage.py shell_plus` command.
+
+[django-debug-toolbar](https://django-debug-toolbar.readthedocs.io/en/stable/) is not automatically enabled, but if you
+run `pip install django-debug-toolbar` it will be detected and enabled by `settings_dev.py`.
 
 Download real data locally 
 --------------------------

--- a/capstone/config/settings/__init__.py
+++ b/capstone/config/settings/__init__.py
@@ -4,7 +4,7 @@
 # If it doesn't exist we assume this is a vanilla development environment and import .deployments.settings_dev.
 try:
     from .settings import *  # noqa
-except ModuleNotFoundError as e:
+except ImportError as e:
     if e.msg == "No module named 'config.settings.settings'":
         from .settings_dev import *  # noqa
     else:

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -40,3 +40,16 @@ if DEBUG_SQL:
         'level': 'DEBUG',
         'handlers': ['sql']
     }
+
+# django-debug-toolbar
+try:
+    import debug_toolbar  # noqa
+    INSTALLED_APPS += (
+        'debug_toolbar',
+    )
+    MIDDLEWARE = [
+        'debug_toolbar.middleware.DebugToolbarMiddleware',
+    ] + MIDDLEWARE
+    INTERNAL_IPS = ['127.0.0.1']
+except ImportError:
+    pass

--- a/capstone/config/urls.py
+++ b/capstone/config/urls.py
@@ -13,6 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
+from django.conf import settings
 from django.conf.urls import url, include
 from django.contrib import admin
 
@@ -21,3 +22,11 @@ urlpatterns = [
     url(r'^', include('capdb.urls')),
     url(r'^', include('capapi.urls')),
 ]
+
+# use django-debug-toolbar if installed
+if settings.DEBUG:
+    try:
+        import debug_toolbar
+        urlpatterns += [url(r'^__debug__/', include(debug_toolbar.urls))]
+    except ImportError:
+        pass


### PR DESCRIPTION
This adds support for django-debug-toolbar, if a developer chooses to install it locally. I just used it to figure out a template issue so thought I'd throw in support. I've found it in the past to be handy, but also to cause weird issues with other middleware when something goes wrong, so I'm keeping it as an opt-in thing.