### PR TITLE
dbs on the move

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository contains Capstone and CAPAPI, the applications written by the Ha
 - [Documentation](#documentation)
 
 ## Project Background <a id="project-background"></a>
-The Caselaw Access Project is a large-scale digitization project hosted by the Harvard Law School [Library Innovation Lab.](http://lil.law.harvard.edu "LIL Website") Visit https://case.law.harvard.edu for more details:
+The Caselaw Access Project is a large-scale digitization project hosted by the Harvard Law School [Library Innovation Lab.](http://lil.law.harvard.edu "LIL Website") Visit https://case.law.harvard.edu for more details.
 
 ## The Data <a id="the-data"></a>
 1. [Format Documentation and Samples](#documentation-and-samples)
@@ -130,7 +130,8 @@ Capstone should now be running at 127.0.0.1:8000.
 We have initial support for local development via `docker compose`. Docker setup looks like this:
 
     $ docker-compose up &
-    $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capstone;"
+    $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capdb;"
+    $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capapi;"
     $ docker-compose exec web fab init_db
     $ docker-compose exec web fab load_test_data
 

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -271,17 +271,15 @@ def test_authenticated_multiple_full_cases(auth_user, api_url, auth_client, thre
     for extra_case in three_cases[1:]:
         extra_case.jurisdiction = jurisdiction
         extra_case.save()
-
     # preload capapi.filters.jur_choices so it doesn't sometimes get counted by django_assert_num_queries below
     from capapi.filters import jur_choices
     len(jur_choices)
 
     # fetch the two blacklisted cases and one whitelisted case
     url = "%scases/?full_case=true" % (api_url)
-    with django_assert_num_queries(select=5, update=1):
+    with django_assert_num_queries(select=3):
         response = auth_client.get(url)
     check_response(response)
-
     # make sure the auth_user's case download number has gone down by 2
     auth_user.refresh_from_db()
     assert auth_user.case_allowance_remaining == auth_user.total_case_allowance - 2

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -150,7 +150,7 @@ class AutoSlugMixin:
                 try:
                     # if we are running in a transaction, we have to run this save in a sub-transaction
                     # to recover from expected IntegrityErrors:
-                    if transaction.get_connection().in_atomic_block:
+                    if transaction.get_connection(using='capdb').in_atomic_block:
                         with transaction.atomic():
                             return super(AutoSlugMixin, self).save(*args, **kwargs)
 
@@ -582,7 +582,7 @@ class VolumeXML(BaseXMLModel):
     def __str__(self):
         return self.metadata_id
 
-    @transaction.atomic
+    @transaction.atomic(using='capdb')
     def save(self, update_related=True, *args, **kwargs):
 
         if self.tracker.has_changed('orig_xml') and update_related:
@@ -743,7 +743,7 @@ class CaseXML(BaseXMLModel):
     tracker = FieldTracker()
     history = TemporalHistoricalRecords()
 
-    @transaction.atomic
+    @transaction.atomic(using='capdb')
     def save(self, update_related=True, *args, **kwargs):
 
         # allow disabling of create_or_update_metadata for testing
@@ -1057,7 +1057,7 @@ class PageXML(BaseXMLModel):
     class Meta:
         ordering = ['barcode']
 
-    @transaction.atomic
+    @transaction.atomic(using='capdb')
     def save(self, force_insert=False, force_update=False, save_case=True, save_volume=True, *args, **kwargs):
         if self.xml_modified():
             if save_volume:

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -150,8 +150,8 @@ class AutoSlugMixin:
                 try:
                     # if we are running in a transaction, we have to run this save in a sub-transaction
                     # to recover from expected IntegrityErrors:
-                    if transaction.get_connection(using='capdb').in_atomic_block:
-                        with transaction.atomic():
+                    if transaction.get_connection().in_atomic_block:
+                        with transaction.atomic(using='capdb'):
                             return super(AutoSlugMixin, self).save(*args, **kwargs)
 
                     # otherwise we run with no transaction for speed:

--- a/capstone/capdb/routers.py
+++ b/capstone/capdb/routers.py
@@ -1,0 +1,6 @@
+from config.routers import SeparateDatabaseRouter
+
+
+class CapDBRouter(SeparateDatabaseRouter):
+    db_name = 'capdb'
+    app_label = 'capdb'

--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from celery import shared_task
-
-from django.db import connection, transaction
+from django.db import connections, transaction
 
 from capdb.models import *
 
@@ -59,14 +58,13 @@ def test_slow(i, ram=10, cpu=30):
 
 
 @shared_task
-# @transaction.atomic(using=CaseMetadata.???)
+@transaction.atomic
 def fix_md5_column(volume_id):
     """
         Our database has xml fields in the casexml and pagexml tables that are missing the <?xml> declaration, and that also don't have the md5 column filled.
 
         Here we update all the xml fields to add the <?xml> declaration and md5 hash.
     """
-    from django.db import connections
     with connections['capdb'].cursor() as cursor:
         new_xml_sql = "E'<?xml version=''1.0'' encoding=''utf-8''?>\n' || orig_xml"
         for table in ('capdb_casexml', 'capdb_pagexml'):
@@ -83,7 +81,6 @@ def get_reporter_count_for_jur(jurisdiction_id):
         print('Must provide jurisdiction id')
         return
 
-    from django.db import connections
     with connections['capdb'].cursor() as cursor:
         cursor.execute("select r.id, r.start_year, r.full_name, r.volume_count from capdb_reporter r join capdb_reporter_jurisdictions j on (r.id = j.reporter_id) where j.jurisdiction_id=%s order by r.start_year;" % jurisdiction_id)
         db_results = cursor.fetchall()
@@ -121,7 +118,6 @@ def get_case_count_for_jur(jurisdiction_id):
         print('Must provide jurisdiction id')
         return
 
-    from django.db import connections
     with connections['capdb'].cursor() as cursor:
         cursor.execute("select extract(year from decision_date)::integer as case_year, count(*) from capdb_casemetadata where duplicative=false and jurisdiction_id=%s group by case_year;" % jurisdiction_id)
         db_results = cursor.fetchall()

--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -59,14 +59,15 @@ def test_slow(i, ram=10, cpu=30):
 
 
 @shared_task
-@transaction.atomic(using='capdb')
+# @transaction.atomic(using=CaseMetadata.???)
 def fix_md5_column(volume_id):
     """
         Our database has xml fields in the casexml and pagexml tables that are missing the <?xml> declaration, and that also don't have the md5 column filled.
 
         Here we update all the xml fields to add the <?xml> declaration and md5 hash.
     """
-    with connection.cursor() as cursor:
+    from django.db import connections
+    with connections['capdb'].cursor() as cursor:
         new_xml_sql = "E'<?xml version=''1.0'' encoding=''utf-8''?>\n' || orig_xml"
         for table in ('capdb_casexml', 'capdb_pagexml'):
             print("Volume %s: updating %s" % (volume_id, table))
@@ -82,7 +83,8 @@ def get_reporter_count_for_jur(jurisdiction_id):
         print('Must provide jurisdiction id')
         return
 
-    with connection.cursor() as cursor:
+    from django.db import connections
+    with connections['capdb'].cursor() as cursor:
         cursor.execute("select r.id, r.start_year, r.full_name, r.volume_count from capdb_reporter r join capdb_reporter_jurisdictions j on (r.id = j.reporter_id) where j.jurisdiction_id=%s order by r.start_year;" % jurisdiction_id)
         db_results = cursor.fetchall()
 
@@ -119,7 +121,8 @@ def get_case_count_for_jur(jurisdiction_id):
         print('Must provide jurisdiction id')
         return
 
-    with connection.cursor() as cursor:
+    from django.db import connections
+    with connections['capdb'].cursor() as cursor:
         cursor.execute("select extract(year from decision_date)::integer as case_year, count(*) from capdb_casemetadata where duplicative=false and jurisdiction_id=%s group by case_year;" % jurisdiction_id)
         db_results = cursor.fetchall()
 

--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -59,7 +59,7 @@ def test_slow(i, ram=10, cpu=30):
 
 
 @shared_task
-@transaction.atomic
+@transaction.atomic(using='capdb')
 def fix_md5_column(volume_id):
     """
         Our database has xml fields in the casexml and pagexml tables that are missing the <?xml> declaration, and that also don't have the md5 column filled.

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -5,7 +5,7 @@ import bagit
 import zipfile
 import os
 import gzip
-from django.db import connection, utils
+from django.db import connections, utils
 import json
 from datetime import datetime
 
@@ -86,7 +86,7 @@ def test_write_inventory_files(tmpdir):
 
 @pytest.mark.django_db
 def test_show_slow_queries(capsys):
-    cursor = connection.cursor()
+    cursor = connections['capdb'].cursor()
     try:
         cursor.execute("create extension if not exists pg_stat_statements;")
         fabfile.show_slow_queries()

--- a/capstone/capdb/tests/test_versioning.py
+++ b/capstone/capdb/tests/test_versioning.py
@@ -23,7 +23,7 @@ def test_versioning(versioned_fixture_name, request):
     # versions are only created once per transaction.
     # since tests run in transactions, run an initial sub-transaction to make sure our
     # next save causes a new version to be created:
-    with transaction.atomic():
+    with transaction.atomic(using='capdb'):
         versioned_instance.save()
 
     # make some modifications:
@@ -33,7 +33,7 @@ def test_versioning(versioned_fixture_name, request):
     versioned_instance.orig_xml = serialize_xml(parsed)
 
     # save modified version:
-    with transaction.atomic():
+    with transaction.atomic(using='capdb'):
         versioned_instance.save()
 
     # historical version should now exist:

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -108,11 +108,20 @@ USE_TEST_TRACKING_TOOL_DB = True
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'capstone',
+        'NAME': 'capapi',
         'USER': 'postgres',
         'PASSWORD': '',
         'HOST': 'localhost',
         'PORT': '',
+    },
+    'capdb': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': 'capdb',
+        'USER': 'postgres',
+        'PASSWORD': '',
+        'HOST': 'localhost',
+        'PORT': '',
+
     },
     'tracking_tool': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -120,9 +129,10 @@ DATABASES = {
     }
 }
 
-# make sure tracking_tool app uses tracking_tool DB:
+# make sure tracking_tool and capdb apps use the correct DBs:
 DATABASE_ROUTERS = [
     'tracking_tool.routers.TrackingToolDatabaseRouter',
+    'capdb.routers.CapDBRouter',
 ]
 
 # Password validation

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -121,7 +121,6 @@ DATABASES = {
         'PASSWORD': '',
         'HOST': 'localhost',
         'PORT': '',
-
     },
     'tracking_tool': {
         'ENGINE': 'django.db.backends.sqlite3',

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -16,7 +16,8 @@ CELERY_TASK_EAGER_PROPAGATES = True
 if os.environ.get('DOCKERIZED'):
     DATABASES['default']['PASSWORD'] = 'password'
     DATABASES['default']['HOST'] = 'db'
-
+    DATABASES['capdb']['PASSWORD'] = 'password'
+    DATABASES['capdb']['HOST'] = 'db'
     REDIS_HOST = 'redis'
 
     # this will only be used if CELERY_TASK_ALWAYS_EAGER = False

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -142,8 +142,8 @@ def migrate():
         Migrate all dbs at once
     """
 
-    local("python manage.py migrate")
-
+    local("python manage.py migrate --database=default")
+    local("python manage.py migrate --database=capdb")
     if settings.USE_TEST_TRACKING_TOOL_DB:
         local("python manage.py migrate --database=tracking_tool")
 

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -90,8 +90,8 @@ def run_pending_migrations():
     data_migrations.run_pending_migrations()
 
 @task
-def update_postgres_env():
-    set_up_postgres.update_postgres_env()
+def update_postgres_env(db='capdb'):
+    set_up_postgres.update_postgres_env(db=db)
 
 @task
 def initialize_denormalization_fields():
@@ -403,7 +403,7 @@ def show_slow_queries():
 
     has been run for the capstone user.
     """
-    cursor = django.db.connection.cursor()
+    cursor = django.db.connections['capdb'].cursor()
     with open('../services/postgres/s1_pg_stat_statements_top_total.sql') as f:
         sql = f.read()
         cursor.execute(sql)

--- a/capstone/scripts/ingest_tt_data.py
+++ b/capstone/scripts/ingest_tt_data.py
@@ -117,7 +117,8 @@ def copyModel(source, destination, field_map, dupcheck, dupe_field='id'):
     # reset primary key sequence number based on imported data
     sequence_sql = connection.ops.sequence_reset_sql(no_style(), [destination])
     if sequence_sql:
-        with connection.cursor() as cursor:
+        from django.db import connections
+        with connections['capdb'].cursor() as cursor:
             cursor.execute(sequence_sql[0])
 
 def populate_jurisdiction():

--- a/capstone/scripts/ingest_tt_data.py
+++ b/capstone/scripts/ingest_tt_data.py
@@ -1,5 +1,6 @@
 from django.core.management.color import no_style
-from django.db import connection
+from django.db import connections
+
 from tqdm import tqdm
 
 from capdb.models import VolumeMetadata, TrackingToolUser, Reporter, ProcessStep, TrackingToolLog, BookRequest, Jurisdiction
@@ -115,15 +116,14 @@ def copyModel(source, destination, field_map, dupcheck, dupe_field='id'):
             print("Error saving %s ID %s: %s" % (source, getattr(source_record, dupe_field), e))
 
     # reset primary key sequence number based on imported data
-    sequence_sql = connection.ops.sequence_reset_sql(no_style(), [destination])
+    sequence_sql = connections['capdb'].ops.sequence_reset_sql(no_style(), [destination])
     if sequence_sql:
-        from django.db import connections
         with connections['capdb'].cursor() as cursor:
             cursor.execute(sequence_sql[0])
 
 def populate_jurisdiction():
     """This populates the jurisdiction table based on what's in the tracking tool stub"""
-    reporters = Reporters.objects.values('state').distinct() 
+    reporters = Reporters.objects.values('state').distinct()
     for jurisdiction in reporters:
         Jurisdiction.objects.get_or_create(name=jurisdiction['state'])
 

--- a/capstone/scripts/mass_update.py
+++ b/capstone/scripts/mass_update.py
@@ -13,7 +13,7 @@ from scripts.helpers import parse_xml, nsmap, serialize_xml
 
 
 def rename_casebody_tags_from_json_id_list(parsed_json, tag_name=None):
-    with transaction.atomic():
+    with transaction.atomic(using='capdb'):
         updated_records = 0
         for element in parsed_json:
             if tag_name is None:

--- a/capstone/scripts/process_ingested_xml.py
+++ b/capstone/scripts/process_ingested_xml.py
@@ -1,3 +1,4 @@
+from django.db import connections
 from capdb.models import VolumeXML, PageXML
 
 
@@ -13,7 +14,6 @@ def build_case_page_join_table(volume_id=None):
         case_page_join_model.objects.filter(casexml__volume_id=volume_id).delete()
 
     # add new relations
-    from django.db import connections
 
     with connections['capdb'].cursor() as cursor:
         params = {'volume_id': volume_id} if volume_id else {}
@@ -52,7 +52,6 @@ def get_people_for_casemetadata():
 
     for opinions, we return array tuples, with type of opinion and opinion author
     """
-    from django.db import connections
     with connections['capdb'].cursor() as cursor:
         sql = """
             CREATE OR REPLACE FUNCTION get_opinions(xml) RETURNS json AS $$

--- a/capstone/scripts/process_ingested_xml.py
+++ b/capstone/scripts/process_ingested_xml.py
@@ -15,7 +15,9 @@ def build_case_page_join_table(volume_id=None):
         case_page_join_model.objects.filter(casexml__volume_id=volume_id).delete()
 
     # add new relations
-    with connection.cursor() as cursor:
+    from django.db import connections
+
+    with connections['capdb'].cursor() as cursor:
         params = {'volume_id': volume_id} if volume_id else {}
         sql = """
             INSERT INTO capdb_pagexml_cases (pagexml_id, casexml_id)
@@ -52,7 +54,8 @@ def get_people_for_casemetadata():
 
     for opinions, we return array tuples, with type of opinion and opinion author
     """
-    with connection.cursor() as cursor:
+    from django.db import connections
+    with connections['capdb'].cursor() as cursor:
         sql = """
             CREATE OR REPLACE FUNCTION get_opinions(xml) RETURNS json AS $$
             DECLARE

--- a/capstone/scripts/process_ingested_xml.py
+++ b/capstone/scripts/process_ingested_xml.py
@@ -1,5 +1,3 @@
-from django.db import connection
-
 from capdb.models import VolumeXML, PageXML
 
 

--- a/capstone/scripts/set_up_postgres.py
+++ b/capstone/scripts/set_up_postgres.py
@@ -7,7 +7,6 @@ from simple_history.manager import HistoryManager
 
 import django.apps
 from django.conf import settings
-from django.db import connection
 
 from .helpers import nsmap
 
@@ -15,14 +14,14 @@ def run_sql_file(cursor, file_name):
     """ Run a sql file in the postgres/ folder """
     cursor.execute(Path(settings.BASE_DIR, "../services/postgres", file_name).read_text())
 
-def update_postgres_env():
+def update_postgres_env(db='capdb'):
     """
         Write or replace stored functions and triggers in postgres. This makes sure that the postgres environment matches
         our models. Queries here should be idempotent, so they're safe to run whenever migrations are run, or any
         other time.
     """
     from django.db import connections
-    with connections['capdb'].cursor() as cursor:
+    with connections[db].cursor() as cursor:
         ### XML namespace stuff ###
 
         # wrapper for the postgres `xpath(<xpath>, <xml>, <namespaces>)` function with our namespaces preloaded.

--- a/capstone/scripts/set_up_postgres.py
+++ b/capstone/scripts/set_up_postgres.py
@@ -21,7 +21,8 @@ def update_postgres_env():
         our models. Queries here should be idempotent, so they're safe to run whenever migrations are run, or any
         other time.
     """
-    with connection.cursor() as cursor:
+    from django.db import connections
+    with connections['capdb'].cursor() as cursor:
         ### XML namespace stuff ###
 
         # wrapper for the postgres `xpath(<xpath>, <xml>, <namespaces>)` function with our namespaces preloaded.
@@ -181,7 +182,8 @@ def initialize_denormalization_fields(*args, **kwargs):
 
         This function takes *args, **kwargs so it can be called from RunPython in a migration.
     """
-    with connection.cursor() as cursor:
+    from django.db import connections
+    with connections['capdb'].cursor() as cursor:
 
         # for each destination table, construct a sql query that updates the table based on all source tables
         dest_triggers, _ = get_denormalization_triggers()

--- a/capstone/scripts/set_up_postgres.py
+++ b/capstone/scripts/set_up_postgres.py
@@ -7,6 +7,7 @@ from simple_history.manager import HistoryManager
 
 import django.apps
 from django.conf import settings
+from django.db import connections
 
 from .helpers import nsmap
 
@@ -20,7 +21,6 @@ def update_postgres_env(db='capdb'):
         our models. Queries here should be idempotent, so they're safe to run whenever migrations are run, or any
         other time.
     """
-    from django.db import connections
     with connections[db].cursor() as cursor:
         ### XML namespace stuff ###
 
@@ -181,7 +181,6 @@ def initialize_denormalization_fields(*args, **kwargs):
 
         This function takes *args, **kwargs so it can be called from RunPython in a migration.
     """
-    from django.db import connections
     with connections['capdb'].cursor() as cursor:
 
         # for each destination table, construct a sql query that updates the table based on all source tables

--- a/capstone/scripts/tests/test_tt_ingest.py
+++ b/capstone/scripts/tests/test_tt_ingest.py
@@ -14,7 +14,8 @@ def test_relink_reporter_jurisdiction(ingest_case_xml):
         return output_map
 
     initial_map = make_reporter_jur_map()
-    with connection.cursor() as cursor:
+    from django.db import connections
+    with connections['capdb'].cursor() as cursor:
         cursor.execute("select count(*) from capdb_reporter_jurisdictions")
         assert cursor.fetchone()[0] == 3
         cursor.execute("delete from capdb_reporter_jurisdictions")

--- a/capstone/scripts/tests/test_tt_ingest.py
+++ b/capstone/scripts/tests/test_tt_ingest.py
@@ -1,8 +1,9 @@
 from collections import defaultdict
 import pytest
+from django.db import connections
+
 from scripts import ingest_tt_data
 from capdb.models import Reporter, Jurisdiction
-from django.db import connection
 
 @pytest.mark.django_db
 def test_relink_reporter_jurisdiction(ingest_case_xml):
@@ -14,7 +15,6 @@ def test_relink_reporter_jurisdiction(ingest_case_xml):
         return output_map
 
     initial_map = make_reporter_jur_map()
-    from django.db import connections
     with connections['capdb'].cursor() as cursor:
         cursor.execute("select count(*) from capdb_reporter_jurisdictions")
         assert cursor.fetchone()[0] == 3

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -112,10 +112,6 @@ def unaltered_alto_xml():
 ### Django json fixtures ###
 
 @pytest.fixture
-def load_user_data():
-    call_command('loaddata', 'test_data/user_data.json')
-
-@pytest.fixture
 def load_tracking_tool_database():
     call_command('loaddata', 'test_data/tracking_tool.json', database='tracking_tool')
 

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 import pytest
 from django.core.cache import cache as django_cache
 from django.core.management import call_command
+from django.db import connections
 import django.apps
 from rest_framework.test import APIRequestFactory, APIClient
 
@@ -74,7 +75,6 @@ def django_assert_num_queries(pytestconfig):
 
         Ensure that the queries run are as expected, then insert the correct counts based on the error message.
     """
-    from django.db import connections
     from django.test.utils import CaptureQueriesContext
 
     @contextmanager

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -67,12 +67,13 @@ def django_assert_num_queries(pytestconfig):
 
         Ensure that the queries run are as expected, then insert the correct counts based on the error message.
     """
-    from django.db import connection
+    from django.db import connections
     from django.test.utils import CaptureQueriesContext
 
     @contextmanager
-    def _assert_num_queries(**expected_counts):
-        with CaptureQueriesContext(connection) as context:
+    def _assert_num_queries(db='capdb', **expected_counts):
+        conn = connections[db]
+        with CaptureQueriesContext(conn) as context:
             yield
             query_counts = defaultdict(int)
             for q in context.captured_queries:


### PR DESCRIPTION
```
DATABASES = {
    'default': {
        'NAME': 'capapi',
        ....
    },
    'capdb': {
        'NAME': 'capdb',
        ...
    },
    ...
}
```
`capapi` db has users and admin django stuff. It is now our `default` database.
`capdb` db only has cap related data ("only")

capapi is now our default because capapi has `AUTH_USER_MODEL` and django admin stuff has separation anxiety. It needs to be in the same db. 

It turns out, the whole time we've had multiple databases (before we moved to one) pytest was only doing teardowns for the `default`, a.k.a `capstone`. This worked for us then because all our tests had to do with testing cap data, but now that cap data lives in a non-default db, it requires [a hack](https://github.com/harvard-lil/capstone/compare/develop...anastasia:capapi-moves-dbs?expand=1#diff-fe517f3c724f4f39aadaa4d38757fcccR29) . This is the subject of a four-year ongoing discussion on [pytest's github.](https://github.com/pytest-dev/pytest-django/issues/76
)

Things I am unhappy with:
- The db naming. I renamed from capstone because the project is named capstone and default dbs have a general tendency to be named the same things as the projects, so it might get confusing/difficult later on. If you buy that, what should the names be? capapi and capdb? weird. users and cap? users is not the only thing on that db. default and cap? 
- Explicitly specifying the `capdb` database seems lame, but also might be nice for being extra careful with where our data lives. Previously when we were using `django.db.connection` instead of `django.db.connections`, we weren't specifying a db, but instead we were piggy backing off of the hardcoded `default` db somewhere in the depths of django code. That bit us (me) in the butt when moving to a new setup. (Also that variable naming is just about the worst, no? `connections`? You can barely see the difference). 

Assuming neither of the points above (nor any others I haven't thought of) bother you,

### _**In order to merge, many steps must be taken!!!**_

```
$ # back up everything, everything, everything
$ # if making changes on prod db, stop server
$ # <-- if you merge PR and install the code here and make changes on prod db, from here on out prod will no longer work for a while -->
$ psql
$ ALTER DATABASE capstone RENAME TO capdb;
exit psql
$ pg_dump -t auth_group capdb | psql capapi
$ pg_dump -t auth_group_permissions capdb | psql capapi
$ pg_dump -t auth_permission capdb | psql capapi
$ pg_dump -t capapi_capuser capdb | psql capapi
$ pg_dump -t authtoken_token capdb | psql capapi
$ pg_dump -t django_admin_log capdb | psql capapi
$ pg_dump -t django_content_type capdb | psql capapi
$ pg_dump -t django_session capdb | psql capapi
```
[This](https://stackoverflow.com/questions/30545562/django-column-name-of-relation-django-content-type-does-not-exist) _might_ be optional:
```
$ psql capapi
$ ALTER TABLE django_content_type ADD COLUMN name character varying(50) NOT NULL DEFAULT 'someName';
```
But you might find running this (below) that it is not:
```
$ python manage.py migrate --fake-initial
$ python manage.py migrate --database=default
$ python manage.py migrate --database=capdb
```
is everything cool?
```
$ psql capdb
$ DROP TABLE auth_group;
$ DROP TABLE auth_group_permissions;
$ DROP TABLE auth_permission;
$ DROP TABLE capapi_capuser;
$ DROP TABLE authtoken_token;
$ DROP TABLE django_admin_log;
$ DROP TABLE django_content_type;
$ DROP TABLE django_session;
```

