### PR TITLE
Include fabfile in test coverage report

### DIFF
--- a/capstone/setup.cfg
+++ b/capstone/setup.cfg
@@ -23,6 +23,4 @@ omit =
     */tests.py
     */tests/*
     manage.py
-    fabfile.py
-    fabfile/*
     */settings/*


### PR DESCRIPTION
Ben noticed that we're leaving fabfile.py out of our test coverage number, which doesn't make sense since it's mostly stuff we run in production. Let's include it.