### PR TITLE
Tweak case browser display

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -101,6 +101,23 @@ class CaseFilter(filters.FilterSet):
         label='Docket Number (contains)',
         lookup_expr='icontains')
 
+    # These aren't really filters, but are used elsewhere in preparing the response.
+    # Included here so they'll show up in the UI.
+    full_case = filters.ChoiceFilter(
+        method='noop',
+        label='Include full case text or just metadata?',
+        choices=(('', 'Just metadata (default)'), ('true', 'Full case text')),
+    )
+    body_format = filters.ChoiceFilter(
+        method='noop',
+        label='Format for case text (applies only if including case text)',
+        choices=(('text', 'text only (default)'), ('html', 'HTML'), ('xml', 'XML')),
+    )
+
+    def noop(self, qs, name, value):
+        """ Not really a filter -- do nothing. """
+        return qs
+
     def find_by_citation(self, qs, name, value):
         return qs.filter(citations__normalized_cite__exact=models.Citation.normalize_cite(value))
 

--- a/capstone/static/css/scss/api.scss
+++ b/capstone/static/css/scss/api.scss
@@ -64,8 +64,11 @@
 .breadcrumb {
   margin-top: 60px;
   font-size: 14px;
-  li {
-    margin-left: 10px;
+  li::after {
+    display: inline-block;
+    content: '\00bb';
+    margin: 0 .6em;
+    color: #959fa5;
   }
 }
 
@@ -96,4 +99,9 @@ nav {
     background: $color-light-blue;
     color: $color-blue;
   }
+}
+
+// hide "Get" button -- button itself doesn't do anything, and dropdown is broken from including bootstrap 4 instead of 3
+#get-form{
+  display:none;
 }


### PR DESCRIPTION
Just a couple minor tweaks to the API browser:

Add these >> between the breadcrumbs:

![image](https://user-images.githubusercontent.com/376272/44168673-0a21d100-a0a0-11e8-9b94-70a943681580.png)

HIde this broken button:

![image](https://user-images.githubusercontent.com/376272/44168708-1c037400-a0a0-11e8-9031-63c16a8e88ec.png)

Add these options to "Filters" to expose the full_case and body_format options:

![image](https://user-images.githubusercontent.com/376272/44168774-4fde9980-a0a0-11e8-999f-8c7672f49755.png)

I don't love how we're exposing the various options here, but it's a start. Doing better I think means providing separate templates for the case list and case detail endpoints, which is a little tricky in DRF -- you have to use separate classes for case list and case detail, and then use subclasses of capapi_renderers.BrowsableAPIRenderer to change the template. 🤢