### PR TITLE
Optimize queries and avoid race condition for case allowance

### DIFF
--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -11,6 +11,7 @@ from django.db import IntegrityError, models
 from django.utils import timezone
 
 from django.conf import settings
+from model_utils import FieldTracker
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,7 @@ class APIUser(AbstractBaseUser):
     USERNAME_FIELD = 'email'
 
     objects = APIUserManager()
+    tracker = FieldTracker()
 
     class Meta:
         verbose_name = 'User'

--- a/capstone/capapi/permissions.py
+++ b/capstone/capapi/permissions.py
@@ -46,7 +46,7 @@ def get_single_casebody_permissions(request, case):
     else:
 
         try:
-            request.user.update_case_allowance(case_count=1)
+            request.user.update_case_allowance(case_count=1, save=False)
             casebody["status"] = casebody_permissions[0]
         except AttributeError:
             casebody["status"] = casebody_permissions[2]

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -1,7 +1,9 @@
 import re
 import logging
 
+from django.db import transaction
 from rest_framework import serializers
+from rest_framework.serializers import ListSerializer
 
 from capdb import models
 from .models import APIUser
@@ -76,8 +78,54 @@ class CaseSerializer(serializers.HyperlinkedModelSerializer):
         )
 
 
-class CaseSerializerWithCasebody(CaseSerializer):
+class CaseAllowanceMixin:
+    """
+        When we serialize case bodies for delivery to the client, we need to make sure, in a race-condition-free
+        way, that the correct case allowance is checked and updated. That's handled here by overriding
+        serializer.data.
+
+        Do this as a mixin because we have to apply it to the regular serializer and also the list serializer.
+    """
+    @property
+    def data(self):
+        request = self.context.get('request')
+
+        if request.user.is_anonymous:
+            # logged out users won't get any blacklisted case bodies, so nothing to update
+            return super().data
+
+        with transaction.atomic(using='capapi'):
+            # for logged-in users, fetch the current user data here inside a transaction, using select_for_update
+            # to lock the row so we don't collide with any simultaneous requests
+            user = request.user.__class__.objects.select_for_update().get(pk=request.user.pk)
+
+            # update the info for the existing user model, in case it's changed since the request began
+            request.user.case_allowance_remaining = user.case_allowance_remaining
+            request.user.case_allowance_last_updated = user.case_allowance_last_updated
+
+            result = super().data
+
+            # if user's case allowance was updated, save
+            # (this works because it's part of the same transaction with the select_for_update --
+            # we don't have to use the same object)
+            if request.user.tracker.changed():
+                request.user.save()
+
+            return result
+
+
+class ListSerializerWithCaseAllowance(CaseAllowanceMixin, ListSerializer):
+    """ Custom ListSerializer for CaseSerializerWithCasebody that enforces CaseAllowance. """
+    pass
+
+
+class CaseSerializerWithCasebody(CaseAllowanceMixin, CaseSerializer):
     casebody = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CaseSerializer.Meta.model
+        fields = CaseSerializer.Meta.fields + ('casebody',)
+        list_serializer_class = ListSerializerWithCaseAllowance
 
     def get_casebody(self, case):
         request = self.context.get('request')
@@ -103,10 +151,6 @@ class CaseSerializerWithCasebody(CaseSerializer):
             # send text to everyone else
             casebody["data"] = helpers.extract_casebody(orig_xml).text()
         return casebody
-
-    class Meta:
-        model = CaseSerializer.Meta.model
-        fields = CaseSerializer.Meta.fields + ('casebody',)
 
 
 class VolumeSerializer(serializers.ModelSerializer):

--- a/capstone/capapi/tests/test_serializers.py
+++ b/capstone/capapi/tests/test_serializers.py
@@ -4,11 +4,10 @@ import pytest
 from rest_framework.request import Request
 
 from capapi import serializers
-from test_data.test_fixtures.factories import setup_case
 
 
 @pytest.mark.django_db(transaction=True)
-def test_CaseSerializerWithCasebody(api_url, api_request_factory, auth_client, case):
+def test_CaseSerializerWithCasebody(api_url, api_request_factory, case, three_cases):
     # can get single case data
     url = os.path.join(api_url, "cases")
     request = api_request_factory.get(url)
