### PR TITLE
Upgrade Django to 2.0.8 and other deps

### DIFF
--- a/capstone/capapi/tests/test_user_views.py
+++ b/capstone/capapi/tests/test_user_views.py
@@ -89,7 +89,7 @@ def test_login_wrong_password(auth_user, client):
     assert "Please enter a correct email and password." in response.content.decode()
 
 @pytest.mark.django_db
-def test_resend_verification(client):
+def test_resend_verification(client, mailoutbox):
     # create new user
     response = client.post(reverse('register'), {
         'email': 'new_user@example.com',
@@ -99,7 +99,7 @@ def test_resend_verification(client):
         'password2': 'Password2',
     })
     check_response(response)
-    assert len(mail.outbox) == 1
+    assert len(mailoutbox) == 1
 
     # resend verification
     response = client.post(reverse('resend-verification'), {
@@ -108,7 +108,7 @@ def test_resend_verification(client):
     check_response(response)
 
     # same verification email sent
-    assert mail.outbox[0].body == mail.outbox[1].body
+    assert mailoutbox[0].body == mailoutbox[1].body
 
 
 ### view account details ###

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -17,7 +17,7 @@ from capapi import renderers as capapi_renderers
 class JurisdictionViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
     serializer_class = serializers.JurisdictionSerializer
     http_method_names = ['get']
-    filter_class = filters.JurisdictionFilter
+    filterset_class = filters.JurisdictionFilter
     queryset = models.Jurisdiction.objects.all()
     lookup_field = 'slug'
 
@@ -33,14 +33,14 @@ class VolumeViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.L
 class ReporterViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
     serializer_class = serializers.ReporterSerializer
     http_method_names = ['get']
-    filter_class = filters.ReporterFilter
+    filterset_class = filters.ReporterFilter
     queryset = models.Reporter.objects.all().prefetch_related('jurisdictions')
 
 
 class CourtViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.ListModelMixin):
     serializer_class = serializers.CourtSerializer
     http_method_names = ['get']
-    filter_class = filters.CourtFilter
+    filterset_class = filters.CourtFilter
     queryset = models.Court.objects.all().select_related('jurisdiction')
     lookup_field = 'slug'
 
@@ -73,7 +73,7 @@ class CaseViewSet(viewsets.GenericViewSet, mixins.RetrieveModelMixin, mixins.Lis
         capapi_renderers.XMLRenderer,
         capapi_renderers.HTMLRenderer,
     )
-    filter_class = filters.CaseFilter
+    filterset_class = filters.CaseFilter
     lookup_field = 'id'
 
     def is_full_case_request(self):

--- a/capstone/capdb/migrations/0043_auto_20180614_1649.py
+++ b/capstone/capdb/migrations/0043_auto_20180614_1649.py
@@ -13,10 +13,10 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddIndex(
             model_name='casemetadata',
-            index=partial_index.PartialIndex(fields=['court_id', 'decision_date', 'id'], name='capdb_casem_court_i_42eeb9_partial', unique=True, where='jurisdiction_id IS NOT NULL AND court_id IS NOT NULL AND NOT duplicative', where_postgresql='', where_sqlite=''),
+            index=partial_index.PartialIndex(fields=['court', 'decision_date', 'id'], name='capdb_casem_court_i_42eeb9_partial', unique=True, where='jurisdiction_id IS NOT NULL AND court_id IS NOT NULL AND NOT duplicative', where_postgresql='', where_sqlite=''),
         ),
         migrations.AddIndex(
             model_name='casemetadata',
-            index=partial_index.PartialIndex(fields=['reporter_id', 'decision_date', 'id'], name='capdb_casem_reporte_3f581c_partial', unique=True, where='jurisdiction_id IS NOT NULL AND court_id IS NOT NULL AND NOT duplicative', where_postgresql='', where_sqlite=''),
+            index=partial_index.PartialIndex(fields=['reporter', 'decision_date', 'id'], name='capdb_casem_reporte_3f581c_partial', unique=True, where='jurisdiction_id IS NOT NULL AND court_id IS NOT NULL AND NOT duplicative', where_postgresql='', where_sqlite=''),
         ),
     ]

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -749,8 +749,8 @@ class CaseMetadata(models.Model):
             PartialIndex(fields=['decision_date', 'id'], unique=True, where=case_metadata_partial_index_where),
             # indexes for ordering of case API endpoint when filtered by jurisdiction, court, or reporter
             PartialIndex(fields=['jurisdiction_slug', 'decision_date', 'id'], unique=True, where=case_metadata_partial_index_where),
