### PR TITLE
Remove separate capapi db

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ the `capstone` virtualenv activated.
 Set up a postgres database:
 
     (capstone)$ psql -c "CREATE DATABASE capstone;"
-    (capstone)$ psql -c "CREATE DATABASE capapi;"
     (capstone)$ fab init_db  # one time -- set up database tables and development Django admin user, migrate databases
     (capstone)$ fab load_test_data  # load in our test data
 
@@ -67,7 +66,6 @@ We have initial support for local development via `docker compose`. Docker setup
 
     $ docker-compose up &
     $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capstone;"
-    $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capapi;"
     $ docker-compose exec web fab init_db
     $ docker-compose exec web fab load_test_data
     

--- a/capstone/capapi/routers.py
+++ b/capstone/capapi/routers.py
@@ -1,6 +1,0 @@
-from config.routers import SeparateDatabaseRouter
-
-
-class CAPAPIRouter(SeparateDatabaseRouter):
-    db_name = 'capapi'
-    app_label = 'capapi'

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -94,7 +94,7 @@ class CaseAllowanceMixin:
             # logged out users won't get any blacklisted case bodies, so nothing to update
             return super().data
 
-        with transaction.atomic(using='capapi'):
+        with transaction.atomic():
             # for logged-in users, fetch the current user data here inside a transaction, using select_for_update
             # to lock the row so we don't collide with any simultaneous requests
             user = request.user.__class__.objects.select_for_update().get(pk=request.user.pk)

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -197,7 +197,7 @@ def test_authenticated_multiple_full_cases(auth_user, api_url, auth_client, thre
         extra_case.save()
 
     url = "%scases/?full_case=true" % (api_url)
-    with django_assert_num_queries(select=5):
+    with django_assert_num_queries(select=8, update=1):
         response = auth_client.get(url, headers={'AUTHORIZATION': 'Token {}'.format(auth_user.get_api_key())})
     check_response(response, format='')
     assert response.headers['Content-Type'] == 'text/html; charset=utf-8'
@@ -316,7 +316,7 @@ def test_reporter(api_url, client, reporter):
 
 
 #  | User views
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 def test_view_details(auth_user, auth_client):
     """
     User is able to log in successfully and see an API Token

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -94,14 +94,6 @@ DATABASES = {
         'HOST': 'localhost',
         'PORT': '',
     },
-    'capapi': {
-        'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'capapi',
-        'USER': 'postgres',
-        'PASSWORD': '',
-        'HOST': 'localhost',
-        'PORT': '',
-    },
     'tracking_tool': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': os.path.join(BASE_DIR, 'test_data/tracking_tool.sqlite'),
@@ -110,7 +102,6 @@ DATABASES = {
 
 # make sure tracking_tool app uses tracking_tool DB:
 DATABASE_ROUTERS = [
-    'capapi.routers.CAPAPIRouter',
     'tracking_tool.routers.TrackingToolDatabaseRouter',
 ]
 

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -18,8 +18,6 @@ CELERY_TASK_EAGER_PROPAGATES = True
 if os.environ.get('DOCKERIZED'):
     DATABASES['default']['PASSWORD'] = 'password'
     DATABASES['default']['HOST'] = 'db'
-    DATABASES['capapi']['PASSWORD'] = 'password'
-    DATABASES['capapi']['HOST'] = 'db'
 
     REDIS_HOST = 'redis'
 

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -110,8 +110,7 @@ def migrate():
         Migrate all dbs at once
     """
 
-    local("python manage.py migrate --database=default")
-    local("python manage.py migrate --database=capapi")
+    local("python manage.py migrate")
 
     if settings.USE_TEST_TRACKING_TOOL_DB:
         local("python manage.py migrate --database=tracking_tool")


### PR DESCRIPTION
Did I miss anything?

Production deployment process:
- Before deploy, pg_dump the data from `capapi.capapi_apitoken`, `capapi.capapi_apiuser`
- Before deploy, `delete from capdb.django_migrations where app='capapi';`. This will cause the next migrate to re-run the capapi migrations in the default schema.
- Deploy.
- Load the data from `capapi.capapi_apitoken`, `capapi.capapi_apiuser` into the newly-created tables in the `capdb` schema.