### PR TITLE
Nav style tweaks

### DIFF
--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -8,20 +8,20 @@
 </div>
 
 <nav aria-label="main">
-    <div class="branding large-screen">
-      <a class="nav-branding" href="{% url "home" %}"></a>
+  <div class="branding large-screen">
+    <a class="nav-branding" href="{% url "home" %}"></a>
+  </div>
 
-    </div>
+  <button id="burger-icon">
+    <div class="burger-item"></div>
+    <div class="burger-item"></div>
+    <div class="burger-item"></div>
+  </button>
 
-    <button id="burger-icon">
-      <div class="burger-item"></div>
-      <div class="burger-item"></div>
-      <div class="burger-item"></div>
-    </button>
   <div class="nav-content">
     <ul class="nav">
       <li class="nav-item dropdown" id="nav-about">
-        <a class="nav-link dropdown-toggle "
+        <a class="nav-link dropdown-toggle"
            href="#" id="navbar-dropdown-about"
            role="button"
            aria-haspopup="true"
@@ -37,7 +37,7 @@
         </div>
       </li>
       <li class="nav-item dropdown" id="nav-tools">
-        <a class="nav-link dropdown-toggle "
+        <a class="nav-link dropdown-toggle"
            href="#" id="navbar-dropdown-tools"
            role="button"
            aria-haspopup="true"
@@ -68,14 +68,14 @@
 
       <li class="nav-item" id="nav-account">
         {% if request.user.is_authenticated %}
-        <a class="nav-link" href="{% url "user-details" %}">
-          ACCOUNT
-        </a>
+          <a class="nav-link" href="{% url "user-details" %}">
+            ACCOUNT
+          </a>
         {% else %}
-        <a class="nav-link "
-           href="{% url "login" %}">
-          LOG IN
-        </a>
+          <a class="nav-link "
+             href="{% url "login" %}">
+            LOG IN
+          </a>
         {% endif %}
       </li>
       <li class="nav-item" id="nav-contact">

