### PR TITLE
Queryset casexmls

### DIFF
--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -205,7 +205,7 @@ def test_authenticated_multiple_full_cases(auth_user, api_url, auth_client, thre
 
     # fetch the two blacklisted cases and one whitelisted case
     url = "%scases/?full_case=true" % (api_url)
-    with django_assert_num_queries(select=7, update=1):
+    with django_assert_num_queries(select=4, update=1):
         response = auth_client.get(url)
     check_response(response)
 

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -76,16 +76,17 @@ class CaseViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Lis
     filter_class = filters.CaseFilter
     lookup_field = 'id'
 
+    def is_full_case_request(self):
+        return True if self.request.query_params.get('full_case', 'false').lower() == 'true' else False
+
     def get_queryset(self):
-        full_case = self.request.query_params.get('full_case', 'false').lower()
-        if full_case == 'true':
+        if self.is_full_case_request():
             return self.queryset.select_related('case_xml')
         else:
             return self.queryset
 
     def get_serializer_class(self, *args, **kwargs):
-        full_case = self.request.query_params.get('full_case', 'false').lower()
-        if full_case == 'true':
+        if self.is_full_case_request():
             return serializers.CaseSerializerWithCasebody
         else:
             return self.serializer_class

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -76,6 +76,13 @@ class CaseViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Lis
     filter_class = filters.CaseFilter
     lookup_field = 'id'
 
+    def get_queryset(self):
+        full_case = self.request.query_params.get('full_case', 'false').lower()
+        if full_case == 'true':
+            return self.queryset.select_related('case_xml')
+        else:
+            return self.queryset
+
     def get_serializer_class(self, *args, **kwargs):
         full_case = self.request.query_params.get('full_case', 'false').lower()
         if full_case == 'true':


### PR DESCRIPTION
fixes https://trello.com/c/qBBebaPK/138-fetch-all-casexml-for-case-endpoint-in-single-query
I think this is potentially a nicer fix? We can use `select_related` for `OneToOne` relationships. I'm seeing 106+ queries, for instance (when getting page_size=100), reduced to 7. 

