### PR TITLE
First cut at showing slow queries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ cache:
 before_install:
   - cd capstone
   - cp config/settings/settings_travis.py config/settings/settings.py
-  - sudo echo shared_preload_libraries = 'pg_stat_statements' >> /etc/postgresql/9.6/main/postgresql.conf
+  - sudo sh -c "echo shared_preload_libraries = 'pg_stat_statements' >> /etc/postgresql/9.6/main/postgresql.conf"
   - sudo /etc/init.d/postgresql restart
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   - cp config/settings/settings_travis.py config/settings/settings.py
   - sudo sh -c "echo shared_preload_libraries = 'pg_stat_statements' >> /etc/postgresql/9.6/main/postgresql.conf"
   - sudo /etc/init.d/postgresql restart
+  - sudo rm -f /etc/boto.cfg
 
 install:
   - pip install -U pip wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ cache:
 before_install:
   - cd capstone
   - cp config/settings/settings_travis.py config/settings/settings.py
+  - echo "shared_preload_libraries = 'pg_stat_statements'" >> /etc/postgresql/9.6/main/postgresql.conf
+  - /etc/init.d/postgresql restart
 
 install:
   - pip install -U pip wheel

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ cache:
 before_install:
   - cd capstone
   - cp config/settings/settings_travis.py config/settings/settings.py
-  - echo "shared_preload_libraries = 'pg_stat_statements'" >> /etc/postgresql/9.6/main/postgresql.conf
-  - /etc/init.d/postgresql restart
+  - sudo echo shared_preload_libraries = 'pg_stat_statements' >> /etc/postgresql/9.6/main/postgresql.conf
+  - sudo /etc/init.d/postgresql restart
 
 install:
   - pip install -U pip wheel

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -3,6 +3,8 @@ import bagit
 import zipfile
 import os
 import gzip
+from django.db import connection
+import json
 
 from capdb.models import CaseMetadata
 from capdb.tasks import create_case_metadata_from_all_vols
@@ -59,3 +61,12 @@ def test_write_inventory_files(tmpdir):
                 continue
             file_path = os.path.join(dir_name, file_path)
             assert file_path[len('test_data/'):] in contents
+
+@pytest.mark.django_db
+def test_show_slow_queries(capsys):
+    cursor = connection.cursor()
+    cursor.execute("create extension if not exists pg_stat_statements;")
+    fabfile.show_slow_queries()
+    captured = capsys.readouterr()
+    output = json.loads(captured.out)
+    assert "*capstone slow query report*" in output['text']

--- a/services/postgres/s1_pg_stat_statements_top_total.sql
+++ b/services/postgres/s1_pg_stat_statements_top_total.sql
@@ -1,0 +1,45 @@
+-- from https://github.com/NikolayS/postgres_dba/blob/3636d3df37e1b01790717e2a58e8bbf925bd7f78/sql/s1_pg_stat_statements_top_total.sql
+--
+--Slowest Queries, by Total Time (requires pg_stat_statements extension)
+
+-- In pg_stat_statements, there is a problem: sometimes (quite often), it registers the same query twice (or even more).
+-- It's easy to check in your DB: 
+--
+--   with heh as (
+--     select userid, dbid, query, count(*), array_agg(queryid) queryids
+--     from pg_stat_statements group by 1, 2, 3 having count(*) > 1
+--  ) select left(query, 85) || '...', userid, dbid, count, queryids from heh;
+--
+-- This query gives you "full picture", aggregating stats for each query-database-username ternary
+
+-- Works with Postgres 9.6
+
+select
+  sum(calls) as calls,
+  sum(total_time) as total_time,
+  sum(mean_time * calls) / sum(calls) as mean_time,
+  max(max_time) as max_time,
+  min(min_time) as min_time,
+  -- stddev_time, -- https://stats.stackexchange.com/questions/55999/is-it-possible-to-find-the-combined-standard-deviation
+  sum(rows) as rows,
+  (select usename from pg_user where usesysid = userid) as usr,
+  (select datname from pg_database where oid = dbid) as db,
+  query,
+  sum(shared_blks_hit) as shared_blks_hit,
+  sum(shared_blks_read) as shared_blks_read,
+  sum(shared_blks_dirtied) as shared_blks_dirtied,
+  sum(shared_blks_written) as shared_blks_written,
+  sum(local_blks_hit) as local_blks_hit,
+  sum(local_blks_read) as local_blks_read,
+  sum(local_blks_dirtied) as local_blks_dirtied,
+  sum(local_blks_written) as local_blks_written,
+  sum(temp_blks_read) as temp_blks_read,
+  sum(temp_blks_written) as temp_blks_written,
+  sum(blk_read_time) as blk_read_time,
+  sum(blk_write_time) as blk_write_time,
+  array_agg(queryid) as queryids -- 9.4+
+from pg_stat_statements
+group by userid, dbid, query
+order by sum(total_time) desc
+limit 5;
+


### PR DESCRIPTION
I'm intending to use this like so:

    fab show_slow_queries | curl -X POST -H 'Content-type: application/json' -d @- https://hooks.slack.com/...

The query just gets the top five by time at the moment, but I suppose we could pass that as a parameter. We could run `pg_stat_statements_reset()` at the end of the task, or rely on the default value of `pg_stat_statements.max` (5000) to roll over from day to day, or change the value.