### PR TITLE
Use DEFAULT_FROM_EMAIL for email

### DIFF
--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -47,7 +47,7 @@ def send_new_signup_email(request, user):
     send_mail(
         'CaseLaw Access Project: Verify your email address',
         "Please click here to verify your email address: \n\n%s \n\nIf you believe you have received this message in error, please ignore it." % token_url,
-        settings.API_EMAIL_ADDRESS,
+        settings.DEFAULT_FROM_EMAIL,
         [user.email],
         fail_silently=False, )
     logger.info("sent new_signup email for %s" % user.email)

--- a/capstone/capapi/tasks.py
+++ b/capstone/capapi/tasks.py
@@ -23,8 +23,8 @@ User emails:
 
 %s
         """ % (site_limits.daily_downloads, site_limits.daily_signups, "\n".join(users_created_today)),
-        settings.API_EMAIL_ADDRESS,
-        [settings.API_EMAIL_ADDRESS],
+        settings.DEFAULT_FROM_EMAIL,
+        [settings.DEFAULT_FROM_EMAIL],
         fail_silently=False,
     )
 

--- a/capstone/capapi/views/user_views.py
+++ b/capstone/capapi/views/user_views.py
@@ -46,7 +46,7 @@ def verify_user(request, user_id, activation_nonce):
             user.total_case_allowance = user.case_allowance_remaining = settings.API_CASE_DAILY_ALLOWANCE
             user.save()
     return render(request, 'registration/verified.html', {
-        'contact_email': settings.API_EMAIL_ADDRESS,
+        'contact_email': settings.DEFAULT_FROM_EMAIL,
         'error': error,
         'page_name': 'user-verify'
     })
@@ -71,7 +71,7 @@ def resend_verification(request):
                 'message': 'Thank you. Please check your email %s for a verification link.' % user.email
             })
     return render(request, 'registration/resend-nonce.html', {
-        'info_email': settings.API_EMAIL_ADDRESS,
+        'info_email': settings.DEFAULT_FROM_EMAIL,
         'form': form,
         'page_name': 'user-resend-verification'
     })

--- a/capstone/capweb/resources.py
+++ b/capstone/capweb/resources.py
@@ -10,7 +10,7 @@ def send_contact(data):
     subject = data.get('subject')
     message = data.get('message')
     email = data.get('email')
-    recipient_list = [settings.EMAIL_ADDRESS]
+    recipient_list = [settings.DEFAULT_FROM_EMAIL]
     send_mail(subject, message, email, recipient_list, fail_silently=False)
 
     logger.info("%s sent contact email" % email)

--- a/capstone/capweb/tests/test_ui.py
+++ b/capstone/capweb/tests/test_ui.py
@@ -47,7 +47,7 @@ def test_contact(client, auth_client):
     response = client.get(reverse('contact'))
     soup = BeautifulSoup(response.content.decode(), 'html.parser')
     email = soup.find('a', {'class': 'contact_email'})
-    assert email.get('href').split("mailto:")[1] == settings.EMAIL_ADDRESS
+    assert email.get('href').split("mailto:")[1] == settings.DEFAULT_FROM_EMAIL
     assert not soup.find('input', {'id': 'id_email'}).get('value')
 
     response = auth_client.get(reverse('contact'))

--- a/capstone/capweb/views.py
+++ b/capstone/capweb/views.py
@@ -56,7 +56,7 @@ def contact(request):
 
     return render(request, 'contact.html', {
         "form": form,
-        "email": settings.EMAIL_ADDRESS
+        "email": settings.DEFAULT_FROM_EMAIL
     })
 
 

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -396,9 +396,6 @@ CACHED_COUNT_TIMEOUT = 60*60*24  # 'count' value in API responses is cached for 
 API_FULL_URL = os.path.join(API_BASE_URL_ROUTE, API_VERSION)
 API_CASE_FILE_TYPE = '.xml'
 
-# BULK DATA
-BULK_DATA_DIR = os.path.join(BASE_DIR, 'bulk-data')
-
 # DATA VISUALIZATION
 DATA_COUNT_DIR = '/tmp/count-data'
 

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -396,23 +396,21 @@ CACHED_COUNT_TIMEOUT = 60*60*24  # 'count' value in API responses is cached for 
 API_FULL_URL = os.path.join(API_BASE_URL_ROUTE, API_VERSION)
 API_CASE_FILE_TYPE = '.xml'
 
-# CAP API EMAIL #
-API_ADMIN_EMAIL_ADDRESS = 'main-email-address@example.com'
-API_EMAIL_ADDRESS = 'admin-email-address@example.com'
-
 # BULK DATA
 BULK_DATA_DIR = os.path.join(BASE_DIR, 'bulk-data')
 
 # DATA VISUALIZATION
 DATA_COUNT_DIR = '/tmp/count-data'
 
+# EMAIL
 EMAIL_USE_TLS = True
 EMAIL_HOST = 'localhost'
 EMAIL_PORT = 25
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 EMAIL_HOST_USER = 'user-secret'
 EMAIL_HOST_PASSWORD = 'secret-secret'
-EMAIL_ADDRESS = 'info@example.com'
+DEFAULT_FROM_EMAIL = 'info@example.com'
+SERVER_EMAIL = 'info@example.com'
 
 # redis
 REDIS_HOST = 'localhost'

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -43,8 +43,6 @@ TEST_SLOW_QUERIES_DB_NAME = 'capstone_test_queries'
 # avoid test errors when running tests locally, since pytest-django sets DEBUG=False and staticfiles/ doesn't exist
 STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 
-BULK_DATA_DIR = os.path.join(BASE_DIR, 'test_data/bulk-data')
-
 # django-debug-toolbar
 try:
     import debug_toolbar  # noqa


### PR DESCRIPTION
Our settings included `API_ADMIN_EMAIL_ADDRESS`, `API_EMAIL_ADDRESS`, and `EMAIL_ADDRESS`. This PR drops those and replaces with `DEFAULT_FROM_EMAIL`, a built-in Django setting that is also used by Django itself.

This PR also adds `SERVER_EMAIL` (which Django uses for error messages) and drops `BULK_DATA_DIR` (which is unused).

*Deployment notes:*

Change salt config:

- Set `SERVER_EMAIL` and `DEFAULT_FROM_EMAIL` to our main contact email.
- Unset `API_ADMIN_EMAIL_ADDRESS`, `API_EMAIL_ADDRESS`, `EMAIL_ADDRESS`, and `BULK_DATA_DIR` if they are being set.