### PR TITLE
Some accessibility tweaks

### DIFF
--- a/capstone/capweb/templates/about.html
+++ b/capstone/capweb/templates/about.html
@@ -31,13 +31,15 @@ About the Caselaw Access Project
       </div>
       <div class="row">
         {# ==============> MENU <============== #}
-        <div class="list-group sidebar-menu">
-          <a class="list-group-item" href="#overview">Overview</a>
-          <a class="list-group-item" href="#data">What data?</a>
-          <a class="list-group-item" href="#usage">Usage &amp; access</a>
-          <a class="list-group-item" href="#press">Press</a>
-          <a class="list-group-item" href="#contributors">Contributors</a>
-        </div>
+        <nav class="list-group sidebar-menu" aria-label="table of contents">
+          <ul>
+            <li><a class="list-group-item" href="#overview">Overview</a></li>
+            <li><a class="list-group-item" href="#data">What data?</a></li>
+            <li><a class="list-group-item" href="#usage">Usage &amp; access</a></li>
+            <li><a class="list-group-item" href="#press">Press</a></li>
+            <li><a class="list-group-item" href="#contributors">Contributors</a></li>
+          </ul>
+        </nav>
         {# ==============> CONTENT <============== #}
           <div class="content">
 

--- a/capstone/capweb/templates/api.html
+++ b/capstone/capweb/templates/api.html
@@ -31,17 +31,19 @@
       </div>
       <div class="row">
         {# ==============> MENU <============== #}
-        <div class="list-group sidebar-menu">
-          <a class="list-group-item" href="#overview">Overview</a>
-          <a class="list-group-item" href="#registration">Registration</a>
-          <a class="list-group-item" href="#usage">Using CAPAPI</a>
-          <a class="list-group-item" href="#beginners">Begginer's Introduction</a>
-          <a class="list-group-item" href="#examples">Usage Examples</a>
-          <a class="list-group-item" href="#endpoints">Endpoint Documentation</a>
-          <a class="list-group-item" href="#limits">Access Limits</a>
-          <a class="list-group-item" href="#problems">Problems</a>
-          <a class="list-group-item" href="#glossary">Glossary</a>
-        </div>
+        <nav class="list-group sidebar-menu" aria-label="table of contents">
+          <ul>
+            <li><a class="list-group-item" href="#overview">Overview</a></li>
+            <li><a class="list-group-item" href="#registration">Registration</a></li>
+            <li><a class="list-group-item" href="#usage">Using CAPAPI</a></li>
+            <li><a class="list-group-item" href="#beginners">Beginner's Introduction</a></li>
+            <li><a class="list-group-item" href="#examples">Usage Examples</a></li>
+            <li><a class="list-group-item" href="#endpoints">Endpoint Documentation</a></li>
+            <li><a class="list-group-item" href="#limits">Access Limits</a></li>
+            <li><a class="list-group-item" href="#problems">Problems</a></li>
+            <li><a class="list-group-item" href="#glossary">Glossary</a></li>
+          </ul>
+        </nav>
         {# ==============> CONTENT <============== #}
         <div class="content">
 

--- a/capstone/capweb/templates/gallery.html
+++ b/capstone/capweb/templates/gallery.html
@@ -53,7 +53,7 @@ Caselaw Access Project gallery
             <div class="row">
               <div class="project-image">
                 <a href="https://opencasebook.org/"
-                   aria-label="Go to H2O homepage"
+                   aria-label="H2O homepage"
                    title="H2O homepage"
                    target="_blank">
                   <img class="main-img rounded"
@@ -83,7 +83,7 @@ Caselaw Access Project gallery
 
                   <span class="website">
                     <a href="https://opencasebook.org/"
-                       aria-label="Go to H2O homepage"
+                       aria-label="H2O homepage"
                        title="H2O homepage"
                        target="_blank">
                     </a>
@@ -100,7 +100,7 @@ Caselaw Access Project gallery
               <div class="project-image">
                 <a href="{% url "wordclouds" %}"
                    title="Wordcloud homepage"
-                   aria-label="Go to wordclouds example">
+                   aria-label="Wordcloud homepage">
                   <img class="main-img rounded"
                      alt=""
                      src="{% static "img/wordclouds-1933.png" %}">
@@ -124,7 +124,7 @@ Caselaw Access Project gallery
                   <span class="website">
                     <a href="{% url "wordclouds" %}"
                        title="Wordcloud homepage"
-                       aria-label="Go to wordclouds example"></a>
+                       aria-label="Wordcloud homepage"></a>
                   </span>
                 </p>
               </div>
@@ -136,7 +136,7 @@ Caselaw Access Project gallery
             <div class="row">
               <div class="project-image">
                 <a href="{% url "limericks" %}"
-                   aria-label="Go to limericks example">
+                   aria-label="Limericks homepage">
                   <img class="main-img"
                      alt=""
                      src="{% static "img/limerick.png" %}">
@@ -161,7 +161,7 @@ Caselaw Access Project gallery
                   <span class="website">
                     <a href="{% url "limericks" %}"
                        title="Limericks homepage"
-                       aria-label="Go to limericks example"></a>
+                       aria-label="Limericks homepage"></a>
                   </span>
                 </p>
               </div>

--- a/capstone/capweb/templates/gallery.html
+++ b/capstone/capweb/templates/gallery.html
@@ -57,7 +57,7 @@ Caselaw Access Project gallery
                    title="H2O homepage"
                    target="_blank">
                   <img class="main-img rounded"
-                     alt="Wordcloud from 1930, California"
+                     alt=""
                      src="{% static "img/h2o.png" %}">
                 </a>
               </div>
@@ -102,7 +102,7 @@ Caselaw Access Project gallery
                    title="Wordcloud homepage"
                    aria-label="Go to wordclouds example">
                   <img class="main-img rounded"
-                     alt="Wordcloud from 1930, California"
+                     alt=""
                      src="{% static "img/wordclouds-1933.png" %}">
                 </a>
               </div>
@@ -138,7 +138,7 @@ Caselaw Access Project gallery
                 <a href="{% url "limericks" %}"
                    aria-label="Go to limericks example">
                   <img class="main-img"
-                     alt="Limericks out of caselaw text"
+                     alt=""
                      src="{% static "img/limerick.png" %}">
                 </a>
               </div>

--- a/capstone/capweb/templates/gallery.html
+++ b/capstone/capweb/templates/gallery.html
@@ -30,11 +30,13 @@ Caselaw Access Project gallery
       </div>
       <div class="row">
         {# ==============> MENU <============== #}
-        <div class="list-group sidebar-menu">
-          <a class="list-group-item" href="#h2o">H2O</a>
-          <a class="list-group-item" href="#wordclouds">Wordclouds</a>
-          <a class="list-group-item" href="#limericks">Limericks</a>
-        </div>
+        <nav class="list-group sidebar-menu" aria-label="table of contents">
+          <ul>
+            <li><a class="list-group-item" href="#h2o">H2O</a></li>
+            <li><a class="list-group-item" href="#wordclouds">Wordclouds</a></li>
+            <li><a class="list-group-item" href="#limericks">Limericks</a></li>
+          </ul>
+        </nav>
         {# ==============> CONTENT <============== #}
         <div class="content">
 

--- a/capstone/capweb/templates/gallery.html
+++ b/capstone/capweb/templates/gallery.html
@@ -77,8 +77,8 @@ Caselaw Access Project gallery
                 <p class="social">
                   <span class="github">
                     <a href="https://github.com/harvard-lil/h2o" target="_blank"
-                       title="H2O source code"
-                       aria-label="Go to wordclouds source code"></a>
+                       title="H2O source code on Github"
+                       aria-label="H2O source code on Github"></a>
                   </span>
 
                   <span class="website">
@@ -113,13 +113,13 @@ Caselaw Access Project gallery
                   </a>
                 </h6>
                 <p>
-                  Most used words for every year of California caselaw from 1852 to 2015.
+                  Graphics showcasing the most-used words in California caselaw each year between 1852 and 2015.
                 </p>
                 <p class="social">
                   <span class="github">
                     <a href="https://github.com/harvard-lil/cap-examples/blob/master/make_wordclouds.py" target="_blank"
-                       title="Wordcloud source code"
-                       aria-label="Go to wordclouds source code"></a>
+                       title="Wordcloud source code on Github"
+                       aria-label="Wordcloud source code on Github"></a>
                   </span>
                   <span class="website">
                     <a href="{% url "wordclouds" %}"
@@ -154,8 +154,8 @@ Caselaw Access Project gallery
                 <p class="social">
                   <span class="github">
                     <a href="https://github.com/harvard-lil/cap-examples/blob/master/generate_limerick.py" target="_blank"
-                       title="Limericks source code"
-                       aria-label="Go to limericks source code"></a>
+                       title="Limericks source code on Github"
+                       aria-label="Limericks source code on Github"></a>
                   </span>
 
                   <span class="website">

--- a/capstone/capweb/templates/includes/footer.html
+++ b/capstone/capweb/templates/includes/footer.html
@@ -54,7 +54,7 @@
       </div>
       <div class="return-to-top">
         <a id="return"
-            onclick="returnToTop()"
+            onclick="returnToTop(event)"
             href="#">
           <span class="arrow">&uarr;</span>
           <br/>
@@ -67,7 +67,11 @@
 </footer>
 
 <script>
-  function returnToTop() {
+  function returnToTop(e) {
+    // ensure viewport scrolls all the way up
+    e.preventDefault();
     window.scrollTo(0, 0);
+    // ensure keyboard focus is reset
+    document.body.focus();
   }
 </script>

--- a/capstone/capweb/templates/includes/footer.html
+++ b/capstone/capweb/templates/includes/footer.html
@@ -5,7 +5,7 @@
       <div class="content-left">
         <a href="https://lil.law.harvard.edu"
            class="lil-logo"
-           title="Library Innovation Lab"
+           aria-label="Library Innovation Lab"
            target="_blank">
         </a>
       </div>

--- a/capstone/capweb/templates/includes/footer.html
+++ b/capstone/capweb/templates/includes/footer.html
@@ -11,34 +11,36 @@
       </div>
       <div class="content-right">
         <div class="text-right">
-          <ul class="list-inline links">
-            <li class="list-inline-item">
-              <a href="{% url "home" %}">HOME</a>
-            </li>
-            <li class="list-inline-item">
-              <a href="{% url "about" %}">ABOUT</a>
-            </li>
-            <li class="list-inline-item">
-              <a href="{% url "tools" %}">TOOLS</a>
-            </li>
-            <li class="list-inline-item">
-              <a href="{% url "gallery" %}">GALLERY</a>
-            </li>
-            <li class="list-inline-item">
-              {% if request.user.is_authenticated %}
-              <a href="{% url "user-details" %}">
-                ACCOUNT
-              </a>
-              {% else %}
-              <a href="{% url "login" %}">
-                LOG IN
-              </a>
-              {% endif %}
-            </li>
-            <li class="list-inline-item">
-              <a href="{% url "contact" %}">CONTACT</a>
-            </li>
-          </ul>
+          <nav aria-label="footer">
+            <ul class="list-inline links">
+              <li class="list-inline-item">
+                <a href="{% url "home" %}">HOME</a>
+              </li>
+              <li class="list-inline-item">
+                <a href="{% url "about" %}">ABOUT</a>
+              </li>
+              <li class="list-inline-item">
+                <a href="{% url "tools" %}">TOOLS</a>
+              </li>
+              <li class="list-inline-item">
+                <a href="{% url "gallery" %}">GALLERY</a>
+              </li>
+              <li class="list-inline-item">
+                {% if request.user.is_authenticated %}
+                <a href="{% url "user-details" %}">
+                  ACCOUNT
+                </a>
+                {% else %}
+                <a href="{% url "login" %}">
+                  LOG IN
+                </a>
+                {% endif %}
+              </li>
+              <li class="list-inline-item">
+                <a href="{% url "contact" %}">CONTACT</a>
+              </li>
+            </ul>
+          </nav>
           <p class="credits copyright">
             ©2017 The President and Fellows of Harvard University
           </p>

--- a/capstone/capweb/templates/includes/footer.html
+++ b/capstone/capweb/templates/includes/footer.html
@@ -56,7 +56,7 @@
         <a id="return"
             onclick="returnToTop(event)"
             href="#">
-          <span class="arrow">&uarr;</span>
+          <span class="arrow" aria-hidden="true">&uarr;</span>
           <br/>
           Return to top
         </a>

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -24,7 +24,6 @@
         <a class="nav-link dropdown-toggle "
            href="#" id="navbar-dropdown-about"
            role="button"
-           data-toggle="dropdown"
            aria-haspopup="true"
            aria-expanded="false">
           ABOUT
@@ -41,7 +40,6 @@
         <a class="nav-link dropdown-toggle "
            href="#" id="navbar-dropdown-tools"
            role="button"
-           data-toggle="dropdown"
            aria-haspopup="true"
            aria-expanded="false">
           TOOLS
@@ -56,7 +54,6 @@
         <a class="nav-link dropdown-toggle"
            href="#" id="navbar-dropdown-gallery"
            role="button"
-           data-toggle="dropdown"
            aria-haspopup="true"
            aria-expanded="false">
           GALLERY

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -1,6 +1,6 @@
 {% load static %}
 <a class="skip" href="#main">Skip to main content</a>
-<!-- On small screens, show logo on its own row --->
+<!-- On small screens, show logo on its own row -->
 <div class="row branding-standalone">
   <div class="branding small-screen">
     <a class="nav-branding" href="{% url "home" %}"></a>

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -7,7 +7,7 @@
   </div>
 </div>
 
-<nav>
+<nav aria-label="main">
     <div class="branding large-screen">
       <a class="nav-branding" href="{% url "home" %}"></a>
 

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -23,6 +23,7 @@
       <li class="nav-item dropdown" id="nav-about">
         <a class="nav-link dropdown-toggle "
            href="#" id="navbar-dropdown-about"
+           role="button"
            data-toggle="dropdown"
            aria-haspopup="true"
            aria-expanded="false">
@@ -39,6 +40,7 @@
       <li class="nav-item dropdown" id="nav-tools">
         <a class="nav-link dropdown-toggle "
            href="#" id="navbar-dropdown-tools"
+           role="button"
            data-toggle="dropdown"
            aria-haspopup="true"
            aria-expanded="false">
@@ -53,6 +55,7 @@
       <li class="nav-item dropdown" id="nav-gallery">
         <a class="nav-link dropdown-toggle"
            href="#" id="navbar-dropdown-gallery"
+           role="button"
            data-toggle="dropdown"
            aria-haspopup="true"
            aria-expanded="false">

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -1,7 +1,5 @@
 {% load static %}
-<a href="#main"
-   class="skip"
-   tabindex="0">Skip to main content</a>
+<a class="skip" href="#main">Skip to main content</a>
 <!-- On small screens, show logo on its own row --->
 <div class="row branding-standalone">
   <div class="branding small-screen">

--- a/capstone/capweb/templates/main_base.html
+++ b/capstone/capweb/templates/main_base.html
@@ -27,7 +27,7 @@
     {% javascript "base" %}
     {% block extra_head %}{% endblock %}
   </head>
-  <body class="hamburger-menu-closed">
+  <body class="hamburger-menu-closed" tabindex="-1">
     {% include "includes/nav.html" %}
     <div class="main-content flex-xl-nowrap"
          id="main"

--- a/capstone/capweb/templates/main_base.html
+++ b/capstone/capweb/templates/main_base.html
@@ -29,11 +29,9 @@
   </head>
   <body class="hamburger-menu-closed" tabindex="-1">
     {% include "includes/nav.html" %}
-    <div class="main-content flex-xl-nowrap"
-         id="main"
-         srole="main">
-        {% block content %}{% endblock content %}
-    </div>
+    <main class="main-content flex-xl-nowrap" id="main">
+      {% block content %}{% endblock content %}
+    </main>
 
     {% if not hide_footer %}
       {% include "includes/footer.html" %}

--- a/capstone/capweb/templates/tools.html
+++ b/capstone/capweb/templates/tools.html
@@ -30,11 +30,13 @@
       </div>
       <div class="row">
         {# ==============> MENU <============== #}
-        <div class="list-group sidebar-menu">
-          <a class="list-group-item" href="#overview">Overview</a>
-          <a class="list-group-item" href="{% url "api" %}">API</a>
-          <a class="list-group-item" href="{% url "bulk-data" %}">Bulk Data</a>
-        </div>
+        <nav class="list-group sidebar-menu" aria-label="table of contents">
+          <ul>
+            <li><a class="list-group-item" href="#overview">Overview</a></li>
+            <li><a class="list-group-item" href="{% url "api" %}">API</a></li>
+            <li><a class="list-group-item" href="{% url "bulk-data" %}">Bulk Data</a></li>
+          </ul>
+        </nav>
         {# ==============> CONTENT <============== #}
           <div class="content">
 

--- a/capstone/static/css/scss/_a11y.scss
+++ b/capstone/static/css/scss/_a11y.scss
@@ -16,3 +16,11 @@ a.skip:active,  a.skip:focus {
   z-index: 999;
   border-bottom: 0;
 }
+
+.fix-list-item {
+  /* Add zero-width space to work around Voiceover bug */
+  /* https://unfetteredthoughts.net/2017/09/26/voiceover-and-list-style-type-none/ */
+  &:before {
+    content: "\200B";
+  }
+}

--- a/capstone/static/css/scss/_nav-inverse.scss
+++ b/capstone/static/css/scss/_nav-inverse.scss
@@ -7,7 +7,7 @@
   }
 }
 
-nav {
+nav[aria-label="main"] {
   background-color: $color-white;
   webkit-box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),0 1px 5px 0 rgba(0,0,0,0.12),0 3px 1px -2px rgba(0,0,0,0.2);
   box-shadow: 0 2px 2px 0 rgba(0,0,0,0.14),0 1px 5px 0 rgba(0,0,0,0.12),0 3px 1px -2px rgba(0,0,0,0.2);

--- a/capstone/static/css/scss/_nav.scss
+++ b/capstone/static/css/scss/_nav.scss
@@ -34,7 +34,7 @@
 .branding.small-screen { display: none; }
 
 
-nav {
+nav[aria-label="main"] {
   display: inline-block;
   flex-wrap: wrap;
   padding: 0;

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -463,7 +463,7 @@ li.item-set {
     .list-group-item {
       border-bottom: $border-width solid $color-white;
     }
-    .list-group-item:last-child {
+    li:last-child .list-group-item {
       border-bottom: 0;
     }
   }

--- a/capstone/static/css/scss/footer.scss
+++ b/capstone/static/css/scss/footer.scss
@@ -51,6 +51,9 @@ footer {
   nav {
     border-bottom: 0;
   }
+  .links li {
+    @extend .fix-list-item;
+  }
   .return-to-top {
     @include make-col(12);
     font-weight: $font-weight-normal;

--- a/capstone/static/css/scss/footer.scss
+++ b/capstone/static/css/scss/footer.scss
@@ -48,7 +48,9 @@ footer {
       }
     }
   }
-
+  nav {
+    border-bottom: 0;
+  }
   .return-to-top {
     @include make-col(12);
     font-weight: $font-weight-normal;

--- a/capstone/static/js/custom.js
+++ b/capstone/static/js/custom.js
@@ -1,3 +1,13 @@
+// force link elements serving the role of buttons to respond correctly
+let patchAnchorTagButtons = function () {
+  document.querySelectorAll("a[role='button']").forEach(function(button){
+    // activate when the spacebar is pressed; the browser should not scroll (default behavior)
+    button.addEventListener('keypress', function(e){ if (e.key==' '||e.keyCode==32) { e.preventDefault(); this.click();}}, false);
+    // when activated, don't navigate/re-focus/scroll the browser, change the location bar, or alter your browsing history
+    button.addEventListener('click', function(e){ e.preventDefault(); }, false);
+  })
+}
+
 let setupDropdown = function () {
     let dropdown = ".dropdown";
     $(dropdown).click(function(e) {
@@ -36,4 +46,5 @@ $(function() {
   selectedNavStyling();
   setupDropdown();
   setupBurgerAction();
+  patchAnchorTagButtons();
 });


### PR DESCRIPTION
Here are a few suggestions for polishing the user experience for people navigating with keyboards and people using screen readers. No show stoppers, just icing!

Landmarks
-----------
- typo in "main" role prevented it from being recognized as such
- added a label for "main navigation" (could be 'primary', etc.)
- added  "footer navigation"
- added "table of contents navigation"

![image](https://user-images.githubusercontent.com/11020492/45651232-cbb47300-ba9e-11e8-821a-d6807374f656.png)
vs
![image](https://user-images.githubusercontent.com/11020492/45651258-eab30500-ba9e-11e8-8a2a-fd3bcbd6a8cc.png)
...which is available by list, but more interestingly is exposed to users as they tab through and enter landmark regions (e.g. "entering table of contents").


Keyboard navigation
---------------------
- "return to top" link works for keyboard users
- navigation bar dropdown "buttons" behave more like standard html buttons


Gallery page links and images
------------------------------
- make "homepage" vs. "example" language consistent (it's considered a good practice to use the same text each time you link to a single url, so people don't think they are two different pages)
- remove "go to", which is implied for links
- remove alt texts that will never be read (they are overridden by these links' aria-labels)
add github to github links' text, for the benefit of those who aren't informed by the icon

The `title` and `aria-label` attributes are redundant, but some users may genuinely benefit from the visual `title`-on-hover here, so I think it's fine, even if some automated testing may disagree.

See the commit messages to find the matching code.

I'll try and send another PR with a few more nits tomorrow: I thought this PR was becoming a little unmanageable lol.