-            PartialIndex(fields=['court_id',          'decision_date', 'id'], unique=True, where=case_metadata_partial_index_where),
-            PartialIndex(fields=['reporter_id',       'decision_date', 'id'], unique=True, where=case_metadata_partial_index_where),
+            PartialIndex(fields=['court',             'decision_date', 'id'], unique=True, where=case_metadata_partial_index_where),
+            PartialIndex(fields=['reporter',          'decision_date', 'id'], unique=True, where=case_metadata_partial_index_where),
         ]
 
 

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -27,6 +27,7 @@ INSTALLED_APPS = [
     'django_extensions',
     'rest_framework',
     'rest_framework.authtoken',
+    'rest_framework_filters',
     'pipeline',
 
     # ours
@@ -46,7 +47,7 @@ REST_FRAMEWORK = {
     'PAGE_SIZE': 100,
     'DEFAULT_PAGINATION_CLASS': 'capapi.pagination.CachedCountLimitOffsetPagination',
     'DEFAULT_FILTER_BACKENDS': (
-        'rest_framework_filters.backends.DjangoFilterBackend',
+        'rest_framework_filters.backends.RestFrameworkFilterBackend',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.TokenAuthentication',

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -6,8 +6,6 @@ SECRET_KEY = 'k2#@_q=1$(__n7#(zax6#46fu)x=3&^lz&bwb8ol-_097k_rj5'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-MOCK_S3 = True
-
 # don't require celery listener
 CELERY_TASK_ALWAYS_EAGER = True
 # propagate exceptions

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -28,7 +28,7 @@ boto3               # for django-storages to talk to s3
 django-bulk-update  # bulk update of models
 whitenoise          # serve static assets
 #django-model-utils  # FieldTracker for tracking changed fields on model instances
-# see https://github.com/jazzband/django-model-utils/pull/313
+# upgrade to master is blocking on https://github.com/jazzband/django-model-utils/issues/331
 -e git://github.com/jcushman/django-model-utils.git@d34043f#egg=django-model-utils
 django-simple-history   # model versioning
 django-partial-index    # create partial postgres indexes
@@ -52,11 +52,12 @@ bagit               # validate BagIt bag
 # API
 beautifulsoup4
 django-extensions
-django-filter
 django-libsass
 django-pipeline
 django-pipeline-compass
-djangorestframework-filters
+#djangorestframework-filters
+# switch back to next release post 8/1/18:
+-e git://github.com/philipn/django-rest-framework-filters.git@c5ffc8276431cf49dddbcebab322b142843de4ef#egg=djangorestframework-filters
 djangorestframework
 django-bootstrap4   # render bootstrap forms in django templates
 drf-yasg            # expose API specification

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -5,50 +5,54 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 -e git+git://github.com/jcushman/django-model-utils.git@d34043f#egg=django-model-utils
+-e git+git://github.com/philipn/django-rest-framework-filters.git@c5ffc8276431cf49dddbcebab322b142843de4ef#egg=djangorestframework-filters
 -e git+git://github.com/jcushman/email-normalize.git@6b5088bd05de247a9a33ad4e5c7911b676d6daf2#egg=email-normalize
 -e git+git://github.com/jcushman/pyquery.git@115173a#egg=pyquery
 amqp==2.2.2               # via kombu
 apipkg==1.4               # via execnet
 asn1crypto==0.22.0        # via cryptography
+atomicwrites==1.1.5       # via pytest
 attrs==17.4.0             # via pytest
+aws-xray-sdk==0.95        # via moto
 babel==2.5.3              # via flower
 bagit==1.6.4
 beautifulsoup4==4.6.0
 billiard==3.5.0.3         # via celery
 boto3==1.7.48
 boto==2.47.0              # via moto
-botocore==1.10.48         # via boto3, s3transfer
+botocore==1.10.48         # via boto3, moto, s3transfer
 celery[redis,sqs]==4.2.0
 certifi==2017.4.17        # via requests
 cffi==1.10.0              # via cryptography
 chardet==3.0.3            # via requests
 click==6.7                # via flex, pip-tools
-cookies==2.2.1            # via moto
+cookies==2.2.1            # via moto, responses
 coreapi==2.3.3            # via drf-yasg, openapi-codec
 coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==4.4.1           # via pytest-cov
-cryptography==1.8.2       # via paramiko
+cryptography==2.3         # via moto, paramiko
 cssselect==1.0.1
-dicttoxml==1.7.4          # via moto
 django-appconf==1.0.2     # via django-compressor
 django-bootstrap4==0.0.6
 django-bulk-update==2.1.0
 django-compressor==2.1.1  # via django-libsass
 django-extensions==2.0.6
-django-filter==1.1.0
+django-filter==2.0.0
 django-libsass==0.7
 django-partial-index==0.4.0
 django-pipeline-compass==0.1.5
 django-pipeline==1.6.14
 django-redis==4.9.0
 django-simple-history==2.1.1
-django-storages==1.5.2
-django==2.0.2
-djangorestframework-filters==0.10.2
-djangorestframework==3.7.7
+django-storages==1.6.6
+django==2.0.8
+djangorestframework==3.8.2
 dnspython==1.15.0
+docker-pycreds==0.3.0     # via docker
+docker==3.4.1             # via moto
 docutils==0.13.1          # via botocore
 drf-yasg==1.7.1
+ecdsa==0.13               # via python-jose
 execnet==1.4.1            # via pytest-xdist
 fabric3==1.13.1.post1
 factory-boy==2.10.0
@@ -57,13 +61,15 @@ first==2.0.1              # via pip-tools
 flake8==3.4.1
 flex==6.13.1
 flower==0.9.2
-future==0.16.0            # via drf-yasg
+future==0.16.0            # via drf-yasg, python-jose
 idna==2.5                 # via cryptography, requests
 img2pdf==0.3.0
 inflection==0.3.1         # via drf-yasg, pytest-factoryboy
 itypes==1.1.0             # via coreapi
 jinja2==2.9.6             # via coreschema, moto
 jmespath==0.9.2           # via boto3, botocore
+jsondiff==1.1.1           # via moto
+jsonpickle==0.9.6         # via aws-xray-sdk
 jsonpointer==1.14         # via flex
 jsonschema==2.6.0         # via swagger-spec-validator
 kombu==4.2.1              # via celery
@@ -72,14 +78,17 @@ lxml==3.7.3
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
 mirakuru==0.8.2           # via pytest-redis
-moto==1.0.0
+mock==2.0.0               # via moto
+more-itertools==4.3.0     # via pytest
+moto==1.3.4
 mysqlclient==1.3.10
 openapi-codec==1.3.2      # via drf-yasg
-packaging==16.8           # via cryptography
 paramiko==2.1.2           # via fabric3
+pathlib2==2.3.2           # via pytest
+pbr==4.2.0                # via mock
 pillow==5.2.0             # via img2pdf, reportlab
 pip-tools==2.0.1
-pluggy==0.6.0             # via pytest
+pluggy==0.7.1             # via pytest
 port-for==0.4             # via pytest-redis
 psutil==5.4.0             # via mirakuru
 psycopg2==2.7.1
@@ -88,29 +97,31 @@ pyaml==16.12.2            # via moto
 pyasn1==0.2.3             # via paramiko
 pycodestyle==2.3.1        # via flake8
 pycparser==2.17           # via cffi
+pycryptodome==3.6.4       # via python-jose
 pycurl==7.43.0
 pyflakes==1.5.0           # via flake8
-pyparsing==2.2.0          # via packaging
 pypdf2==1.26.0
 pyscss==1.3.5             # via django-pipeline-compass
 pytest-cov==2.5.1
-pytest-django==3.1.2
+pytest-django==3.3.3
 pytest-factoryboy==2.0.1
 pytest-redis==1.3.2
 pytest-xdist==1.16.0
-pytest==3.4.2             # via pytest-cov, pytest-django, pytest-factoryboy, pytest-redis, pytest-xdist
+pytest==3.7.0             # via pytest-cov, pytest-django, pytest-factoryboy, pytest-redis, pytest-xdist
 python-dateutil==2.6.0    # via botocore, faker, moto
+python-jose==2.0.2        # via moto
 pytz==2017.2              # via babel, celery, django, flower, moto
 pyyaml==3.12              # via flex, pyaml
 rcssmin==1.0.6            # via django-compressor
 redis==2.10.6
 reportlab==3.5.2
-requests==2.16.4          # via coreapi, flex, moto
+requests==2.16.4          # via aws-xray-sdk, coreapi, docker, flex, moto, responses
+responses==0.9.0          # via moto
 rfc3987==1.3.7            # via flex
 rjsmin==1.0.12            # via django-compressor
 ruamel.yaml==0.15.37      # via drf-yasg
 s3transfer==0.1.10        # via boto3
-six==1.10.0               # via cryptography, django-extensions, drf-yasg, fabric3, faker, flex, libsass, moto, packaging, pip-tools, pyscss, pytest, python-dateutil, swagger-spec-validator
+six==1.10.0               # via cryptography, django-extensions, docker, docker-pycreds, drf-yasg, fabric3, faker, flex, libsass, mock, more-itertools, moto, pathlib2, pip-tools, pyscss, pytest, python-dateutil, python-jose, responses, swagger-spec-validator, websocket-client
 strict-rfc3339==0.7       # via flex
 swagger-spec-validator==2.1.0
 tornado==5.0.2            # via flower
@@ -119,6 +130,7 @@ uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.21.1           # via requests
 validate-email==1.3       # via flex
 vine==1.1.4               # via amqp
+websocket-client==0.48.0  # via docker
 werkzeug==0.12.2          # via moto
 whitenoise==3.3.1
 wrapt==1.10.11


### PR DESCRIPTION
Upgrade Django to 2.0.8

In preparation for later upgrade to Django 2.1 (which is blocking on fixes to django-model-utils), upgrade these packages:

- pytest-django
- moto
- djangorestframework
- django-storages
- django-filter

Some tweaks to support those upgrades.