### PR TITLE
Staff/user admin permissions

### DIFF
--- a/capstone/capapi/admin.py
+++ b/capstone/capapi/admin.py
@@ -3,7 +3,6 @@ from django.contrib import admin
 
 from . import models
 
-
 def authenticate_user(modeladmin, request, queryset):
     """
     This method will override old key_expires fields by setting it to timezone.now()

--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -7,6 +7,7 @@ from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.db import IntegrityError, models
 from django.utils import timezone
 from django.conf import settings
+from capapi.permissions import staff_level_permissions
 
 from model_utils import FieldTracker
 
@@ -138,15 +139,12 @@ class CapUser(AbstractBaseUser):
             return True
 
     def has_module_perms(self, app_label):
-        if app_label == 'capapi':
+        if app_label == 'capapi' or app_label == 'capdb':
             return self.is_staff
 
         return self.is_superuser
 
     def has_perm(self, perm, obj=None):
-        app, action = perm.split('.')
-
-        if app == 'capapi':
+        if perm in staff_level_permissions:
             return self.is_staff
-
         return self.is_superuser

--- a/capstone/capapi/permissions.py
+++ b/capstone/capapi/permissions.py
@@ -1,14 +1,6 @@
 from rest_framework import permissions
 
 
-class AdminUserPermissions(permissions.BasePermission):
-    def has_permission(self, request, view):
-        return view.action == 'retrieve' or request.user.is_admin
-
-
-class IsAdmin(permissions.BasePermission):
-    def has_permission(self, request, view):
-        return request.user.is_admin
 staff_level_permissions = [
     'capdb.change_jurisdiction',
     'capapi.add_capuser',

--- a/capstone/capapi/permissions.py
+++ b/capstone/capapi/permissions.py
@@ -9,6 +9,12 @@ class AdminUserPermissions(permissions.BasePermission):
 class IsAdmin(permissions.BasePermission):
     def has_permission(self, request, view):
         return request.user.is_admin
+staff_level_permissions = [
+    'capdb.change_jurisdiction',
+    'capapi.add_capuser',
+    'capapi.change_capuser',
+    'capapi.delete_capuser',
+]
 
 
 class IsAuthenticatedCapUser(permissions.BasePermission):

--- a/capstone/capdb/admin.py
+++ b/capstone/capdb/admin.py
@@ -8,39 +8,47 @@ from .models import VolumeXML, CaseXML, PageXML, TrackingToolLog, VolumeMetadata
 def new_class(name, *args, **kwargs):
     return type(name, args, kwargs)
 
+
 class VolumeXMLAdmin(SimpleHistoryAdmin):
     pass
-admin.site.register(VolumeXML, VolumeXMLAdmin)
+
 
 class CasePageInline(admin.TabularInline):
     model = PageXML.cases.through
     show_change_link = True
     raw_id_fields = ['casexml', 'pagexml']
 
+
 class PageXMLAdmin(SimpleHistoryAdmin):
     inlines = [CasePageInline]
     exclude = ('cases',)
-admin.site.register(PageXML, PageXMLAdmin)
+
 
 class CaseXMLAdmin(SimpleHistoryAdmin):
     inlines = [CasePageInline]
-admin.site.register(CaseXML, CaseXMLAdmin)
+
 
 class TrackingToolLogAdmin(admin.ModelAdmin):
     raw_id_fields = ['volume']
-admin.site.register(TrackingToolLog, TrackingToolLogAdmin)
+
 
 class ReporterAdmin(admin.ModelAdmin):
     pass
     # to inline volumes:
     # inlines = [new_class('VolumeInline', admin.TabularInline, model=VolumeMetadata)]
-admin.site.register(Reporter, ReporterAdmin)
 
-@admin.register(SlowQuery)
+
 class SlowQueryAdmin(admin.ModelAdmin):
     list_display = ['last_seen', 'label', 'query']
     list_editable = ['label']
 
+
+admin.site.register(VolumeXML, VolumeXMLAdmin)
+admin.site.register(PageXML, PageXMLAdmin)
+admin.site.register(CaseXML, CaseXMLAdmin)
+admin.site.register(TrackingToolLog, TrackingToolLogAdmin)
+admin.site.register(Reporter, ReporterAdmin)
+admin.site.register(SlowQuery, SlowQueryAdmin)
 admin.site.register(VolumeMetadata)
 admin.site.register(ProcessStep)
 admin.site.register(BookRequest)

--- a/capstone/capdb/admin.py
+++ b/capstone/capdb/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from simple_history.admin import SimpleHistoryAdmin
 
 from .models import VolumeXML, CaseXML, PageXML, TrackingToolLog, VolumeMetadata, Reporter, ProcessStep, BookRequest, \
-    TrackingToolUser, SlowQuery
+    TrackingToolUser, SlowQuery, Jurisdiction
 
 
 def new_class(name, *args, **kwargs):
@@ -43,12 +43,18 @@ class SlowQueryAdmin(admin.ModelAdmin):
     list_editable = ['label']
 
 
+class JurisdictionAdmin(admin.ModelAdmin):
+    list_display = ['whitelisted', 'name_long']
+
+
 admin.site.register(VolumeXML, VolumeXMLAdmin)
 admin.site.register(PageXML, PageXMLAdmin)
 admin.site.register(CaseXML, CaseXMLAdmin)
 admin.site.register(TrackingToolLog, TrackingToolLogAdmin)
 admin.site.register(Reporter, ReporterAdmin)
 admin.site.register(SlowQuery, SlowQueryAdmin)
+admin.site.register(Jurisdiction, JurisdictionAdmin)
+
 admin.site.register(VolumeMetadata)
 admin.site.register(ProcessStep)
 admin.site.register(BookRequest)

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -151,6 +151,12 @@ def admin_user(db, django_user_model, django_username_field):
             'test_admin_user@example.com', 'password', **extra_fields)
     return user
 
+@pytest.fixture()
+def staff_user(cap_user):
+    cap_user.is_staff = True
+    cap_user.save()
+    return cap_user
+
 
 @pytest.fixture()
 def admin_client(db, admin_user):


### PR DESCRIPTION
- added Jurisdiction to admin app
- allowing staff users to change jurisdictions but not add or delete (as per https://trello.com/c/GPkEZ5tS/122-add-jurisdictions-to-admin-panel-for-quick-whitelisting-blacklisting)
- added explicit list of permissions in permissions.py
- testing user level permissions