### PR TITLE
Break out opinions in casebody text format

### DIFF
--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -107,13 +107,13 @@ def test_create_or_update_metadata(ingest_case_xml):
     ingest_case_xml.save()
     # fetch new metadata
     new_case_metadata = CaseMetadata.objects.get(pk=case_metadata.pk)
-    assert new_case_metadata.opinions == {"majority": new_author}
+    assert new_case_metadata.opinions == [{"type": "majority", "author": new_author}]
 
     # strip soft dashes
     ingest_case_xml.orig_xml = ingest_case_xml.orig_xml.replace(new_author, new_author + '\xad')
     ingest_case_xml.save()
     ingest_case_xml.metadata.refresh_from_db()
-    assert ingest_case_xml.metadata.opinions['majority'] == new_author
+    assert ingest_case_xml.metadata.opinions[0]['author'] == new_author
 
 @pytest.mark.django_db
 def test_denormalized_fields(case):

--- a/capstone/scripts/process_metadata.py
+++ b/capstone/scripts/process_metadata.py
@@ -51,16 +51,13 @@ def get_case_metadata(case_xml):
     judges = [judge.text for judge in parsed('casebody|judges')]
     attorneys = [attorney.text for attorney in parsed('casebody|attorneys')]
     parties = [party.text for party in parsed('casebody|parties')]
-
-    opinions = {}
-    for opinion in parsed('casebody|opinion'):
-        # sometimes authors are not included, default to ""
-        opinions[opinion.attrib['type']] = ""
-        for child in opinion.getchildren():
-            # record author for each opinion type
-            if 'author' in child.tag:
-                opinions[opinion.attrib['type']] = child.text
-
+    opinions = [
+        {
+            'type': opinion.attr('type'),
+            'author': opinion('casebody|author').text() or None,
+        }
+        for opinion in parsed.items('casebody|opinion')
+    ]
 
     return dict(metadata, **{
         'name': name,

--- a/capstone/scripts/tests/test_process_metadata.py
+++ b/capstone/scripts/tests/test_process_metadata.py
@@ -34,7 +34,7 @@ def test_get_case_metadata():
                     assert len(case_metadata["jurisdiction"]) > 0
                     assert type(case_metadata["decision_date"]) is datetime.date
                     assert type(case_metadata["decision_date_original"]) is str
-                    assert type(case_metadata["opinions"]) is dict
+                    assert type(case_metadata["opinions"]) is list
                     assert type(case_metadata["attorneys"]) is list
                     assert type(case_metadata["judges"]) is list
                     assert type(case_metadata["parties"]) is list
@@ -45,12 +45,11 @@ def test_case_metadata_opinion():
     case_xml = read_file(casemets_file)
     case_metadata = dict(process_metadata.get_case_metadata(case_xml))
     assert type(case_metadata["parties"]) is list
-    assert "majority" in case_metadata["opinions"]
+    assert case_metadata["opinions"][0] == {"type": "majority", "author": None}
 
     # test case with opinion author
     casemets_file = "test_data/from_vendor/32044057892259_redacted/casemets/32044057892259_redacted_CASEMETS_0001.xml"
     case_xml = read_file(casemets_file)
     case_metadata = dict(process_metadata.get_case_metadata(case_xml))
-    assert "majority" in case_metadata["opinions"]
-    assert "Lacey, J." in case_metadata["opinions"]["majority"]
+    assert case_metadata["opinions"][0] == {"type": "majority", "author": "Lacey, J."}
 


### PR DESCRIPTION
As discussed in cap-dev, this changes the "casebody" format for the default (json), html, and xml body_format options.

* Default format takes the single line of text and breaks it out into a dictionary with "head_matter", "judges", "attorneys", "parties", and "opinions".
* "opinions" is removed as a separate dict.
* "judges", "attorneys", "parties" are dropped from the "html" and "xml" formats, where they are redundant.

SO:

Default looks like this:

```
"casebody": {
    "status": "ok",
    "data": {
        "head_matter": "No. 06-278.\nMORSE et al. ...",
        "judges": [
            "Roberts, C. J., delivered the opinion of the Court ..."
        ],
        "attorneys": [
            "Kenneth W. Starr ...",
            "Deputy Solicitor General ...",
            "Douglas K. Mertz ..."
        ],
        "parties": [
            "MORSE et al. v. FREDERICK"
        ]
        "opinions": [
            {"kind": "majority", "author": "Chief Justice Roberts", "text": "Chief Justice Roberts delivered the opinion of the Court. At a school-sanctioned and school-supervised event ..."},
            {"kind": "concurrence", "author": "Justice Breyer,", "text": "..."},
            {"kind": "concurrence", "author": "Justice ...,", "text": "..."},
            {"kind": "concurrence", "author": "Justice ...,", "text": "..."},
            {"kind": "dissent", "author": "Justice ...,", "text": "..."},
        ]
    }
}
```

"xml" looks like this:

```
"casebody": {
    "status": "ok",
    "data": "<mets xmlns:xlink..."
}
```

"html" looks like this:

```
"casebody": {
    "status": "ok",
    "data": "<section class=\"casebody\"..."
}
```
