### PR TITLE
Tweak case API format

### DIFF
--- a/capstone/capapi/templates/home.html
+++ b/capstone/capapi/templates/home.html
@@ -200,7 +200,7 @@
           <pre><a href="/api/v1/cases/{{ case_id }}/">{{ request.build_absolute_uri }}api/v1/cases/{{ case_id }}/</a></pre>
 
           One or more cases with the same citation:
-          <pre><a href="/api/v1/cases/?cite={{ case_metadata.citations.0.normalized_cite }}/">{{ request.build_absolute_uri }}api/v1/cases/?cite={{ case_metadata.citations.0.normalized_cite }}/</a></pre>
+          <pre><a href="/api/v1/cases/?cite={{ case_metadata.citations.0.cite }}">{{ request.build_absolute_uri }}api/v1/cases/?cite={{ case_metadata.citations.0.cite }}</a></pre>
           <!--<pre class="json-response">{{ case_metadata }}</pre>-->
           <p class="body-text subsection">Case text</p>
           A request for full case text must include the query parameter <code>full_case=true</code>:


### PR DESCRIPTION
At Greg's suggestion, this makes a few tweaks to the /cases/ endpoint:

- volume_url and volume_number are merged into a `volume` dict
- reporter_url and reporter name are merged into a `reporter` dict
- `normalized_cite` is dropped from the citations dict

Example output:

```
{
    "id": 3,
   ...
    "citations": [
        {
            "type": "official",
            "cite": "1 Ill. 17"
        }
    ],
    "volume": {
        "url": "http://localhost:8000/api/v1/volumes/32044057891608/",
        "volume_number": "1"
    },
    "reporter": {
        "url": "http://localhost:8000/api/v1/reporters/1058/",
        "full_name": "Illinois Reports"
    },
```