### PR TITLE
Handle body_format in serializer

### DIFF
--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -2,7 +2,7 @@ import urllib
 from django.http import HttpResponseRedirect
 from django.utils.text import slugify
 
-from rest_framework import viewsets, mixins
+from rest_framework import viewsets, mixins, renderers
 from rest_framework.reverse import reverse
 
 from capdb import models
@@ -66,7 +66,7 @@ class CaseViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Lis
     )
 
     renderer_classes = (
-        capapi_renderers.CaseJSONRenderer,
+        renderers.JSONRenderer,
         capapi_renderers.BrowsableAPIRenderer,
         capapi_renderers.XMLRenderer,
         capapi_renderers.HTMLRenderer,


### PR DESCRIPTION
This moves the check of body_format from `renderers.CaseJSONRenderer` to `CaseSerializerWithCasebody.get_casebody`. Fixes an issue where body_format was only respected for the single case endpoint and not for the case list endpoint.

Also tweaked the HTML renderer's error format string to match its parameters.