### PR TITLE
Skip test_show_slow_queries if pg_stat_statements is not present

### DIFF
--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -3,7 +3,7 @@ import bagit
 import zipfile
 import os
 import gzip
-from django.db import connection
+from django.db import connection, utils
 import json
 
 from capdb.models import CaseMetadata
@@ -65,8 +65,11 @@ def test_write_inventory_files(tmpdir):
 @pytest.mark.django_db
 def test_show_slow_queries(capsys):
     cursor = connection.cursor()
-    cursor.execute("create extension if not exists pg_stat_statements;")
-    fabfile.show_slow_queries()
-    captured = capsys.readouterr()
-    output = json.loads(captured.out)
-    assert "*capstone slow query report*" in output['text']
+    try:
+        cursor.execute("create extension if not exists pg_stat_statements;")
+        fabfile.show_slow_queries()
+        captured = capsys.readouterr()
+        output = json.loads(captured.out)
+        assert "*capstone slow query report*" in output['text']
+    except utils.OperationalError:
+        pytest.skip("pg_stat_statements is not in shared_preload_libraries")


### PR DESCRIPTION
To run this test, you need `shared_preload_libraries = 'pg_stat_statements'` in `postgresql.conf`. I considered conditioning it on OS with an annotation like this:

    import sys
    ...
    @pytest.mark.skipif(sys.platform == 'darwin', reason="we don't assume devs have pg_stat_statements in shared_preload_libraries")

but thought that the try-except was more flexible.