### PR TITLE
Export tweaks 2

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -142,18 +142,11 @@ class CaseFilter(filters.FilterSet):
 
 class CaseExportFilter(filters.FilterSet):
     with_old = filters.ChoiceFilter(
-        field_name='jurisdiction_slug',
+        field_name='with_old',
         label='Include previous versions of files?',
         choices=(('true', 'Include previous versions of files'), ('false', 'Only include newest version of each file')),
-        method='find_with_old',
+        method='noop',  # handled by CaseExportViewSet.filter_queryset()
     )
-
-    def __init__(self, data, *args, **kwargs):
-        # make sure with_old defaults to "false", so we apply the filter in find_with_old by default
-        if data.get('with_old') != 'true':
-            data = data.copy()
-            data['with_old'] = 'false'
-        super().__init__(data, *args, **kwargs)
 
     class Meta:
         model = models.CaseExport
@@ -163,9 +156,6 @@ class CaseExportFilter(filters.FilterSet):
             'filter_id': ['exact'],
         }
 
-    def find_with_old(self, qs, name, value):
-        """ Unless user requests otherwise with with_old=true, only show latest version of each export. """
-        if value != 'true':
-            qs = qs.exclude_old()
+    def noop(self, qs, name, value):
+        """ Not really a filter -- do nothing. """
         return qs
-

--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -1,6 +1,7 @@
 import hashlib
 
 from django.conf import settings
+from django.http.response import HttpResponseBase
 from django.template import loader
 from rest_framework import renderers
 
@@ -68,14 +69,16 @@ class BrowsableAPIRenderer(renderers.BrowsableAPIRenderer):
         return super().get_filter_form(data, view, request)
 
 
-class PassthroughRenderer(renderers.BaseRenderer):
+class PassthroughRenderer(renderers.JSONRenderer):
     """
         Return data as-is. View should supply a Response.
     """
     media_type = 'application/json'  # used only for rendering errors
     format = ''
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        return data
+        if isinstance(data, HttpResponseBase):
+            return data
+        return super().render(data, accepted_media_type, renderer_context)
 
 
 def generate_xml_error(error_text, message_text):

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -68,7 +68,7 @@ def check_exports(case, filter_item, tmpdir):
 
 
 @pytest.mark.django_db
-def test_bag_jurisdiction(case_xml, tmpdir):
+def test_bag_jurisdiction(case_xml, tmpdir, django_assert_num_queries):
     # setup
     case = case_xml.metadata
     jurisdiction = case.jurisdiction
@@ -76,7 +76,8 @@ def test_bag_jurisdiction(case_xml, tmpdir):
     jurisdiction.save()
 
     # bag the jurisdiction
-    fabfile.bag_jurisdiction(jurisdiction.name)
+    with django_assert_num_queries(select=4, insert=2):
+        fabfile.bag_jurisdiction(jurisdiction.name)
     check_exports(case, jurisdiction, tmpdir)
 
 

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -608,7 +608,6 @@ def fix_court_names(dry_run=False):
 
             # see if there are any entries which already have the correct court name/abbr/jur
             similar_court = Court.objects.order_by('slug')\
-                .prefetch_related('case_metadatas__case_xml')\
                 .filter(name=stripped_name, name_abbreviation=stripped_abbrev, jurisdiction=court.jurisdiction)\
                 .first()
 

--- a/capstone/scripts/export.py
+++ b/capstone/scripts/export.py
@@ -67,7 +67,9 @@ def export_queryset(queryset, dir_name, filter_item, public=False):
         public controls whether export is downloadable by non-researchers.
     """
     formats = {'xml': {}, 'text': {}}
-    queryset = queryset.order_by('id')
+    
+    # we can safely select_related case_xml because we fetch these in blocks of 1000 via ordered_query_iterator
+    queryset = queryset.select_related('case_xml').order_by('id')
 
     try:
         # set up vars for each format

--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -253,9 +253,11 @@ def ordered_query_iterator(queryset, chunk_size=1000):
     filter = Q()
     while True:
         obj = None
+        i = 0
         for obj in queryset.filter(filter)[:chunk_size]:
             yield obj
-        if not obj:
+            i += 1
+        if i < chunk_size:
             break
         filter = get_filter(order_by, obj)
             


### PR DESCRIPTION
- Tweaked the export query to fetch XML in blocks of 1000, which should save a few minutes per export
- Fixed the API view that lets you download previous versions of exports
- Fixed the unnecessary inefficient query from `fab fix_court_names:dry_run=1`