### PR TITLE
Add fab task to bulk export case JSON by jurisdiction

### DIFF
--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -338,6 +338,16 @@ def bag_reporter(name, zip_directory=".", zip_filename=None):
 
 
 @task
+def export_jurisdiction_json(name, out_path, body_format=""):
+    """ Write .jsonl.gz file of all cases for given jurisdiction to out_path. E.g. `fab export_jurisdiction_json:Ill.,ill.jsonl.gz,xml`. """
+    export.export_jurisdiction_json(name, out_path, body_format)
+
+@task
+def export_reporter_json(name, out_path, body_format=""):
+    """ Write .jsonl.gz file of all cases for given reporter to out_path. E.g. `fab export_reporter_json:Illinois Appellate Court Reports,ill-app.jsonl.gz,xml`. """
+    export.export_reporter_json(name, out_path, body_format)
+
+@task
 def write_inventory_files(output_directory=os.path.join(settings.BASE_DIR, 'test_data/inventory/data')):
     """ Create inventory.csv.gz files in test_data/inventory/data. Should be re-run if test_data/from_vendor changes. """
 


### PR DESCRIPTION
This is a first pass at a fab task to supplement or replace our current bulk downloads. The new downloads would mirror our API results, so Ill.zip would essentially be the same as saving all results from `/cases/?jurisdiction=ill` into a file. This is intended to be both smaller and easier to load into a program for bulk processing.

Results are saved in gzipped jsonlines format (one JSON object per line, for reading in series), so the file extension should be `.jsonl.gz`.

Results are almost identical to API results, except that all "url" fields are dropped.

We would offer two versions of each download: one with just text, for NLP, and one with XML if you care about styles, pagination, citation markup or the like. So a given jurisdiction would have two exports:

`fab export_jurisdiction_json:Ill.,ill-text.jsonl.gz`
`fab export_jurisdiction_json:Ill.,ill-xml.jsonl.gz,xml`