### PR TITLE
Semantic Headings

### DIFF
--- a/capstone/capapi/templates/400.html
+++ b/capstone/capapi/templates/400.html
@@ -2,11 +2,17 @@
 {% load pipeline %}
 
 {% block content %}
-  <div class="container header-margin">
-    <h3>Bad request</h3>
-    <p>
-      Your request resulted in a "400 Bad Request" response. If you see this error repeatedly,
-      please <a href="mailto:info@capapi.org">write to us</a> to let us know what's going wrong.
-    </p>
+  <div class="basic-page">
+    <div class="full-content">
+      <div class="row">
+        <h1 class="h3">Bad request</h1>
+        <p>
+          Your request resulted in a "400 Bad Request" response. If you see this error repeatedly,
+          please <a href="mailto:info@capapi.org">write to us</a> to let us know what's going wrong.
+        </p>
+      </div>
+    </div>
   </div>
 {% endblock %}
+
+{% block footer %}{% endblock %}

--- a/capstone/capapi/templates/403.html
+++ b/capstone/capapi/templates/403.html
@@ -2,13 +2,19 @@
 {% load pipeline %}
 
 {% block content %}
-  <div class="container header-margin">
-    <h3>Permission denied</h3>
-    <p>
-      You don't have permission to access this page. You may need to <a href="{% url "login" %}">log in</a>.
-    </p>
-    <p>
-      Please <a href="mailto:info@capapi.org">write to us</a> if you think this is a mistake.
-    </p>
+  <div class="basic-page">
+    <div class="full-content">
+      <div class="row">
+        <h1 class="h3">Permission denied</h1>
+        <p>
+          You don't have permission to access this page. You may need to <a href="{% url "login" %}">log in</a>.
+        </p>
+        <p>
+          Please <a href="mailto:info@capapi.org">write to us</a> if you think this is a mistake.
+        </p>
+      </div>
+    </div>
   </div>
 {% endblock %}
+
+{% block footer %}{% endblock %}

--- a/capstone/capapi/templates/403_csrf.html
+++ b/capstone/capapi/templates/403_csrf.html
@@ -2,14 +2,20 @@
 {% load pipeline %}
 
 {% block content %}
-  <div class="container header-margin">
-    <h3>CSRF verification failed</h3>
-    <p>
-      This usually means you submitted an out-of-date form or have an issue with your browser cookies.
-    </p>
-    <p>
-      Please try going back to the previous page, refreshing, and submitting again. If that doesn't work, try
-      deleting your browser cookies for this site, or <a href="mailto:info@capapi.org">contact us</a>.
-    </p>
+  <div class="basic-page">
+    <div class="full-content">
+      <div class="row">
+        <h1 class="h3">CSRF verification failed</h1>
+        <p>
+          This usually means you submitted an out-of-date form or have an issue with your browser cookies.
+        </p>
+        <p>
+          Please try going back to the previous page, refreshing, and submitting again. If that doesn't work, try
+          deleting your browser cookies for this site, or <a href="mailto:info@capapi.org">contact us</a>.
+        </p>
+      </div>
+    </div>
   </div>
 {% endblock %}
+
+{% block footer %}{% endblock %}

--- a/capstone/capapi/templates/404.html
+++ b/capstone/capapi/templates/404.html
@@ -2,8 +2,14 @@
 {% load pipeline %}
 
 {% block content %}
-  <div class="container header-margin">
-    <h3>We didn't find the page you were looking for!</h3>
-    <p>Please <a href="mailto:info@capapi.org">write to us</a> if you think this is a mistake.</p>
+  <div class="basic-page">
+    <div class="full-content">
+      <div class="row">
+        <h1 class="h3">We didn't find the page you were looking for!</h1>
+        <p>Please <a href="mailto:info@capapi.org">write to us</a> if you think this is a mistake.</p>
+      </div>
+    </div>
   </div>
 {% endblock %}
+
+{% block footer %}{% endblock %}

--- a/capstone/capapi/templates/500.html
+++ b/capstone/capapi/templates/500.html
@@ -2,11 +2,17 @@
 {% load pipeline %}
 
 {% block content %}
