### PR TITLE
Add recommended Django SSL settings

### DIFF
--- a/capstone/config/settings/settings_prod.py
+++ b/capstone/config/settings/settings_prod.py
@@ -55,3 +55,9 @@ DATABASES['tracking_tool'] = {
 
 ### API
 API_DOCS_CASE_ID = '11301409' # Brown v. Board
+
+### SECURITY
+
+SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
Will have to test this with our proxy setup, but these are settings recommended by https://docs.djangoproject.com/en/2.0/topics/security/ to redirect requests to https and ensure that session cookies are only set on secure requests.