### PR TITLE
Add full_url templatetag

### DIFF
--- a/capstone/capweb/templates/api.html
+++ b/capstone/capweb/templates/api.html
@@ -1,6 +1,7 @@
 {% extends "main_base.html" %}
 {% load static %}
 {% load pipeline %}
+{% load full_url %}
 
 {% block extra_head %}
   {% stylesheet 'tools' %}
@@ -96,7 +97,7 @@
                   Case Browse/Search Endpoint
                 </dt>
                 <dd>
-                  <a href="/api/v1/cases/">{{ request.build_absolute_uri }}api/v1/cases/</a>
+                  <a href="{% url "casemetadata-list" %}">{% full_url "casemetadata-list" %}</a>
                 </dd>
                 <dd>
                   <p>

--- a/capstone/capweb/templatetags/full_url.py
+++ b/capstone/capweb/templatetags/full_url.py
@@ -1,0 +1,9 @@
+from django import template
+from rest_framework.reverse import reverse
+
+register = template.Library()
+
+@register.simple_tag(takes_context=True)
+def full_url(context, url_name, *args, **kwargs):
+    """ Like the {% url %} tag, but output includes the full domain. """
+    return reverse(url_name, args=args, kwargs=kwargs, request=context.request)


### PR DESCRIPTION
There's an issue on prod where API urls in the docs have an extra /api/ in them, like `https://capapi.org/api/api/v1/cases/`. I think @ChefAndy is still working on the docs in general, so I just wanted to toss in a bit of Django magic to help with the URL bit. This provides a `{% full_url %}` template tag and an example of using it. You can run `./manage.py show_urls` to get a list of all the URL names.