-  <div class="container header-margin">
-    <h3>Oops! Something's gone wrong</h3>
-    <p>
-      We experienced a server error. We've logged the error and will look into it. If you see this error repeatedly,
-      please <a href="mailto:info@capapi.org">write to us</a> to let us know what's going wrong.
-    </p>
+  <div class="basic-page">
+    <div class="full-content">
+      <div class="row">
+        <h1 class="h3">Oops! Something's gone wrong</h1>
+        <p>
+          We experienced a server error. We've logged the error and will look into it. If you see this error repeatedly,
+          please <a href="mailto:info@capapi.org">write to us</a> to let us know what's going wrong.
+        </p>
+      </div>
+    </div>
   </div>
 {% endblock %}
+
+{% block footer %}{% endblock %}

--- a/capstone/capapi/templates/bulk.html
+++ b/capstone/capapi/templates/bulk.html
@@ -32,17 +32,17 @@
         <div class="content">
           {% if exports.public %}
             <div class="page-section">
-              <h4 class="subtitle">
+              <h2 class="subtitle">
                Public Bulk Data
-              </h4>
+              </h2>
               <p>Click a link to download.</p>
                 {% include "includes/download_list.html" with zips=exports.public %}
             </div>
           {% endif %}
           <div class="page-section">
-            <h4 class="subtitle">
+            <h2 class="subtitle">
               Bulk Data for Academic Research
-            </h4>
+            </h2>
             {% if exports.private %}
               <p>
                 The following jurisdictions are available for download under your academic research agreement.

