### PR TITLE
Public downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ db.sqlite3
 tracking_tool.sqlite
 .coverage
 
-bulk-data/
+capstone/bulk-data/
 

--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 import uuid
 import logging
 
-from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
+from django.contrib.auth.models import AbstractBaseUser, BaseUserManager, AnonymousUser
 from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
 from django.db import models
 from django.utils import timezone
@@ -151,3 +151,8 @@ class CapUser(AbstractBaseUser):
         if perm in staff_level_permissions:
             return self.is_staff
         return self.is_superuser
+
+
+# make AnonymousUser API conform with CapUser API
+AnonymousUser.unlimited_access_until = None
+AnonymousUser.unlimited_access_in_effect = lambda self: False

--- a/capstone/capapi/templates/bulk.html
+++ b/capstone/capapi/templates/bulk.html
@@ -9,16 +9,43 @@ The Caselaw Access Project Bulk Access
 
 {% block content %}
   <div class="container header-margin">
-  <h3 class="font-header-semibold">Bulk Data</h3>
-  <p class="font-body">Click a link to download</p>
-  <hr/>
-  {% for jur, filelist in files.items %}
-    <h2 class="section-title">{{ jur }}</h2>
-    <ul>
-    {% for file in filelist %}
-      <li><a href="download/{{ jur }}/{{ file }}">{{ file }}</a></li>
-    {% endfor %}
-    </ul>
-  {% endfor %}
+
+    <h1>Bulk Caselaw Data</h1>
+
+    <section class="border-bottom mb-5">
+      <h2 class="font-header-semibold">Public Bulk Data</h2>
+      <p class="font-body">Click a link to download.</p>
+      {% for jur, filelist in public_zips.items %}
+        <h3 class="section-title">{{ jur }}</h3>
+        <ul>
+        {% for file in filelist %}
+          <li><a href="download/public/{{ jur }}/{{ file }}">{{ file }}</a></li>
+        {% endfor %}
+        </ul>
+      {% endfor %}
+    </section>
+
+    <section>
+      <h2 class="font-header-semibold">Bulk Data for Academic Research</h2>
+      {% if private_zips %}
+        <p class="font-body">
+          The following jurisdictions are available for download under to your academic research agreement.
+          Click a link to download.
+        </p>
+        {% for jur, filelist in private_zips.items %}
+          <h3 class="section-title">{{ jur }}</h3>
+          <ul>
+            {% for file in filelist %}
+              <li><a href="download/private/{{ jur }}/{{ file }}">{{ file }}</a></li>
+            {% endfor %}
+          </ul>
+        {% endfor %}
+      {% else %}
+        <p class="font-body">
+          Bulk downloads of the remaining jurisdictions are freely available for academic research.
+          Please <a href="mailto:info@capapi.org">contact us</a> for access.
+        </p>
+      {% endif %}
+    </section>
   </div>
 {% endblock %}

--- a/capstone/capapi/templates/home.html
+++ b/capstone/capapi/templates/home.html
@@ -266,6 +266,7 @@
             These are listed at <a href="/api/v1/">the API's root view</a>.
           </p>
       </section>
+
       <section class="border-bottom">
         <a class="anchor-offset"
            id="whitelisted-jurisdictions-section"
@@ -295,6 +296,23 @@
           <br />
           You can help us expand this list by asking your courts to
           digitize their caselaw!
+        </p>
+      </section>
+
+      <section class="border-bottom">
+        <a class="anchor-offset"
+           id="bulk-data-section"
+           aria-label="Bulk Data"></a>
+
+
+        <h2 class="section-title">
+          Bulk Data
+        </h2>
+
+        <p class="body-text">
+          We offer bulk data ZIP files by jurisdiction, including XML files for all cases. Download for our whitelisted
+          jurisdictions are available without a login. Downloads for remaining jurisdictions are available for academic
+          research on request. <a href="{% url "bulk-data" %}">Download bulk data here.</a>
         </p>
       </section>
 

--- a/capstone/capapi/templates/includes/api-doc-toc.html
+++ b/capstone/capapi/templates/includes/api-doc-toc.html
@@ -31,6 +31,11 @@
       </a>
     </li>
     <li class="list-group-item">
+      <a href="#bulk-data-section">
+        Bulk Data
+      </a>
+    </li>
+    <li class="list-group-item">
       <a href="#terms-of-use-section">
         Terms of Use
       </a>

