### PR TITLE
Cache API count values

### DIFF
--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -43,7 +43,7 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     'PAGE_SIZE': 100,
-    'DEFAULT_PAGINATION_CLASS': 'capapi.pagination.CountlessPagination',
+    'DEFAULT_PAGINATION_CLASS': 'capapi.pagination.CachedCountLimitOffsetPagination',
     'DEFAULT_FILTER_BACKENDS': (
         'rest_framework_filters.backends.DjangoFilterBackend',
     ),
@@ -261,7 +261,7 @@ API_CASE_EXPIRE_HOURS = 24
 API_BASE_URL_ROUTE = '/api'
 API_VERSION = 'v1'
 API_DOCS_CASE_ID = 2
-
+API_COUNT_CACHE_TIMEOUT = 60*60*24  # 'count' value in API responses is cached for 1 day
 API_FULL_URL = os.path.join(API_BASE_URL_ROUTE, API_VERSION)
 API_CASE_FILE_TYPE = '.xml'
 

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -3,6 +3,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 import pytest
+from django.core.cache import cache as django_cache
 
 from django.core.management import call_command
 import django.apps
@@ -32,6 +33,9 @@ def clear_caches():
     try:
         yield
     finally:
+        # clear django cache
+        django_cache.clear()
+
         # call reset_cache for all models that have it:
         for model in django.apps.apps.get_models():
             if hasattr(model, 'reset_cache'):


### PR DESCRIPTION
Create a cache for the 'count' value in API responses. By default values are cached for one day.