### PR TITLE
smartquotes

### DIFF
--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -1,3 +1,4 @@
+import re
 import shutil
 from lxml import etree
 from pyquery import PyQuery
@@ -225,6 +226,11 @@ def chunked_iterator(queryset, chunk_size=1000):
 def extract_casebody(case_xml):
     # strip soft hyphens from line endings
     text = case_xml.replace(u'\xad', '')
+
+    # fix quotation marks
+    text = re.sub(r'[\u201c\u201d]', '"', text)
+    text = re.sub(r'[\u2018\u2019]', "'", text)
+
     case = parse_xml(text)
 
     # strip labels from footnotes:

--- a/capstone/scripts/tests/test_helpers.py
+++ b/capstone/scripts/tests/test_helpers.py
@@ -1,6 +1,6 @@
 import re
 import pytest
-from scripts.helpers import serialize_xml, parse_xml
+from scripts.helpers import serialize_xml, parse_xml, extract_casebody
 from scripts.generate_case_html import generate_html, tag_map
 from scripts.merge_alto_style import generate_styled_case_xml
 from scripts.compare_alto_case import validate
@@ -162,3 +162,12 @@ def test_validate_alto_casemets_error(ingest_case_xml):
     assert results['results'] == 'gave up after 2 consecutive bad words'
     assert problem_1 in results['problems']
     assert problem_2 in results['problems']
+
+
+@pytest.mark.django_db
+def test_extract_casebody(ingest_case_xml):
+    # extract_casebody should clean up quotation marks
+    orig_xml = ingest_case_xml.orig_xml
+    assert '\u2019' in orig_xml
+    casebody = extract_casebody(orig_xml)
+    assert '\u2019' not in casebody.text()


### PR DESCRIPTION
fixes https://trello.com/c/TvH0oFbo/154-check-funky-characters-in-api-responses-wrong-response-headers-for-character-encoding

- replace smartquotes with dumb quotes when extracting casebody

Note: this issue only shows up in Safari
There is still the issue of "de- • fendant" in the example case mentioned in the Trello card, but I'm uneasy about removing all bullets — this might be best for a case by case basis (though @ChefAndy confirmed it's definitely an OCR error with this case).