### PR TITLE
Cache HTML for API filters

### DIFF
--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -4,18 +4,15 @@ from scripts.generate_case_html import generate_html
 from scripts import helpers
 
 
-class JSONRenderer(renderers.JSONRenderer):
-    media_type = 'application/json'
-    format = 'json'
-
+class CaseJSONRenderer(renderers.JSONRenderer):
     def render(self, data, media_type=None, renderer_context=None):
         request = renderer_context['request']
 
         if 'casebody' not in data:
-            return super(JSONRenderer, self).render(data, renderer_context=renderer_context)
+            return super(CaseJSONRenderer, self).render(data, renderer_context=renderer_context)
 
         if data['casebody']['status'] != 'ok':
-            return super(JSONRenderer, self).render(data, renderer_context=renderer_context)
+            return super(CaseJSONRenderer, self).render(data, renderer_context=renderer_context)
 
         body_format = request.query_params.get('body_format', None)
 
@@ -29,7 +26,7 @@ class JSONRenderer(renderers.JSONRenderer):
             # send text to everyone else
             data['casebody']['data'] = helpers.extract_casebody(data['casebody']['data']).text()
 
-        return super(JSONRenderer, self).render(data, renderer_context=renderer_context)
+        return super(CaseJSONRenderer, self).render(data, renderer_context=renderer_context)
 
 
 class XMLRenderer(renderers.BaseRenderer):
@@ -51,6 +48,7 @@ class XMLRenderer(renderers.BaseRenderer):
             return generate_xml_error("Case Body Error", data['casebody']['status'])
         else:
             return data['casebody']['data']
+
 
 class HTMLRenderer(renderers.BaseRenderer):
     media_type = 'text/html'

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -2,7 +2,7 @@ import urllib
 from django.http import HttpResponseRedirect
 from django.utils.text import slugify
 
-from rest_framework import renderers, viewsets, mixins
+from rest_framework import viewsets, mixins
 from rest_framework.reverse import reverse
 
 from capdb import models
@@ -66,8 +66,8 @@ class CaseViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Lis
     )
 
     renderer_classes = (
-        capapi_renderers.JSONRenderer,
-        renderers.BrowsableAPIRenderer,
+        capapi_renderers.CaseJSONRenderer,
+        capapi_renderers.BrowsableAPIRenderer,
         capapi_renderers.XMLRenderer,
         capapi_renderers.HTMLRenderer,
     )

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -56,7 +56,7 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_RENDERER_CLASSES': (
         'rest_framework.renderers.JSONRenderer',
-        'rest_framework.renderers.BrowsableAPIRenderer',
+        'capapi.renderers.BrowsableAPIRenderer',
     ),
 }
 


### PR DESCRIPTION
Since I added massive dropdown lists for reporters and courts, the API filters take a long time to render on the server.

* Add handy decorator to cache the output of any function.
* Cache API filters form using decorator.
* Also switch the paginator counts cache to use the same handy decorator.