### PR TITLE
Case edit tweaks

### DIFF
--- a/capstone/capdb/admin.py
+++ b/capstone/capdb/admin.py
@@ -50,7 +50,7 @@ class CachedCountMixin(object):
 
 @admin.register(VolumeXML)
 class VolumeXMLAdmin(SimpleHistoryAdmin):
-    pass
+    raw_id_fields = ['metadata']
 
 
 @admin.register(CaseMetadata)
@@ -103,7 +103,7 @@ class PageXMLAdmin(CachedCountMixin, SimpleHistoryAdmin):
 @admin.register(CaseXML)
 class CaseXMLAdmin(CachedCountMixin, SimpleHistoryAdmin):
     inlines = [CasePageInline]
-    raw_id_fields = ['volume']
+    raw_id_fields = ['volume', 'metadata']
 
 
 @admin.register(TrackingToolLog)

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -585,7 +585,7 @@ def count_case_totals(write_to_file=True, min_year=1640):
         return results
 
 @task
-def fix_court_names():
+def fix_court_names(dry_run=False):
 
     def update_cases(old_court_entry, stripped_name, stripped_abbrev, new_court_entry = None):
         for case_metadata in old_court_entry.case_metadatas.all():
@@ -616,6 +616,9 @@ def fix_court_names():
             # We are assuming that the first entry, organized by slug, is the correct one.
             if similar_court:
                 print("- Replacing %s with %s" % (court.name, similar_court.name))
+                if dry_run:
+                    continue
+
                 update_cases(court, stripped_name, stripped_abbrev, similar_court)
 
                 # we delete the court once we confirm that there are no more cases associated with it
@@ -629,10 +632,15 @@ def fix_court_names():
             # If there are no other similar courts, let's correct this name and cases
             else:
                 print("- Changing %s to %s" % (court.name, similar_court.name))
+                if dry_run:
+                    continue
+
+                update_cases(court, stripped_name, stripped_abbrev)
+
+                # update court to match new cases
                 court.name = stripped_name
                 court.name_abbreviation = stripped_abbrev
                 court.save()
-                update_cases(court, stripped_name, stripped_abbrev)
 
 
 @task


### PR DESCRIPTION
Two updates to earlier PRs today:

- additional fields that need raw_id_fields in admin
- add dry_run option and change save order for `fix_court_names` task