--- a/capstone/capweb/templates/about.html
+++ b/capstone/capweb/templates/about.html
@@ -67,9 +67,9 @@ About the Caselaw Access Project
             {# ==============> DATA <============== #}
             <div class="page-section">
               <a name="data"></a>
-              <h4 class="subtitle">
+              <h2 class="subtitle">
                 What data do we have?
-              </h4>
+              </h2>
               <p>
                 Short blurb about what kind of data we have.
                 We took xyz reporters and stripped them of abc proprietary data. This is what we have. Voluptas maxime earum non et voluptatem nulla recusandae. Expedita ut esse sit voluptatem soluta rerum. Sit sapiente animi id necessitatibus ea accusamus. Nobis veritatis odit maxime.
@@ -82,9 +82,9 @@ About the Caselaw Access Project
             {# ==============> USAGE <============== #}
             <div class="page-section">
               <a name="usage"></a>
-              <h4 class="subtitle">
+              <h2 class="subtitle">
                 Usage &amp; access
-              </h4>
+              </h2>
               <p>
                 <span class="highlighted">The CAP data is free for the public to use and access.</span>
               </p>
@@ -112,9 +112,9 @@ About the Caselaw Access Project
             {# ==============> PRESS <============== #}
             <div class="page-section">
               <a name="press"></a>
-              <h4 class="subtitle">
+              <h2 class="subtitle">
                 Press
-              </h4>
+              </h2>
               <ul>
                 {% for news_item in news %}
                   <li class="item-set">
@@ -138,9 +138,9 @@ About the Caselaw Access Project
             {# ==============> CONTRIBUTORS <============== #}
             <div class="page-section">
               <a name="contributors"></a>
-              <h4 class="subtitle">
+              <h2 class="subtitle">
                 Contributors
-              </h4>
+              </h2>
 
                 <ul>
                   {% for key,contributor in contributors.items %}

--- a/capstone/capweb/templates/gallery.html
+++ b/capstone/capweb/templates/gallery.html
@@ -62,11 +62,11 @@ Caselaw Access Project gallery
                 </a>
               </div>
               <div class="project-description">
-                <h6 class="subtitle">
+                <h2 class="subtitle">
                   <a href="https://opencasebook.org/">
                     H2O
                   </a>
-                </h6>
+                </h2>
                 <p>
                   H2O uses the
                   <a href="{% url "api" %}">
@@ -107,11 +107,11 @@ Caselaw Access Project gallery
                 </a>
               </div>
               <div class="project-description">
-                <h6 class="subtitle">
+                <h2 class="subtitle">
                   <a href="{% url "wordclouds" %}">
                     Wordclouds
                   </a>
-                </h6>
+                </h2>
                 <p>
                   Graphics showcasing the most-used words in California caselaw each year between 1852 and 2015.
                 </p>
@@ -143,11 +143,11 @@ Caselaw Access Project gallery
                 </a>
               </div>
               <div class="project-description">
-                <h6 class="subtitle">
+                <h2 class="subtitle">
                   <a href="{% url "limericks" %}">
                     Limericks
                   </a>
-                </h6>
+                </h2>
                 <p>
                   Generate rhymes using caselaw!
                 </p>

--- a/capstone/capweb/templates/index.html
+++ b/capstone/capweb/templates/index.html
@@ -8,9 +8,10 @@
 {% endblock %}
 
 {% block content %}
+  <h1>Caselaw Access Project</h1>
   <section id="section-quote" class="bg-black">
     <div class="splash-quote">
-      <h3>
+      <span>
         <img class="decorative-arrow"
              alt=""
              aria-hidden="true"
@@ -20,7 +21,7 @@
              alt=""
              aria-hidden="true"
              src='{% static "img/red-arrow-left.svg" %}'/>
-      </h3>
+      </span>
     </div>
       <img class="decorative-mountains-purple"
            alt=""
@@ -40,52 +41,52 @@
         <div class="content-small-screen numbers">
           <div class="row">
             <div class="col">
-              <h1>{{ numbers.cases }}</h1>
+              <span class="number">{{ numbers.cases }}</span>
             </div>
             <div class="col mt-3">
-              <h4 class="font-weight-bold">
+              <span class="label-big">
                 Million
-              </h4>
+              </span>
               <img
                    alt=""
                    aria-hidden="true"
                    src='{% static "img/red-arrow-left.svg" %}'/>
-              <h5>
+              <span class="label">
                 <span class="color-yellow-bright">Unique</span> cases
-              </h5>
+              </span>
             </div>
             <hr/>
             <div class="col">
-              <h3 class="reporters-number">{{ numbers.reporters }}</h3>
-              <h5 class="color-yellow-bright">Reporters</h5>
+              <span class="reporters-number">{{ numbers.reporters }}</span>
+              <span class="label color-yellow-bright">Reporters</span>
             </div>
             <div class="dotted-vr"></div>
             <div class="col pl-1">
-              <h3 class="pages-scanned-number">{{ numbers.pages_scanned }}M</h3>
-              <h5>Pages scanned</h5>
+              <span class="pages-scanned-number">{{ numbers.pages_scanned }}M</span>
+              <span class="label">Pages scanned</span>
             </div>
           </div>
         </div>
         <div class="content-left">
-          <h1 class="font-serif section-title">
+          <h2 class="section-title">
             <img class="decorative-arrow"
                  alt=""
                  aria-hidden="true"
                  src='{% static "img/red-arrow-right.svg" %}'>
               What data do we have?
-          </h1>
+          </h2>
           <div class="numbers numbers-vertical">
             <ul>
               <li class="item-set">
-                <h1 class="num_cases">{{ numbers.cases }}M</h1>
+                <span class="number num_cases">{{ numbers.cases }}M</span>
                 <p>Unique cases</p>
               </li>
               <li class="item-set">
-                <h1 class="num_reporters">{{ numbers.reporters }}</h1>
+                <span class="number num_reporters">{{ numbers.reporters }}</span>
                 <p>Reporters</p>
               </li>
               <li class="item-set">
-                <h1 class="num_pages">{{ numbers.pages_scanned }}M</h1>
+                <span class="number num_pages">{{ numbers.pages_scanned }}M</span>
                 <p>Pages scanned</p>
               </li>
             </ul>
@@ -101,15 +102,15 @@
           <div id="numbers" class="numbers numbers-horizontal">
             <div class="row">
               <div class="col-4">
-                <h1 class="num_cases">{{ numbers.cases }}M</h1>
+                <span class="number num_cases">{{ numbers.cases }}M</span>
                 <p>Unique cases</p>
               </div>
               <div class="col-4">
-                <h1 class="num_reporters">{{ numbers.reporters }}</h1>
+                <span class="number num_reporters">{{ numbers.reporters }}</span>
                 <p>Reporters</p>
               </div>
               <div class="col-4">
-                <h1 class="num_pages">{{ numbers.pages_scanned }}M</h1>
+                <span class="number num_pages">{{ numbers.pages_scanned }}M</span>
                 <p>Pages scanned</p>
               </div>
             </div>
@@ -127,33 +128,34 @@
       <div class="row">
         <div class="content-left">
           <!-- section title -->
-          <h1 class="font-serif section-title">
+          <h2 class="section-title">
             <img class="decorative-arrow"
                  alt=""
                  aria-hidden="true"
                  src='{% static "img/red-arrow-right.svg" %}'>
               Dive in!
-          </h1>
+          </h2>
         </div>
         <div class="content-right">
           <!-- section subtitle -->
-          <h5 class=" section-subtitle">
+          <span class=" section-subtitle">
             Start exploring the data! Here are some tools you can use to check it out.
-          </h5>
+          </span>
 
-          <h6>
-            <span class="section-symbol color-red">&#167;</span>
+          <h3>
+            <span class="section-symbol color-red" aria-hidden="true">&#167;</span>
             <a href="{% url "api" %}">
               API
             </a>
-          </h6>
+          </h3>
           <p>The API allows users to browse and download cases using a few short commands.</p>
-          <h6>
-            <span class="section-symbol color-red">&#167;</span>
+
+          <h3>
+            <span class="section-symbol color-red" aria-hidden="true">&#167;</span>
             <a href="{% url "bulk-data" %}">
               Bulk data
             </a>
-          </h6>
+          </h3>
           <p>Download whole zip files of whitelisted jurisdictions like Illinois.</p>
           <br/>
           <a href="/tools"
@@ -171,32 +173,32 @@
       <div class="row">
         <div class="content-left">
           <!-- section title -->
-          <h1 class="font-serif section-title">
+          <h2 class="section-title">
             <img class="decorative-arrow"
                  alt=""
                  aria-hidden="true"
                  src='{% static "img/red-arrow-right.svg" %}'>
               Gallery
-          </h1>
+          </h2>
         </div>
         <div class="content-right">
           <!-- section subtitle -->
-          <h5 class="section-subtitle">
+          <span class="section-subtitle">
             Sky’s the limit. See some early experiments made possible by the opening up of caselaw data.
-          </h5>
-          <h6>
-            <span class="section-symbol color-yellow">&#167;</span>
+          </span>
+          <h3>
+            <span class="section-symbol color-yellow" aria-hidden="true">&#167;</span>
             <a class="color-white" href="{% url "wordclouds" %}">
               Wordclouds
             </a>
-          </h6>
+          </h3>
           <p>Most used words for every year of California caselaw from 1852 to 2015.</p>
-          <h6>
-            <span class="section-symbol color-yellow">&#167;</span>
+          <h3>
+            <span class="section-symbol color-yellow" aria-hidden="true">&#167;</span>
             <a class="color-white" href="{% url "limericks" %}">
               Limericks
             </a>
-          </h6>
+          </h3>
           <p>Generate rhymes using caselaw!</p>
           <br/>
           <a class="btn btn-inverse"
@@ -214,19 +216,19 @@
       <div class="row">
         <div class="content-left">
           <!-- section title -->
-          <h1 class="font-serif section-title">
+          <h2 class="section-title">
             <img class="decorative-arrow"
                  alt=""
                  aria-hidden="true"
                  src='{% static "img/red-arrow-right.svg" %}'>
               Links &amp; press
-          </h1>
+          </h2>
         </div>
         <div class="content-right">
           <!-- section subtitle -->
-          <h5 class=" section-subtitle">
+          <span class="section-subtitle">
             What's been written about Caselaw Access Project around the web
-          </h5>
+          </span>
           <ul>
           {% for news_item in news %}
             <li class="item-set">

--- a/capstone/capweb/templates/main_base.html
+++ b/capstone/capweb/templates/main_base.html
@@ -34,7 +34,9 @@
     </main>
 
     {% if not hide_footer %}
-      {% include "includes/footer.html" %}
+      {% block footer %}
+          {% include "includes/footer.html" %}
+      {% endblock %}
     {% endif %}
   </body>
 </html>

--- a/capstone/capweb/templates/tools.html
+++ b/capstone/capweb/templates/tools.html
@@ -62,9 +62,9 @@
             {# ==============> API  <============== #}
             <div class="page-section">
               <a name="api"></a>
-              <h4 class="subtitle">
+              <h2 class="subtitle">
                 <a href="{% url "api" %}">The API</a>
-              </h4>
+              </h2>
               <p>
                   Our open-source API is the best option for anybody interested in programmatically accessing our
                   metadata, full-text search, or individual cases.
@@ -77,9 +77,9 @@
             {# ==============> BULK!! <============== #}
             <div class="page-section">
               <a name="bulk"></a>
-              <h4 class="subtitle">
+              <h2 class="subtitle">
                 <a href="{% url "bulk-data" %}">Bulk Downloads</a>
-              </h4>
+              </h2>
               <p>
                 If you need a large collection of cases, you will probably be best served by our bulk data downloads.
                   With no registration or formal agreements, we offer zip files containing all cases from Illinois and

--- a/capstone/static/css/scss/_variables.scss
+++ b/capstone/static/css/scss/_variables.scss
@@ -237,29 +237,27 @@ $font-sans-serif: "titillium", "Helvetica", sans-serif;
   $base-font-size: 20px;
   $heading-scale: 8; // amount of px headings grow from h6 to h1
   @for $i from 1 through 6 {
-  h#{$i} {
-    font-size: $base-font-size + $heading-scale * (6 - $i);
+    h#{$i}, .h#{$i} {
+      font-size: $base-font-size + $heading-scale * (6 - $i);
+    }
   }
-}
-
 }
 
 @include media-breakpoint-only(lg) {
   $base-font-size: 18px;
   $heading-scale: 8; // amount of px headings grow from h6 to h1
   @for $i from 1 through 6 {
-    h#{$i} {
+    h#{$i}, .h#{$i} {
       font-size: $base-font-size + $heading-scale * (6 - $i);
     }
   }
-
 }
 
 @include media-breakpoint-only(md) {
   $base-font-size: 16px;
   $heading-scale: 6; // amount of px headings grow from h6 to h1
   @for $i from 1 through 6 {
-    h#{$i} {
+    h#{$i}, .h#{$i} {
       font-size: $base-font-size + $heading-scale * (6 - $i);
     }
   }
@@ -269,7 +267,7 @@ $font-sans-serif: "titillium", "Helvetica", sans-serif;
   $base-font-size: 14px;
   $heading-scale: 4; // amount of px headings grow from h6 to h1
   @for $i from 1 through 6 {
-    h#{$i} {
+    h#{$i}, .h#{$i} {
       font-size: $base-font-size + $heading-scale * (6 - $i);
     }
   }

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -395,6 +395,7 @@ li.item-set {
     }
   }
   .subtitle {
+    @extend .h4;
     color: $color-violet;
   }
   @include media-breakpoint-up(md) {

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -189,8 +189,6 @@ section > .content > .row > .content-left {
 }
 
 section > .content > .row > .content-right {
-  /* usually includes subtitle, content */
-  h5, h6 { font-weight: $font-weight-semibold; }
   @include media-breakpoint-only(xl) {
     @include make-col(7);
     @include make-col-offset(1);
@@ -233,12 +231,6 @@ section > .content > .row > .content-right {
   }
 }
 
-.content {
-  .numbers {
-    h1 { font-weight: $font-weight-bold; }
-  }
-}
-
 .content-right > .numbers-horizontal {
   text-align: center;
   @include media-breakpoint-down(lg) {
@@ -260,26 +252,6 @@ section > .content > .row > .content-right {
   }
   @include media-breakpoint-up(md) {
     display: none;
-  }
-  h1 { font-size: 5rem; }
-  h3 { font-size: 3rem; }
-  h4 { font-size: 1.8rem; }
-  h1, h3, h4, h5 {
-    font-family: $font-sans-serif;
-    @include media-breakpoint-only(sm) {
-      h1 {
-        font-size: 7rem;
-      }
-      h4 {
-        font-size: 5rem;
-      }
-      h3 {
-        font-size: 4rem;
-      }
-      h5 {
-        font-size: 1.8rem;
-      }
-    }
   }
   hr {
     border-top: 2px dotted $color-yellow-bright;

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -39,7 +39,7 @@ body {
   line-height: 29px;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1, .h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   font-family: $font-serif;
 }
 

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -366,9 +366,17 @@ li.item-set {
       @include make-col(6);
     }
   }
-  .subtitle {
+  h2.subtitle {
     @extend .h4;
     color: $color-violet;
+  }
+  h3.subtitle {
+    @extend .h5;
+    color: $color-violet;
+  }
+  h4, h5, h6 {
+    @extend .h6;
+    font-weight: $font-weight-bold;
   }
   @include media-breakpoint-up(md) {
     .subtitle:before {

--- a/capstone/static/css/scss/gallery.scss
+++ b/capstone/static/css/scss/gallery.scss
@@ -16,6 +16,7 @@
 }
 
 .basic-page.inverse .subtitle {
+  @extend .h6;
   font-family: $font-sans-serif;
   font-weight: $font-weight-semibold;
   border-bottom: 0;

--- a/capstone/static/css/scss/index.scss
+++ b/capstone/static/css/scss/index.scss
@@ -1,5 +1,76 @@
 @import 'variables';
 
+h1 {
+  @include sr-only;
+}
+
+/*
+ * specialized lettering for index page
+ */
+
+ @mixin header-styles {
+  display: block;
+  font-family: $font-serif;
+  font-weight: $font-weight-bold;
+  line-height: $headings-line-height;
+  margin-bottom: $headings-margin-bottom;
+ }
+
+.splash-quote span {
+  @extend .h3;
+  @include header-styles;
+}
+
+.section-title {
+  @extend .h1;
+  @include header-styles;
+  font-weight: $font-weight-normal;
+}
+
+.section-subtitle {
+  @extend .h5;
+  @include header-styles;
+  margin-bottom: 1em;
+  margin-top: 20px;
+}
+
+.number {
+  @extend .h1;
+  @include header-styles;
+
+  .content-small-screen & {
+    font-family: $font-sans-serif;
+    font-size: 5rem;
+  }
+}
+
+.pages-scanned-number, .reporters-number {
+  @include header-styles;
+  font-size: 3rem;
+}
+
+.pages-scanned-number {
+  font-family: $font-sans-serif;
+}
+
+.label {
+  @extend .h5;
+  @include header-styles;
+  font-family: $font-sans-serif;
+  font-weight: 500; // is this in a variable somewhere?
+}
+
+.label-big {
+  @include header-styles;
+  font-size: 1.8rem;
+  font-family: $font-sans-serif;
+}
+
+.content-right h3 {
+  @extend .h6;
+  font-weight: $font-weight-bold;
+}
+
 
 /* on index, display white background logo on small screens
   display black background logo in all other instances */


### PR DESCRIPTION
This PR tries to introduce semantic heading levels (1 -> {2 -> {3 , 3},  2}  etc.) without affecting the super-snazzy typography of the design.

I tried to do this unobtrusively by replacing the content tag with the matching `.h1`-`.h6` class from bootstrap (tweaked so that the classes know about cap's custom sizing); I can easily imagine that you'd prefer to organize your css completely differently. Hopefully this strategy isn't too offensive for the time-being.

Since (https://github.com/harvard-lil/capstone/pull/468/files), there are now more deeply-nested heading on the tools > api page than were yet explicitly included in the design. I included a guess here (https://github.com/harvard-lil/capstone/pull/472/files). Since before this PR, the largest heading corresponded to .h4, I went down from there. Unlikely I got it right.

Example before:
![image](https://user-images.githubusercontent.com/11020492/45720204-5cf41a00-bb71-11e8-9b5d-fdd86f7e7b08.png)

Example after:
![image](https://user-images.githubusercontent.com/11020492/45720214-6a110900-bb71-11e8-827e-79b042b35205.png)

I'm not sure I got all the pages that are in play:
- landing
- about
- tools > overview
- tools > api
- tools > bulk
- gallery
- 400/403/404/500 (classes hard-coded, rather than applied via scss)
(contact/sign-up/sign-in looked fine; I didn't look at any other registration-related pages)

If I missed any, just let me know!