--- a/capstone/capapi/tests/helpers.py
+++ b/capstone/capapi/tests/helpers.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from rest_framework.response import Response
 
 
@@ -17,3 +18,7 @@ def check_response(response, status_code=200, content_type=None, content_include
     if content_includes:
         assert content_includes in response.content.decode()
 
+
+def is_cached(response):
+    cache_header = response['cache-control'] if response.has_header('cache-control') else ''
+    return 's-maxage=%d' % settings.CACHE_CONTROL_DEFAULT_MAX_AGE in cache_header

--- a/capstone/capapi/urls.py
+++ b/capstone/capapi/urls.py
@@ -60,6 +60,6 @@ urlpatterns = [
     re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=None), name='schema-redoc'),
 
     ### bulk data ###
-    path('bulk-access/download/<str:jur>/<str:filename>', user_views.bulk_download, name='bulk-download'),
+    path('bulk-access/download/<str:public_or_private>/<str:jur>/<str:filename>', user_views.bulk_download, name='bulk-download'),
     path('bulk-access/', user_views.bulk, name='bulk-data'),
 ]

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -302,7 +302,7 @@ API_ADMIN_EMAIL_ADDRESS = 'main-email-address@example.com'
 API_EMAIL_ADDRESS = 'admin-email-address@example.com'
 
 # BULK DATA
-BULK_DATA_DIR = 'bulk-data'
+BULK_DATA_DIR = os.path.join(BASE_DIR, 'bulk-data')
 
 # DATA VISUALIZATION
 DATA_COUNT_DIR = '/tmp/count-data'

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -44,6 +44,8 @@ TEST_SLOW_QUERIES_DB_NAME = 'capstone_test_queries'
 # avoid test errors when running tests locally, since pytest-django sets DEBUG=False and staticfiles/ doesn't exist
 STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 
+BULK_DATA_DIR = os.path.join(BASE_DIR, 'test_data/bulk-data')
+
 # django-debug-toolbar
 try:
     import debug_toolbar  # noqa

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -3,7 +3,9 @@
 body {
   @extend .font-body;
   height: 100%;
-  display: block;
+  /* push footer to bottom of screen if insufficient main-content to fill page */
+  display: flex;
+  flex-direction: column;
 }
 
 h1, h2, h3, h4, h5, h6 {
@@ -118,8 +120,10 @@ h1 {
 .main-content {
   padding-left: 0;
   padding-right: 0;
-  min-height: 100%;
+  margin-bottom: 2em;
   overflow-x: hidden;
+  /* push footer to bottom of screen if insufficient main-content to fill page */
+  flex: 1 0 auto;
 }
 
 .blue-button {

--- a/capstone/test_data/bulk-data/private/Massachusetts/Fake Massachusetts.zip
+++ b/capstone/test_data/bulk-data/private/Massachusetts/Fake Massachusetts.zip
@@ -1,0 +1,1 @@
+fake zip content

--- a/capstone/test_data/bulk-data/private/New York/Fake New York.zip
+++ b/capstone/test_data/bulk-data/private/New York/Fake New York.zip
@@ -1,0 +1,1 @@
+fake zip content

--- a/capstone/test_data/bulk-data/public/Arkansas/Fake Arkansas.zip
+++ b/capstone/test_data/bulk-data/public/Arkansas/Fake Arkansas.zip
@@ -1,0 +1,1 @@
+fake zip content

--- a/capstone/test_data/bulk-data/public/Illinois/Fake Illinois.zip
+++ b/capstone/test_data/bulk-data/public/Illinois/Fake Illinois.zip
@@ -1,0 +1,1 @@
+fake zip content

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -147,7 +147,16 @@ def auth_client(auth_user):
     client.credentials(HTTP_AUTHORIZATION='Token ' + auth_user.get_api_key())
     # Django auth
     client.force_login(user=auth_user)
+    # make user available to tests
+    client.auth_user = auth_user
     return client
+
+@pytest.fixture
+def unlimited_auth_client(auth_client):
+    user = auth_client.auth_user
+    user.unlimited_access_until = timezone.now() + timedelta(days=1)
+    user.save()
+    return auth_client
 
 @pytest.fixture
 def api_url():


### PR DESCRIPTION
Looks like:

<img width="1691" alt="screen shot 2018-06-19 at 3 43 16 pm" src="https://user-images.githubusercontent.com/376272/41620430-b5a97ea6-73d7-11e8-9abc-8d4111b819c3.png">

- Add separate folders for public and private zip downloads
- Add cache headers for public downloads
- Add bulk data link from homepage
- Tweak CSS so footer is pushed down to bottom of page but is still visible on short pages
- Add tests