### PR TITLE
Query profiling

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from django.utils.functional import SimpleLazyObject
 from django.utils.text import slugify
 import rest_framework_filters as filters
@@ -5,7 +7,10 @@ import rest_framework_filters as filters
 from capdb import models
 
 # lazy load jur_choices so we don't get an error if this file is imported when database tables don't exist yet
-jur_choices = SimpleLazyObject(lambda: [(jur.id, jur.name) for jur in models.Jurisdiction.objects.all()])
+@lru_cache(None)
+def get_jur_choices():
+    return [(jur.id, jur.name) for jur in models.Jurisdiction.objects.all()]
+jur_choices = SimpleLazyObject(get_jur_choices)
 
 
 class JurisdictionFilter(filters.FilterSet):

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -32,6 +32,7 @@ INSTALLED_APPS = [
     'capdb',
     'tracking_tool',
     'capapi',
+    'django_sql_trace',
 
     # 3rd party
     'storages',  # http://django-storages.readthedocs.io/en/latest/index.html

--- a/capstone/django_sql_trace/__init__.py
+++ b/capstone/django_sql_trace/__init__.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+from django.utils.module_loading import import_string
+import django.db.backends.base.base
+
+WrapperClass = import_string(getattr(settings, 'SQL_TRACE_WRAPPER_CLASS', 'django_sql_trace.wrapper.TracingDebugWrapper'))
+django.db.backends.base.base.BaseDatabaseWrapper.make_debug_cursor = lambda self, cursor: WrapperClass(cursor, self)

--- a/capstone/django_sql_trace/wrapper.py
+++ b/capstone/django_sql_trace/wrapper.py
@@ -1,0 +1,44 @@
+from distutils.sysconfig import get_python_lib
+import inspect
+
+from django.db.backends import utils
+
+
+python_lib_path = get_python_lib()
+
+class TracingDebugWrapper(utils.CursorDebugWrapper):
+    def log_message(self, message):
+        utils.logger.debug(message)
+
+    def get_userland_stack_frame(self, stack):
+        try:
+            return next(x for x in stack[2:] if not x.filename.startswith(python_lib_path))
+        except StopIteration:
+            return None
+
+    def capture_stack(self):
+        stack = inspect.stack()
+        userland_stack_frame = self.get_userland_stack_frame(stack)
+
+        self.db.queries_log[-1].update({
+            'stack': stack,
+            'userland_stack_frame': userland_stack_frame,
+        })
+
+        if userland_stack_frame:
+            self.log_message("Previous SQL query called by %s:%s:\n%s" % (
+                userland_stack_frame.filename,
+                userland_stack_frame.lineno,
+                userland_stack_frame.code_context[0].rstrip()))
+
+    def execute(self, *args, **kwargs):
+        try:
+            return super().execute(*args, **kwargs)
+        finally:
+            self.capture_stack()
+
+    def executemany(self, *args, **kwargs):
+        try:
+            return super().executemany(*args, **kwargs)
+        finally:
+            self.capture_stack()


### PR DESCRIPTION
- Avoid extra queries for populating `jur_choices` -- I didn't realize that `SimpleLazyObject` doesn't cache its value.
- Add a `django_sql_trace` app that keeps track of where SQL queries are called from. Source of queries will now be logged by `django_assert_num_queries`, and also if query logging is enabled with

```
LOGGING['loggers']['django.db.backends'] = {
    'level': 'DEBUG',
    'handlers': ['console'],
    'propagate': False,
}
```