### PR TITLE
Remove default ordering on CaseMetadata

### DIFF
--- a/capstone/capapi/views.py
+++ b/capstone/capapi/views.py
@@ -65,16 +65,20 @@ class CaseViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Lis
     serializer_class = serializers.CaseSerializer
     http_method_names = ['get']
     queryset = models.CaseMetadata.objects.exclude(
-        duplicative=True).select_related(
+        duplicative=True
+    ).select_related(
         'volume',
         'reporter',
         'jurisdiction',
         'court'
-        ).prefetch_related(
+    ).prefetch_related(
         'citations'
-        ).filter(
+    ).filter(
         jurisdiction__isnull=False,
-        court__isnull=False)
+        court__isnull=False
+    ).order_by(
+        'decision_date', 'id'  # include id to get consistent ordering for cases with same date
+    )
 
     renderer_classes = (
         renderers.BrowsableAPIRenderer,

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -489,10 +489,10 @@ class CaseMetadata(models.Model):
         return self.case_id
 
     class Meta:
-        ordering = ['decision_date', 'id']  # include id to get consistent ordering for cases with same date
-        # speed up queries with default ordering
         indexes = [
+            # index for ordering of case API endpoint
             models.Index(fields=['decision_date', 'id']),
+            # index for ordering of case API endpoint when filtered by jurisdiction
             models.Index(fields=['jurisdiction_id', 'decision_date', 'id']),
         ]
 


### PR DESCRIPTION
Having a default ordering on CaseMetadata turns out to slow down unrelated parts of the app, like a random `cases = CaseMetadata.objects.filter(reporter=reporter)` in a fab task that results in a slow query. Let's make ordering something you have to opt into.

Is there anywhere else besides the /cases/ endpoint that expects cases to come back in date order?