### PR TITLE
api filter indexing take 2

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -48,10 +48,6 @@ class CourtFilter(filters.FilterSet):
 
 
 class CaseFilter(filters.FilterSet):
-    name = filters.CharFilter(
-        field_name='name',
-        label='Name',
-        lookup_expr='iexact')
     name_abbreviation = filters.CharFilter(
         field_name='name_abbreviation',
         label='Name Abbreviation',
@@ -91,13 +87,11 @@ class CaseFilter(filters.FilterSet):
         model = models.CaseMetadata
         fields = [
                   'cite',
-                  'name',
                   'name_abbreviation',
                   'jurisdiction',
                   'reporter_name',
                   'decision_date_min',
                   'decision_date_max',
-                  'docket_number',
                   ]
 
 

--- a/capstone/capdb/migrations/0032_auto_20180409_0113.py
+++ b/capstone/capdb/migrations/0032_auto_20180409_0113.py
@@ -30,9 +30,10 @@ class Migration(migrations.Migration):
             name='full_name',
             field=models.CharField(db_index=True, max_length=1024),
         ),
-        migrations.RunSQL(
-            sql='CREATE INDEX idx_casemetadata_name_upper ON capdb_casemetadata (UPPER(name) text_pattern_ops);',
-            reverse_sql='DROP INDEX idx_casemetadata_name_upper;'
+        migrations.AlterField(
+            model_name='casemetadata',
+            name='name_abbreviation',
+            field=models.CharField(blank=True, db_index=True, max_length=1024),
         ),
         migrations.RunSQL(
             sql='CREATE INDEX idx_casemetadata_name_abbr_upper ON capdb_casemetadata (UPPER(name_abbreviation) varchar_pattern_ops);',

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -478,7 +478,7 @@ class CaseMetadata(models.Model):
     decision_date_original = models.CharField(max_length=100, blank=True)
     court = models.ForeignKey('Court', null=True, related_name='case_metadatas', on_delete=models.SET_NULL)
     name = models.TextField(blank=True)
-    name_abbreviation = models.CharField(max_length=10000, blank=True)
+    name_abbreviation = models.CharField(max_length=1024, blank=True, db_index=True)
     volume = models.ForeignKey('VolumeMetadata', related_name='case_metadatas',
                                on_delete=models.DO_NOTHING)
     reporter = models.ForeignKey('Reporter', related_name='case_metadatas',


### PR DESCRIPTION
- removed indexing on casemetadata name and hid from front-end filter view
- changed name_abbreviation length (our longest right now is 1007, thanks @bensteinberg) 
- added indexing on name_abbreviation field (missing before, there's also an UPPER index on this field)
- removed docket_number from front-end filtering view