### PR TITLE
Maybe? tweak nav structure

### DIFF
--- a/capstone/capweb/templates/about.html
+++ b/capstone/capweb/templates/about.html
@@ -18,7 +18,6 @@ About the Caselaw Access Project
     <div class="full-content">
       <div class="row">
         <div class="page-title">
-          <a name="overview"></a>
           <h1>
             <img alt=""
                  aria-hidden="true"
@@ -33,7 +32,7 @@ About the Caselaw Access Project
         {# ==============> MENU <============== #}
         <nav class="list-group sidebar-menu" aria-label="table of contents">
           <ul>
-            <li><a class="list-group-item" href="#overview">Overview</a></li>
+            <li><a class="list-group-item" href="#introduction">Introduction</a></li>
             <li><a class="list-group-item" href="#data">What data?</a></li>
             <li><a class="list-group-item" href="#usage">Usage &amp; access</a></li>
             <li><a class="list-group-item" href="#press">Press</a></li>
@@ -43,13 +42,15 @@ About the Caselaw Access Project
         {# ==============> CONTENT <============== #}
           <div class="content">
 
-            {# ==============> OVERVIEW <============== #}
+            {# ==============> INTRODUCTION <============== #}
             <div class="page-section">
+              <a name="introduction"></a>
               <p>
                <img class="img-fluid"
                  alt="Scanning reporters"
                  src="{% static "img/book-scan.jpg" %}">
               </p>
+              <h2 class="subtitle">Introduction</h2>
               <p>
                 <span class="highlighted">
                   The Caselaw Access Project (&#8220;CAP&#8221;)

--- a/capstone/capweb/templates/api.html
+++ b/capstone/capweb/templates/api.html
@@ -33,8 +33,7 @@
         {# ==============> MENU <============== #}
         <nav class="list-group sidebar-menu" aria-label="table of contents">
           <ul>
-            <li><a class="list-group-item" href="#overview">Overview</a></li>
-            <li><a class="list-group-item" href="#usage">Using CAPAPI</a></li>
+            <li><a class="list-group-item" href="#getting-started">Getting Started</a></li>
             <li>
               <ul>
                 <li><a class="list-group-item" href="#registration">Registration</a></li>
@@ -54,14 +53,15 @@
         {# ==============> CONTENT <============== #}
         <div class="content">
 
-          {# ==============> OVERVIEW <============== #}
+          {# ==============> GETTING STARTED <============== #}
           <div class="page-section">
+            <a id="getting-started"></a>
             <p>
               <img class="img-fluid"
                    alt="Scanning reporters"
                    src="{% static "img/vacuum-seal.jpg" %}">
             </p>
-            <a id="overview"></a>
+            <h2 class="subtitle">Getting Started</h2>
             <p><a href="{% url "api-root" %}" class="font-weight-bold">Browse the API</a></p>
             <p>
               The Caselaw Access Project API, also known as CAPAPI, serves all official US court cases
@@ -88,9 +88,6 @@
             </p>
           </div>
           <div class="page-section">
-            <a id="overview"></a>
-            <h2 class="subtitle">Overview</h2>
-
             {# ==============> REGISTER  <============== #}
             <a id="registration"></a>
             <h3 class="subtitle">Registration (if you need it)</h3>
@@ -327,9 +324,9 @@
           {# ==============> EXAMPLES <============== #}
           <div class="page-section">
             <a id="examples"></a>
-            <h4 class="subtitle">
+            <h3 class="subtitle">
               Usage Examples
-            </h4>
+            </h3>
             <p>
               This is a non-exhaustive set of examples intended to orient new users. The
               <a href="#endpoints">endpoints</a> section contains more comprehensive documentation about the URLs and

--- a/capstone/capweb/templates/gallery.html
+++ b/capstone/capweb/templates/gallery.html
@@ -18,7 +18,6 @@ Caselaw Access Project gallery
     <div class="full-content">
       <div class="row">
         <div class="page-title">
-          <a name="overview"></a>
           <h1>
             <img alt=""
                  aria-hidden="true"
@@ -32,6 +31,7 @@ Caselaw Access Project gallery
         {# ==============> MENU <============== #}
         <nav class="list-group sidebar-menu" aria-label="table of contents">
           <ul>
+            <li><a class="list-group-item" href="#introduction">Introduction</a></li>
             <li><a class="list-group-item" href="#h2o">H2O</a></li>
             <li><a class="list-group-item" href="#wordclouds">Wordclouds</a></li>
             <li><a class="list-group-item" href="#limericks">Limericks</a></li>
@@ -40,8 +40,10 @@ Caselaw Access Project gallery
         {# ==============> CONTENT <============== #}
         <div class="content">
 
-          {# ==============> OVERVIEW <============== #}
+          {# ==============> INTRODUCTION <============== #}
           <div class="page-section">
+            <a name="introduction"></a>
+            <h2 class="subtitle">Introduction</h2>
             <p>
               Sky is the limit!
               <br/> Here are some examples of what’s possible.

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -20,21 +20,8 @@
 
   <div class="nav-content">
     <ul class="nav">
-      <li class="nav-item dropdown" id="nav-about">
-        <a class="nav-link dropdown-toggle"
-           href="#" id="navbar-dropdown-about"
-           role="button"
-           aria-haspopup="true"
-           aria-expanded="false">
-          ABOUT
-        </a>
-        <div class="dropdown-menu" aria-labelledby="navbar-dropdown-about">
-          <a class="dropdown-item" href="{% url "about" %}">Overview</a>
-          <a class="dropdown-item" href="{% url "about" %}#data">What data?</a>
-          <a class="dropdown-item" href="{% url "about" %}#usage">Usage & access</a>
-          <a class="dropdown-item" href="{% url "about" %}#press">Press</a>
-          <a class="dropdown-item" href="{% url "about" %}#contributors">Contributors</a>
-        </div>
+      <li class="nav-item" id="nav-about">
+        <a class="nav-link" href="{% url "about" %}">ABOUT</a>
       </li>
       <li class="nav-item dropdown" id="nav-tools">
         <a class="nav-link dropdown-toggle"
@@ -45,7 +32,7 @@
           TOOLS
         </a>
         <div class="dropdown-menu" aria-labelledby="navbar-dropdown-tools">
-          <a class="dropdown-item" href="{% url "tools" %}#overview">Overview</a>
+          <a class="dropdown-item" href="{% url "tools" %}">Overview</a>
           <a class="dropdown-item" href="{% url "api" %}">API</a>
           <a class="dropdown-item" href="{% url "bulk-data" %}">Bulk Data</a>
         </div>
@@ -59,10 +46,9 @@
           GALLERY
         </a>
         <div class="dropdown-menu" aria-labelledby="navbar-dropdown-gallery">
-          <a class="dropdown-item" href="{% url "gallery" %}#overview">Overview</a>
-          <a class="dropdown-item" href="{% url "gallery" %}#h2o">H2O</a>
-          <a class="dropdown-item" href="{% url "limericks" %}">Limericks</a>
+          <a class="dropdown-item" href="{% url "gallery" %}">Overview</a>
           <a class="dropdown-item" href="{% url "wordclouds" %}">Wordclouds</a>
+          <a class="dropdown-item" href="{% url "limericks" %}">Limericks</a>
         </div>
       </li>
 

--- a/capstone/capweb/templates/tools.html
+++ b/capstone/capweb/templates/tools.html
@@ -32,22 +32,23 @@
         {# ==============> MENU <============== #}
         <nav class="list-group sidebar-menu" aria-label="table of contents">
           <ul>
-            <li><a class="list-group-item" href="#overview">Overview</a></li>
-            <li><a class="list-group-item" href="{% url "api" %}">API</a></li>
-            <li><a class="list-group-item" href="{% url "bulk-data" %}">Bulk Data</a></li>
+            <li><a class="list-group-item" href="#introduction">Introduction</a></li>
+            <li><a class="list-group-item" href="#api">API</a></li>
+            <li><a class="list-group-item" href="#bulk">Bulk Data</a></li>
           </ul>
         </nav>
         {# ==============> CONTENT <============== #}
           <div class="content">
 
-            {# ==============> OVERVIEW <============== #}
+            {# ==============> INTRODUCTION <============== #}
             <div class="page-section">
+              <a name="introduction"></a>
               <p>
                <img class="img-fluid"
                  alt="Scanning reporters"
                  src="{% static "img/vacuum-seal.jpg" %}">
               </p>
-              <a name="overview"></a>
+              <h2 class="subtitle">Introduction</h2>
               <p>
                 <span class="highlighted">
                     Information is only useful if it's accessible.


### PR DESCRIPTION
- Try listing only distinct pages in main nav: no dropdown on about, tools => {Overview, API, Bulk Data}, gallery => {Overview, Wordclouds, Limericks}
- Try calling first in-page sections "Introduction" rather than "Overview", so that overview pages don't have overview sections
- Try renaming the API docs' "Overview" `<h2>` to "Getting Started" for the same reason (...yeah....maybe not?)

This would start getting to a place where https://github.com/harvard-lil/capstone/issues/474 is easier to solve.

![image](https://user-images.githubusercontent.com/11020492/45773527-9469d180-bc18-11e8-8346-f428a18b472c.png)
![image](https://user-images.githubusercontent.com/11020492/45773666-db57c700-bc18-11e8-922e-69b22a81de29.png)
![image](https://user-images.githubusercontent.com/11020492/45773683-e874b600-bc18-11e8-9444-2f768d33380c.png)


