### PR TITLE
Disable s3 full sync

### DIFF
--- a/capstone/scripts/ingest_by_manifest.py
+++ b/capstone/scripts/ingest_by_manifest.py
@@ -61,7 +61,12 @@ def sync_s3_data(full_sync=False):
 
         If full_sync is false, only sync files where the VolumeXML with that md5 has not already been successfully ingested.
     """
-
+    if full_sync:
+        raise Exception("""Full sync is not currently supported. We currently cannot distinguish between volumes that
+            have been imported and edited in the database, and those that have been imported and had a second version
+            uploaded to S3, so we will only import a volume from S3 a single time unless it is marked as
+            import_status='pending' to trigger re-import.""")
+    
     # pre-run setup
     wipe_redis_db()
 


### PR DESCRIPTION
Once we edit volumes, the current logic in our import script won't work because volume md5s will stop matching and trigger re-import of the old version. Let's just disable re-checking of imported volumes  (the `fab total_sync_with_s3` command) for now.