--- a/capstone/static/css/scss/_nav.scss
+++ b/capstone/static/css/scss/_nav.scss
@@ -45,6 +45,7 @@ nav[aria-label="main"] {
   font-weight: $font-weight-normal;
   letter-spacing: 0.1em;
   z-index: 1;
+  user-select: none;
   @include media-breakpoint-up(lg) {
     -webkit-box-shadow: 0 1px 5px $color-violet-gray-dark;
     -moz-box-shadow: 0 1px 5px $color-violet-gray-dark;
@@ -68,25 +69,27 @@ nav[aria-label="main"] {
   }
 
   @include media-breakpoint-down(md) {
-    position: fixed;
-    height: 100%;
+    position: absolute;
     width: 260px;
     background-color: $color-black;
+    border: 1px white solid;
   }
 
   .dropdown-menu {
-    > a {
+    background-color: $color-black;
+    a {
       font-weight: $font-weight-normal;
       color: $color-white;
       border-bottom: $border-width solid $color-white;
       padding-bottom: 15px;
     }
-    > a:hover, a:focus, a:active {
+    a:hover, a:focus, a:active {
       background-color: $color-yellow;
       color: $color-black;
     }
-    > a:last-child { border-bottom: 0 }
-    background-color: $color-black;
+    a:last-child {
+      border-bottom: 0;
+    }
     @include media-breakpoint-up(lg) {
       margin-top: 26px;
       border-left: $border-width solid $color-white;
@@ -94,7 +97,10 @@ nav[aria-label="main"] {
       border-bottom: $border-width solid $color-white;
     }
     @include media-breakpoint-down(md) {
-      > a:before {
+      a {
+        border: none;
+      }
+      a:before {
         color: $color-violet;
         content: "\0226B  ";
       }
@@ -106,10 +112,11 @@ nav[aria-label="main"] {
 li.nav-item.dropdown {
   > a.nav-link:after {
     content: url('../../img/arrow-expand.svg');
+    display: inline-block;
   }
   &.show {
     > a:after {
-      content: "\02212";
+      transform: rotate(180deg);
     }
   }
 }
@@ -134,10 +141,10 @@ li.nav-item.dropdown {
   color: $color-white;
   padding: 0.5rem;
   &:hover, &:active, &:focus {
-    color: $color-yellow-bright;
+    color: $color-yellow-bright!important;
   }
   &.selected {
-    color: $color-yellow;
+    color: $color-yellow!important;
   }
 }
 
@@ -194,36 +201,24 @@ body.hamburger-menu-open {
 body.hamburger-menu-closed {
   overflow-y: scroll;
   .nav-content {
-    @include media-breakpoint-down(md) {
-      display: none;
-    }
     padding: 10px 20px;
     right: -85%;
     z-index: -1;
-    transition: height 0s .14s linear,visibility 0s .14s linear;
-  }
-  .main-content {
-    position: relative;
-    left: 0;
-    transition: transform .14s ease-in-out;
+    transition: all .14s ease-in-out;
   }
 }
 
 body.hamburger-menu-open {
-  overflow-y: hidden;
   .nav-content {
     right: 0;
-    transition: height 0s .14s linear,visibility 0s .14s linear;
+    transition: all .14s ease-in-out;
     z-index: 1;
-  }
-  .main-content {
-    position: relative;
-    transform: translatex(-260px) translatez(0);
+    overflow: scroll;
   }
   .nav-link {
     margin-left: 2rem;
   }
   .dropdown-item {
-    padding-left: 2rem;
+    padding-left: 3rem;
   }
 }

--- a/capstone/static/js/custom.js
+++ b/capstone/static/js/custom.js
@@ -8,19 +8,27 @@ let patchAnchorTagButtons = function () {
   })
 }
 
-let setupDropdown = function () {
-    let dropdown = ".dropdown";
-    $(dropdown).click(function(e) {
-        let showingDropdown = $(this).hasClass("show");
-        $(dropdown).removeClass("show");
-        showingDropdown ? $(this).removeClass("show") : $(this).addClass("show");
+const hideDropdown = function(dropdown) {
+  dropdown.removeClass("show");
+  dropdown.find("> a").attr("aria-expanded", "false");
+};
 
-        e.stopPropagation();
-    });
+const showDropdown = function(dropdown){
+  dropdown.addClass("show");
+  dropdown.find("> a").attr("aria-expanded", "true");
+};
 
-    $(document).click(function(){
-      $(dropdown).removeClass("show");
-    });
+const setupDropdown = function () {
+  const dropdowns = $(".dropdown");
+  dropdowns.click(function(e) {
+    const dropdown = $(this);
+    const showingDropdown = dropdown.hasClass("show");
+    hideDropdown(dropdowns);  // close other dropdowns
+    showingDropdown ? hideDropdown(dropdown) : showDropdown(dropdown);
+    e.stopPropagation();
+  });
+
+  $(document).click(function(){ hideDropdown(dropdowns) });
 };
 
 let setupBurgerAction = function() {
@@ -39,7 +47,7 @@ let selectedNavStyling = function() {
   path = path.split('#')[0];
   path = path === 'user' ? 'account': path;
   path = path === 'bulk-access' || path === 'api' ? 'tools': path;
-  $('#nav-' + path).find('a').addClass('selected');
+  $('#nav-' + path).find('a').addClass('selected').attr('aria-current', 'page');
 };
 
 $(function() {


### PR DESCRIPTION
I made some suggested changes -- feel free to reject/suggest further tweaks/take a whack at it.

- Nav animates when sliding in as well as out
- Main content does not slide anymore (I found that there was a janky flash of white underneath the nav when animating the main content, and I don't think it's necessary)
- Page will still scroll while nav is open, and hamburger nav is as high as it wants to be instead of 100% (I found that not all menu items were always reachable otherwise, and it also keeps the page usable if a user can't get to the close button)
- Menu text can't be accidentally selected (which caused confusing highlights if you dragged a bit while clicking)
- Open menu glyph is "^" instead of "–" to keep items from changing width when opening
- Tweak padding and borders for hamburger items
- Accessibility: JS updates "aria-current" and "aria-expanded"
- Make sure current-page highlight color doesn't get overridden by default styles

Before:

![image](https://user-images.githubusercontent.com/376272/45574290-8b09ef00-b83d-11e8-9445-35586d634c06.png)

After:

![image](https://user-images.githubusercontent.com/376272/45574294-8e04df80-b83d-11e8-8064-e7fab3038bd3.png)
