### PR TITLE
Measure query counts from CaseXML.save()

### DIFF
--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -75,7 +75,7 @@ def test_related_names(ingest_case_xml):
 # CaseXML update
 
 @pytest.mark.django_db
-def test_checksums_update_casebody_modify_word(ingest_case_xml):
+def test_checksums_update_casebody_modify_word(ingest_case_xml, django_assert_num_queries):
 
     parsed_volume_xml = parse_xml(ingest_case_xml.volume.orig_xml)
     parsed_case_xml = parse_xml(ingest_case_xml.orig_xml)
@@ -94,7 +94,8 @@ def test_checksums_update_casebody_modify_word(ingest_case_xml):
     updated_text = parsed_case_xml('casebody|p[id="b17-6"]').text().replace('argument', '4rgUm3nt')
     parsed_case_xml('casebody|p[id="b17-6"]').text(updated_text)
     ingest_case_xml.orig_xml = serialize_xml(parsed_case_xml)
-    ingest_case_xml.save()
+    with django_assert_num_queries(select=9, update=6):
+        ingest_case_xml.save()
 
 
     # make sure the change was saved in the case_xml


### PR DESCRIPTION
This is just a start on optimizing CaseXML.save() -- currently changing a word in CaseXML.orig_xml takes 9 select queries and 6 update queries on save. Added an assert to measure that.