### PR TITLE
update - expose decision_date_original as decision_date for clarity

### DIFF
--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -45,6 +45,7 @@ class CaseSerializer(serializers.HyperlinkedModelSerializer):
     citations = CitationSerializer(many=True)
     volume_number = serializers.ReadOnlyField(source='volume.volume_number')
     volume_url = serializers.HyperlinkedRelatedField(source='volume', view_name='volumemetadata-detail', read_only=True)
+    decision_date = serializers.DateField(source='decision_date_original')
 
     class Meta:
         model = models.CaseMetadata
@@ -54,7 +55,6 @@ class CaseSerializer(serializers.HyperlinkedModelSerializer):
             'name',
             'name_abbreviation',
             'decision_date',
-            'decision_date_original',
             'docket_number',
             'first_page',
             'last_page',


### PR DESCRIPTION
- showing `decision_date_original` as `decision_date` in /cases endpoint
- allowing date filtering using the datefield `decision_date` 


finishes https://trello.com/c/9AWqKUWb/132-figure-out-what-to-do-with-decisiondate-field