@@ -18,12 +17,7 @@ def test_CaseSerializerWithCasebody(api_url, api_request_factory, auth_client, c
     assert 'casebody' in serialized.data.keys()
 
     # can get multiple cases' data
-    cases = []
-    for c in range(0, 3):
-        case = setup_case()
-        cases.append(case)
-
-    serialized = serializers.CaseSerializerWithCasebody(cases, many=True, context=serializer_context)
+    serialized = serializers.CaseSerializerWithCasebody(three_cases, many=True, context=serializer_context)
     assert len(serialized.data) == 3
     for case in serialized.data:
         assert 'casebody' in case.keys()

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -33,7 +33,7 @@ django-compressor==2.1.1  # via django-libsass
 django-extensions==1.8.1
 django-filter==1.1.0
 django-libsass==0.7
-django-pipeline==1.6.13
+django-pipeline==1.6.14
 django-storages==1.5.2
 django==2.0.2
 djangorestframework-filters==0.10.2
@@ -45,7 +45,6 @@ factory-boy==2.10.0
 faker==0.8.4              # via factory-boy
 first==2.0.1              # via pip-tools
 flake8==3.4.1
-futures==3.1.1            # via django-pipeline
 idna==2.5                 # via cryptography, requests
 inflection==0.3.1         # via pytest-factoryboy
 jinja2==2.9.6             # via moto

--- a/capstone/scripts/process_metadata.py
+++ b/capstone/scripts/process_metadata.py
@@ -39,7 +39,7 @@ def get_case_metadata(case_xml):
     last_page = parsed('casebody|casebody').attr.lastpage
 
     decision_date_original = parsed('case|decisiondate').text()
-    decision_date = decision_datetime(decision_date_original)
+    decision_date = parse_decision_date(decision_date_original)
 
     docket_number = parsed('case|docketnumber').text()
 
@@ -81,10 +81,10 @@ def get_case_metadata(case_xml):
     })
 
 
-def decision_datetime(decision_date_text):
+def parse_decision_date(decision_date_text):
     try:
         try:
-            return datetime.strptime(decision_date_text, '%Y-%m-%d')
+            return datetime.strptime(decision_date_text, '%Y-%m-%d').date()
         except ValueError as e:
 
             # if court used an invalid day of month (typically Feb. 29), strip day from date
@@ -92,9 +92,9 @@ def decision_datetime(decision_date_text):
                 decision_date_text = decision_date_text.rsplit('-', 1)[0]
 
             try:
-                return datetime.strptime(decision_date_text, '%Y-%m')
+                return datetime.strptime(decision_date_text, '%Y-%m').date()
             except ValueError:
-                return datetime.strptime(decision_date_text, '%Y')
+                return datetime.strptime(decision_date_text, '%Y').date()
     except Exception as e:
         # if for some reason we can't parse the date, just store None
         return None

--- a/capstone/scripts/tests/test_process_metadata.py
+++ b/capstone/scripts/tests/test_process_metadata.py
@@ -15,7 +15,7 @@ def test_get_single_case_metadata(ingest_case_xml):
     parties = case["parties"]
     assert "John Kirk" in parties[0]
 
-    assert type(case['decision_date']) is datetime.datetime
+    assert type(case['decision_date']) is datetime.date
     assert type(case['decision_date_original']) is str
 
     assert case['jurisdiction'] == 'Illinois'
@@ -32,7 +32,7 @@ def test_get_case_metadata():
                 if not case_metadata['duplicative']:
                     assert len(case_metadata["name"]) > 0
                     assert len(case_metadata["jurisdiction"]) > 0
-                    assert type(case_metadata["decision_date"]) is datetime.datetime
+                    assert type(case_metadata["decision_date"]) is datetime.date
                     assert type(case_metadata["decision_date_original"]) is str
                     assert type(case_metadata["opinions"]) is dict
                     assert type(case_metadata["attorneys"]) is list

--- a/capstone/test_data/test_fixtures/factories.py
+++ b/capstone/test_data/test_fixtures/factories.py
@@ -15,22 +15,6 @@ from capdb.models import *
 # Calling @pytest_factoryboy.register on each factory exposes it as a pytest fixture.
 # For example, APIUserFactory will be available as the fixture "api_user".
 
-
-def setup_case(**kwargs):
-    # set up casemetadata instance
-    case = CaseFactory(**kwargs)
-    citation = CitationFactory(type='official')
-    citation.case = case
-    citation.save()
-
-    # Add VolumeXML and CaseXML instances
-    volume_xml = VolumeXMLFactory(metadata=case.volume)
-    casexml = CaseXMLFactory.build(metadata=case, volume=volume_xml)
-    casexml.save(create_or_update_metadata=False)
-
-    return case
-
-
 @register
 class APIUserFactory(factory.DjangoModelFactory):
     class Meta:

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -107,8 +107,12 @@ def load_tracking_tool_database():
 
 ### Factory fixtures ###
 @pytest.fixture
-def case():
-    return setup_case()
+def case(case_xml):
+    return case_xml.metadata
+
+@pytest.fixture
+def three_cases():
+    return [CaseXMLFactory().metadata for _ in range(3)]
 
 @pytest.fixture
 def auth_user(api_token):


### PR DESCRIPTION
- Change the case allowance tracking to issue a single save to update case allowance after serializing all blacklisted case bodies. 
- Run in a transaction to avoid race conditions.
- Add test to check case allowance when downloading multiple cases.

This was a little trickier than I hoped because DRF uses some trickiness to generate a `ListSerializer` when serializing more than one object for the list view. So we have to do the `def data` override as a mixin and apply it to a custom `ListSerializer` as well as to the `CaseSerializerWithCasebody`.