### PR TITLE
Database-related tweaks for Docker installation

### DIFF
--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -1,7 +1,10 @@
 version: '2'
 services:
     db:
-        image: postgres:9.6
+        build:
+          context: ../services/docker
+          dockerfile: extended-postgres.dockerfile
+        image: extended-postgres
         environment:
             POSTGRES_PASSWORD: password
         volumes:

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -21,6 +21,7 @@ services:
         image: capstone
         volumes:
             - .:/app
+            - ../services:/services
         depends_on:
             - redis
             - db
@@ -33,6 +34,7 @@ services:
         image: capstone
         volumes:
             - .:/app
+            - ../services:/services
         depends_on:
             - redis
             - db

--- a/services/docker/extended-postgres.dockerfile
+++ b/services/docker/extended-postgres.dockerfile
@@ -1,0 +1,8 @@
+FROM postgres:9.6
+
+RUN apt-get update && \
+    apt-get install -y libpq-dev && \
+    apt-get install -y postgresql-9.6-plv8
+
+# One could add temporal_tables installation here,
+# if one could get it working.... non-trivial


### PR DESCRIPTION
- Mounts the `services` directory so that `/services/postgres` directory is available to `fab init_db`. Mounts the whole `services` directory rather than just the `postgres` subdirectory in case other dependencies: can tease out later if it proves helpful
- Customizes postgres to include to plv8 extension. I attempted to install temporal_tables as well, but kept running into issues (the image's python is too old; missing make dependencies, etc.) and Andy suggested it wasn't worth it)

With these tweaks, the docker installation instructions in the README worked perfectly! 