### PR TITLE
Move api to subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This repository contains Capstone and CAPAPI, the applications written by the Ha
 - [The Capstone Application](#the-capstone-application)
 - [CAPAPI](#capapi)
 - [Installing Capstone and CAPAPI](#installing-capstone-and-capapi)
+  - [Hosts Setup](#hosts-setup)
   - [Manual Local Setup](#manual-local-setup)
     - [Install global system requirements](#install-global-system-requirements)
     - [Clone the repository](#clone-the-repository)
@@ -80,7 +81,14 @@ CAPAPI is the API with which users can access CAP data.
 ## Installing Capstone and CAPAPI <a id="installing-capstone-and-capapi"></a>
 - [Manual Local Setup](#manual-local-setup)
 - [Docker Setup](#docker-setup)
- 
+
+### Hosts Setup <a id="hosts-setup"></a>
+
+Add the following to `/etc/hosts`:
+
+    127.0.0.1       case.test
+    127.0.0.1       api.case.test
+
 ### Manual Local Setup <a id="manual-local-setup"></a>
 1. [Install global system requirements](#install-global-system-requirements)
 2. [Clone the repository](#clone-the-repository)

--- a/capstone/capapi/__init__.py
+++ b/capstone/capapi/__init__.py
@@ -1,7 +1,7 @@
 import rest_framework.request
+import rest_framework.reverse
 
-from capapi.resources import TrackingWrapper
-
+from capapi.resources import TrackingWrapper, api_reverse
 
 # Monkeypatch rest_framework.request.Request to track accesses to request.user attributes.
 # See capapi/middleware for rationale.
@@ -24,3 +24,7 @@ class CustomRequest(OriginalRequest):
 # make sure we only patch once if this module is re-imported
 if OriginalRequest.__name__ != "CustomRequest":
     rest_framework.request.Request = CustomRequest
+
+
+# Monkeypatch rest_framework.reverse._reverse to use our api_reverse function
+rest_framework.reverse._reverse = api_reverse

--- a/capstone/capapi/api_urls.py
+++ b/capstone/capapi/api_urls.py
@@ -1,0 +1,52 @@
+from django.conf import settings
+from django.urls import path, re_path, include
+from django.views.generic import RedirectView
+from rest_framework import routers, permissions
+from drf_yasg.views import get_schema_view
+from drf_yasg import openapi
+
+from capapi.views import api_views
+
+
+router = routers.DefaultRouter()
+router.register('cases', api_views.CaseViewSet)
+router.register('citations', api_views.CitationViewSet)
+router.register('jurisdictions', api_views.JurisdictionViewSet)
+router.register('courts', api_views.CourtViewSet)
+router.register('volumes', api_views.VolumeViewSet)
+router.register('reporters', api_views.ReporterViewSet)
+router.register('bulk', api_views.CaseExportViewSet)
+
+schema_view = get_schema_view(
+    openapi.Info(
+        title="CAP API",
+        default_version='v1',
+        description="United States Caselaw",
+        terms_of_service="https://capapi.org/terms",
+        contact=openapi.Contact(email="lil@law.harvard.edu"),
+    ),
+    validators=['flex', 'ssv'],
+    public=True,
+    permission_classes=(permissions.AllowAny,),
+)
+
+urlpatterns = [
+    path('v1/', include(router.urls)),
+    # convenience pattern: catch all citations, redirect in CaseViewSet's retrieve
+    re_path(r'^v1/cases/(?P<id>[0-9A-Za-z\s\.]+)/$', api_views.CaseViewSet.as_view({'get': 'retrieve'}), name='casemetadata-get-cite'),
+
+    ### Swagger/OpenAPI/ReDoc ###
+    re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=None), name='schema-json'),
+    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=None), name='schema-swagger-ui'),
+    re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=None), name='schema-redoc'),
+
+    path('', RedirectView.as_view(url='/v1/', permanent=False), name='api-root')
+]
+
+# use django-debug-toolbar if installed
+if settings.DEBUG:
+    try:
+        import debug_toolbar
+        urlpatterns += [path('__debug__/', include(debug_toolbar.urls))]
+    except ImportError:
+        pass

--- a/capstone/capapi/forms.py
+++ b/capstone/capapi/forms.py
@@ -1,9 +1,9 @@
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django import forms
-from django.urls import reverse
 from django.utils.safestring import mark_safe
 
 from capapi.models import CapUser
+from capweb.helpers import reverse
 
 
 class LoginForm(AuthenticationForm):

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -14,7 +14,9 @@ from django.core.mail import send_mail
 from django.db.models import QuerySet
 from django.template.defaultfilters import slugify
 from django.http import FileResponse
-from rest_framework.reverse import reverse
+from django_hosts import reverse as django_hosts_reverse
+
+from capweb.helpers import reverse
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +45,7 @@ def create_download_response(filename='', content=[]):
 
 
 def send_new_signup_email(request, user):
-    token_url = reverse('verify-user', kwargs={'user_id':user.pk, 'activation_nonce': user.get_activation_nonce()}, request=request)
+    token_url = reverse('verify-user', kwargs={'user_id':user.pk, 'activation_nonce': user.get_activation_nonce()}, scheme="https")
     send_mail(
         'CaseLaw Access Project: Verify your email address',
         "Please click here to verify your email address: \n\n%s \n\nIf you believe you have received this message in error, please ignore it." % token_url,
@@ -113,3 +115,13 @@ class CachedCountQuerySet(QuerySet):
     )
     def count(self):
         return super().count()
+
+
+def api_reverse(viewname, args=None, kwargs=None, request=None, format=None, **extra):
+    """
+        Same as `django.urls.reverse`, but uses api_urls.py for routing, and includes full domain name.
+    """
+    if format is not None:
+        kwargs = kwargs or {}
+        kwargs['format'] = format
+    return django_hosts_reverse(viewname, args=args, kwargs=kwargs, host='api', scheme='http' if settings.DEBUG else 'https', **extra)

--- a/capstone/capapi/templates/includes/download_list.html
+++ b/capstone/capapi/templates/includes/download_list.html
@@ -1,3 +1,4 @@
+{% load api_url %}
 {% for section_label, item_list in zips.items %}
   <h3 class="section-title">By {{ section_label }}</h3>
   {% for filter_item, exports in item_list.items %}
@@ -5,7 +6,7 @@
       <div class="col-3">{{ filter_item }}</div>
       {% for export_type, export in exports.items %}
         <div class="col-4 {% if not forloop.first %}offset-1{% endif %}">
-          <a href="{% url "caseexport-download" pk=export.pk %}">{{ export.file_name }}</a>
+          <a href="{% api_url "caseexport-download" pk=export.pk %}">{{ export.file_name }}</a>
           ({{ export.file.size|filesizeformat }})
         </div>
       {% endfor %}

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -1,16 +1,15 @@
 import pytest
 
-from django.urls import reverse
-
+from capapi import api_reverse
 from test_data.test_fixtures.factories import *
 from scripts.process_metadata import parse_decision_date
 from capapi.tests.helpers import check_response
 
 @pytest.mark.django_db
-def test_flow(client, api_url, case):
+def test_flow(client, case):
     """user should be able to click through to get to different tables"""
     # start with case
-    response = client.get("%scases/%s/" % (api_url, case.pk))
+    response = client.get(api_reverse("casemetadata-detail", args=[case.pk]))
     check_response(response)
     content = response.json()
     # onwards to court
@@ -28,14 +27,14 @@ def test_flow(client, api_url, case):
 
 
 @pytest.mark.django_db
-def test_jurisdiction_redirect(api_url, client, case, jurisdiction):
+def test_jurisdiction_redirect(client, case, jurisdiction):
     jurisdiction.name = 'Neb.'
     jurisdiction.slug = 'neb'
     jurisdiction.save()
     case.jurisdiction = jurisdiction
     case.save()
 
-    response = client.get("%scases/?jurisdiction=%s" % (api_url, jurisdiction.name), follow=True)
+    response = client.get(api_reverse("casemetadata-list"), {"jurisdiction": jurisdiction.name}, follow=True)
     query_string = response.request.get('QUERY_STRING')
     query, jurisdiction_name = query_string.split('=')
     assert jurisdiction_name == jurisdiction.slug
@@ -43,94 +42,50 @@ def test_jurisdiction_redirect(api_url, client, case, jurisdiction):
 
 # RESOURCE ENDPOINTS
 @pytest.mark.django_db
-def test_jurisdictions(client, api_url, case):
-    response = client.get("%sjurisdictions/" % api_url)
+@pytest.mark.parametrize("fixture_name, detail_attr, comparison_attr", [
+    ("jurisdiction", "slug", "name_long"),
+    ("court", "slug", "name"),
+    ("case", "pk", "name_abbreviation"),
+    ("reporter", "pk", "full_name"),
+    ("volume_metadata", "pk", "title"),
+    ("case_export", "pk", "file_name"),
+])
+def test_model_endpoint(request, client, fixture_name, detail_attr, comparison_attr):
+    """ Generic test to kick the tires on -list and -detail for model endpoints. """
+    instance = request.getfuncargvalue(fixture_name)
+    model = instance.__class__
+    resource_name = model.__name__.lower()
+
+    # test list endpoint
+    response = client.get(api_reverse("%s-list" % resource_name))
     check_response(response)
-    jurisdictions = response.json()['results']
-    assert len(jurisdictions) > 0
-    assert len(jurisdictions) == Jurisdiction.objects.count()
+    results = response.json()['results']
+    assert results
+    assert len(results) == model.objects.count()
 
-
-@pytest.mark.django_db
-def test_single_jurisdiction(client, api_url, jurisdiction):
-    response = client.get("%sjurisdictions/%s/" % (api_url, jurisdiction.slug))
+    # test detail endpoint
+    response = client.get(api_reverse("%s-detail" % resource_name, args=[getattr(instance, detail_attr)]))
     check_response(response)
-    jur_result = response.json()
-    assert len(jur_result) > 1
-    print(jur_result)
-    assert jur_result['name_long'] == jurisdiction.name_long
-
-
-@pytest.mark.django_db
-def test_courts(api_url, client, court):
-    response = client.get("%scourts/" % api_url)
-    check_response(response)
-    courts = response.json()['results']
-    assert len(courts) > 0
-    assert len(courts) == Court.objects.count()
-
-
-@pytest.mark.django_db
-def test_single_court(api_url, client, court):
-    court.slug = "unique-slug"
-    court.save()
-    response = client.get("%scourts/%s/" % (api_url, court.slug))
-    check_response(response)
-    court_result = response.json()
-    assert court_result['name'] == court.name
-
-
-@pytest.mark.django_db
-def test_cases(client, api_url, case):
-    response = client.get("%scases/" % api_url)
-    check_response(response)
-    cases = response.json()['results']
-    assert len(cases) > 0
-    assert len(cases) == CaseMetadata.objects.count()
-
-
-@pytest.mark.django_db
-def test_single_case(client, api_url, case):
-    response = client.get("%scases/%s/" % (api_url, case.pk))
-    check_response(response)
-    content = response.json()
-    assert content.get("name_abbreviation") == case.name_abbreviation
-
+    results = response.json()
+    assert results[comparison_attr] == getattr(instance, comparison_attr)
 
 @pytest.mark.django_db
 def test_cases_count_cache(client, three_cases, django_assert_num_queries):
     # fetching same endpoing a second time should have one less query, because queryset.count() is cached
     with django_assert_num_queries(select=3):
-        response = client.get(reverse('casemetadata-list'))
+        response = client.get(api_reverse('casemetadata-list'))
         assert response.json()['count'] == 3
     with django_assert_num_queries(select=2):
-        response = client.get(reverse('casemetadata-list'))
+        response = client.get(api_reverse('casemetadata-list'))
         assert response.json()['count'] == 3
-
-@pytest.mark.django_db
-def test_reporters(client, api_url, reporter):
-    response = client.get("%sreporters/" % api_url)
-    check_response(response)
-    reporters = response.json()['results']
-    assert len(reporters) > 0
-    assert len(reporters) == Reporter.objects.count()
-
-
-@pytest.mark.django_db
-def test_single_reporter(client, api_url, reporter):
-    response = client.get("%sreporters/%s/" % (api_url, reporter.pk))
-    check_response(response)
-    content = response.json()
-    assert content.get("full_name") == reporter.full_name
 
 
 # REQUEST AUTHORIZATION
 @pytest.mark.django_db
-def test_unauthorized_request(cap_user, api_url, client, case):
+def test_unauthorized_request(cap_user, client, case):
     assert cap_user.case_allowance_remaining == cap_user.total_case_allowance
-    url = "%scases/%s/?full_case=true" % (api_url, case.id)
     client.credentials(HTTP_AUTHORIZATION='Token fake')
-    response = client.get(url)
+    response = client.get(api_reverse("casemetadata-detail", args=[case.id]), {"full_case": "true"})
     check_response(response, status_code=401)
 
     cap_user.refresh_from_db()
@@ -138,7 +93,7 @@ def test_unauthorized_request(cap_user, api_url, client, case):
 
 
 @pytest.mark.django_db
-def test_unauthenticated_full_case(api_url, case, jurisdiction, client):
+def test_unauthenticated_full_case(case, jurisdiction, client):
     """
     we should allow users to get full case without authentication
     if case is whitelisted
@@ -149,9 +104,9 @@ def test_unauthenticated_full_case(api_url, case, jurisdiction, client):
     jurisdiction.save()
     case.jurisdiction = jurisdiction
     case.save()
+    case_url = api_reverse("casemetadata-detail", args=[case.id])
 
-    url = "%scases/%s/?full_case=true" % (api_url, case.pk)
-    response = client.get(url)
+    response = client.get(case_url, {"full_case": "true"})
     check_response(response)
     content = response.json()
     assert "casebody" in content
@@ -162,33 +117,28 @@ def test_unauthenticated_full_case(api_url, case, jurisdiction, client):
     case.jurisdiction = jurisdiction
     case.save()
 
-    url = "%scases/%s/?full_case=true" % (api_url, case.pk)
-    response = client.get(url)
+    response = client.get(case_url, {"full_case": "true"})
     check_response(response)
     content = response.json()
     casebody = content['casebody']
     assert 'error_' in casebody['status']
     assert not casebody['data']
 
-    url = "%scases/%s/?format=xml&full_case=true" % (api_url, case.pk)
-    response = client.get(url)
-
+    response = client.get(case_url, {"full_case": "true", "format": "xml"})
     check_response(response, content_type="application/xml", content_includes='error_auth_required')
 
-    url = "%scases/%s/?format=html&full_case=true" % (api_url, case.pk)
-    response = client.get(url)
+    response = client.get(case_url, {"full_case": "true", "format": "html"})
     check_response(response, content_type="text/html", content_includes='<h1>Error: Not Authenticated')
 
 
 @pytest.mark.django_db
-def test_authenticated_full_case_whitelisted(auth_user, api_url, auth_client, case):
+def test_authenticated_full_case_whitelisted(auth_user, auth_client, case):
     ### whitelisted jurisdiction should not be counted against the user
 
     case.jurisdiction.whitelisted = True
     case.jurisdiction.save()
 
-    url = "%scases/%s/?full_case=true" % (api_url, case.pk)
-    response = auth_client.get(url)
+    response = auth_client.get(api_reverse("casemetadata-detail", args=[case.id]), {"full_case": "true"})
     check_response(response)
     result = response.json()
     casebody = result['casebody']
@@ -201,14 +151,13 @@ def test_authenticated_full_case_whitelisted(auth_user, api_url, auth_client, ca
 
 
 @pytest.mark.django_db
-def test_authenticated_full_case_blacklisted(auth_user, api_url, auth_client, case):
+def test_authenticated_full_case_blacklisted(auth_user, auth_client, case):
     ### blacklisted jurisdiction cases should be counted against the user
 
     case.jurisdiction.whitelisted = False
     case.jurisdiction.save()
 
-    url = "%scases/%s/?full_case=true" % (api_url, case.pk)
-    response = auth_client.get(url)
+    response = auth_client.get(api_reverse("casemetadata-detail", args=[case.id]), {"full_case": "true"})
     check_response(response)
     result = response.json()
     assert result['casebody']['status'] == 'ok'
@@ -219,16 +168,16 @@ def test_authenticated_full_case_blacklisted(auth_user, api_url, auth_client, ca
 
 
 @pytest.mark.django_db
-def test_unlimited_access(auth_user, api_url, auth_client, case):
+def test_unlimited_access(auth_user, auth_client, case):
     ### user with unlimited access should not have blacklisted cases count against them
     auth_user.total_case_allowance = 500
     auth_user.unlimited_access_until = timedelta(hours=24) + timezone.now()
     auth_user.save()
     case.jurisdiction.whitelisted = False
     case.jurisdiction.save()
+    case_url = api_reverse("casemetadata-detail", args=[case.id])
 
-    url = "%scases/%s/?full_case=true" % (api_url, case.pk)
-    response = auth_client.get(url)
+    response = auth_client.get(case_url, {"full_case": "true"})
     check_response(response)
     auth_user.refresh_from_db()
     assert auth_user.case_allowance_remaining == auth_user.total_case_allowance
@@ -237,8 +186,7 @@ def test_unlimited_access(auth_user, api_url, auth_client, case):
     auth_user.total_case_allowance = 0
     auth_user.case_allowance_remaining = 0
     auth_user.save()
-    url = "%scases/%s/?full_case=true" % (api_url, case.pk)
-    response = auth_client.get(url)
+    response = auth_client.get(case_url, {"full_case": "true"})
     check_response(response)
     result = response.json()
     casebody = result['casebody']
@@ -251,15 +199,14 @@ def test_unlimited_access(auth_user, api_url, auth_client, case):
     auth_user.case_allowance_remaining = 0
     auth_user.unlimited_access_until = timezone.now() - timedelta(hours=1)
     auth_user.save()
-    url = "%scases/%s/?full_case=true" % (api_url, case.pk)
-    response = auth_client.get(url)
+    response = auth_client.get(case_url, {"full_case": "true"})
     check_response(response)
     result = response.json()
     assert result['casebody']['status'] != 'ok'
 
 
 @pytest.mark.django_db
-def test_authenticated_multiple_full_cases(auth_user, api_url, auth_client, three_cases, jurisdiction, django_assert_num_queries):
+def test_authenticated_multiple_full_cases(auth_user, auth_client, three_cases, jurisdiction, django_assert_num_queries):
     ### mixed requests should be counted only for blacklisted cases
 
     # one whitelisted case
@@ -277,9 +224,8 @@ def test_authenticated_multiple_full_cases(auth_user, api_url, auth_client, thre
     len(jur_choices)
 
     # fetch the two blacklisted cases and one whitelisted case
-    url = "%scases/?full_case=true" % (api_url)
     with django_assert_num_queries(select=3):
-        response = auth_client.get(url)
+        response = auth_client.get(api_reverse("casemetadata-list"), {"full_case": "true"})
     check_response(response)
     # make sure the auth_user's case download number has gone down by 2
     auth_user.refresh_from_db()
@@ -288,13 +234,13 @@ def test_authenticated_multiple_full_cases(auth_user, api_url, auth_client, thre
 
 # CITATION REDIRECTS
 @pytest.mark.django_db
-def test_case_citation_redirect(api_url, client, citation):
+def test_case_citation_redirect(client, citation):
     """Should allow various forms of citation, should redirect to normalized_cite"""
-    url = "%scases/%s" % (api_url, citation.normalized_cite)
+    url = api_reverse("casemetadata-detail", args=[citation.normalized_cite])
 
     # should have received a redirect
     response = client.get(url)
-    check_response(response, status_code=301)
+    check_response(response, status_code=302)
 
     response = client.get(url, follow=True)
     check_response(response)
@@ -309,7 +255,7 @@ def test_case_citation_redirect(api_url, client, citation):
     assert citations_result[0]['cite'] == citation.cite
 
     # allow user to enter real citation (not normalized)
-    url = "%scases/%s" % (api_url, citation.cite)
+    url = api_reverse("casemetadata-get-cite", args=[citation.cite])
     response = client.get(url, follow=True)
 
     check_response(response)
@@ -322,9 +268,9 @@ def test_case_citation_redirect(api_url, client, citation):
     new_citation = CitationFactory(cite='1 Mass. 1', normalized_cite='1-mass-1', case=citation.case)
     new_citation.save()
 
-    url = "%scases/%s" % (api_url, new_citation.cite)
+    url = api_reverse("casemetadata-get-cite", args=[new_citation.cite])
     response = client.get(url)
-    check_response(response, status_code=301)
+    check_response(response, status_code=302)
     response = client.get(url, follow=True)
     check_response(response)
     content = response.json()['results']
@@ -335,7 +281,7 @@ def test_case_citation_redirect(api_url, client, citation):
 
 # FORMATS
 def get_casebody_data_with_format(client, case, body_format):
-    response = client.get(reverse('casemetadata-detail', args=[case.pk]), {"full_case": "true", "body_format": body_format})
+    response = client.get(api_reverse('casemetadata-detail', args=[case.pk]), {"full_case": "true", "body_format": body_format})
     check_response(response)
     content = response.json()
     casebody = content["casebody"]
@@ -363,21 +309,22 @@ def test_body_format_html(auth_client, case):
     assert "</h4>" in data
 
 @pytest.mark.django_db
-def test_full_text_search(api_url, client, ingest_case_xml):
+def test_full_text_search(client, ingest_case_xml):
     # filtering case with full-text search
     case_to_test = CaseXML.objects.get(metadata__case_id="32044057892259_0001").metadata
     wrong_case = CaseXML.objects.get(metadata__duplicative=True).metadata
-    response = client.get("%scases/?search=%s" % (api_url, "insurance peoria"))
+    response = client.get(api_reverse("casemetadata-list"), {"search": "insurance peoria"})
     content = response.json()
     assert [case_to_test.id] == [result['id'] for result in content['results']]
     assert [wrong_case.id] != [result['id'] for result in content['results']]
-    response = client.get("%scases/?search=%s" % (api_url, "Punk in Drublic"))
+    response = client.get(api_reverse("casemetadata-list"), {"search": "Punk in Drublic"})
     content = response.json()
     assert content == {'previous': None, 'count': 0, 'results': [], 'next': None}
 
 # FILTERING
 @pytest.mark.django_db
-def test_filter_case(api_url, client, three_cases, court, jurisdiction):
+def test_filter_case(client, three_cases, court, jurisdiction):
+    search_url = api_reverse("casemetadata-list")
 
     # filtering case by court
     case_to_test = three_cases[2]
@@ -389,26 +336,26 @@ def test_filter_case(api_url, client, three_cases, court, jurisdiction):
     case_to_test.name_abbreviation = "Bill v. Bob"
     case_to_test.save()
     assert case_to_test.name_abbreviation != three_cases[1].name_abbreviation
-    response = client.get("%scases/?name_abbreviation=%s" % (api_url, case_to_test.name_abbreviation))
+    response = client.get(search_url, {"name_abbreviation": case_to_test.name_abbreviation})
     content = response.json()
     assert [case_to_test.id] == [result['id'] for result in content['results']]
 
     # filtering case by name_abbreviation lowercased substring
     assert case_to_test.name_abbreviation != three_cases[1].name_abbreviation
-    response = client.get("%scases/?name_abbreviation=%s" % (api_url, "bill"))
+    response = client.get(search_url, {"name_abbreviation": "bill"})
     content = response.json()
     assert [case_to_test.id] == [result['id'] for result in content['results']]
 
     # filtering case by court substring
     case_to_test = three_cases[2]
     court = case_to_test.court
-    response = client.get("%scases/?court=%s" % (api_url, court.slug))
+    response = client.get(search_url, {"court": court.slug})
     content = response.json()
     assert [case_to_test.id] == [result['id'] for result in content['results']]
 
     # filtering case by reporter
     reporter = case_to_test.reporter
-    response = client.get("%scases/?reporter=%s" % (api_url, reporter.pk))
+    response = client.get(search_url, {"reporter": reporter.pk})
     content = response.json()
     assert [case_to_test.id] == [result['id'] for result in content['results']]
 
@@ -419,7 +366,7 @@ def test_filter_case(api_url, client, three_cases, court, jurisdiction):
     case_to_test.decision_date_original = "1988"
     case_to_test.decision_date = parse_decision_date(case_to_test.decision_date_original)
     case_to_test.save()
-    response = client.get("%scases/?decision_date_min=%s&decision_date_max=%s" % (api_url, "1987-12-30", "1988-01-02"))
+    response = client.get(search_url, {"decision_date_min": "1987-12-30", "decision_date_max": "1988-01-02"})
     content = response.json()
     result = content['results'][0]
     assert case_to_test.decision_date_original == result['decision_date']
@@ -431,8 +378,7 @@ def test_filter_case(api_url, client, three_cases, court, jurisdiction):
     jurisdiction.save()
     case_to_test.jurisdiction = jurisdiction
     case_to_test.save()
-
-    response = client.get("%scases/?jurisdiction=%s" % (api_url, jurisdiction.name), follow=True)
+    response = client.get(search_url, {"jurisdiction": jurisdiction.name}, follow=True)
     content = response.json()
     result = content['results'][0]
     assert case_to_test.jurisdiction.slug == result['jurisdiction']['slug']
@@ -441,7 +387,7 @@ def test_filter_case(api_url, client, three_cases, court, jurisdiction):
     case_to_test = three_cases[0]
     case_to_test.docket_number = "NUMBER 13-16-00273-CV"
     case_to_test.save()
-    response = client.get("%scases/?docket_number=%s" % (api_url, "13-16-00273"), follow=True)
+    response = client.get(search_url, {"docket_number": "13-16-00273"})
     content = response.json()
     result = content['results'][0]
     assert case_to_test.docket_number== result['docket_number']
@@ -449,27 +395,27 @@ def test_filter_case(api_url, client, three_cases, court, jurisdiction):
 
 
 @pytest.mark.django_db
-def test_filter_court(api_url, client, court):
+def test_filter_court(client, court):
     # filtering court by jurisdiction
     jur_slug = court.jurisdiction.slug
-    response = client.get("%scourts/?jurisdiction_slug=%s" % (api_url, jur_slug))
+    response = client.get(api_reverse("court-list"), {"jurisdiction_slug": jur_slug})
     check_response(response)
     results = response.json()['results']
     assert court.name_abbreviation == results[0]['name_abbreviation']
 
     # filtering court by name substring
     court_name_str = court.name.split(' ')[1]
-    response = client.get("%scourts/?name=%s" % (api_url, court_name_str))
+    response = client.get(api_reverse("court-list"), {"name": court_name_str})
     content = response.json()
     for result in content['results']:
         assert court_name_str in result['name']
 
 
 @pytest.mark.django_db
-def test_filter_reporter(api_url, client, reporter):
+def test_filter_reporter(client, reporter):
     # filtering reporter by name substring
     reporter_name_str = reporter.full_name.split(' ')[1]
-    response = client.get("%sreporters/?full_name=%s" % (api_url, reporter_name_str))
+    response = client.get(api_reverse("reporter-list"), {"full_name": reporter_name_str})
     content = response.json()
     for result in content['results']:
         assert reporter_name_str in result['full_name']
@@ -477,40 +423,36 @@ def test_filter_reporter(api_url, client, reporter):
 
 # RESPONSE FORMATS
 @pytest.mark.django_db
-def test_formats(api_url, client, auth_client, case):
-    formats = [
-        ('html', 'text/html'),
-        ('xml', 'application/xml'),
-        ('json', 'application/json'),
-    ]
-    for format, content_type in formats:
-        # test format html without api_key
-        url = "%scases/%s/?format=%s&full_case=true" % (api_url, case.id, format)
-        response = client.get(url)
-        check_response(response, content_type=content_type)
-        response_content = response.content.decode()
-        assert 'error' in response_content.lower()
+@pytest.mark.parametrize("format, content_type", [
+    ('html', 'text/html'),
+    ('xml', 'application/xml'),
+    ('json', 'application/json'),
+])
+def test_formats(client, auth_client, case, format, content_type):
+    # test format without api_key
+    response = client.get(api_reverse("casemetadata-detail", args=[case.id]), {"format": format, "full_case": "true"})
+    check_response(response, content_type=content_type)
+    response_content = response.content.decode()
+    assert 'error' in response_content.lower()
 
-        # test full, authorized case
-        url = "%scases/%s/?format=%s&full_case=true" % (api_url, case.id, format)
-        response = auth_client.get(url)
-        check_response(response, content_type=content_type, content_includes=case.name)
+    # test full, authorized case
+    response = auth_client.get(api_reverse("casemetadata-detail", args=[case.id]), {"format": format, "full_case": "true"})
+    check_response(response, content_type=content_type, content_includes=case.name)
 
 
 # API SPECIFICATION ENDPOINTS
 @pytest.mark.django_db
-def test_swagger(client):
-    routes = [
-        ('/', 'text/html'),
-        ('.json', 'application/json'),
-        ('.yaml', 'application/yaml'),
-    ]
-    for route, content_type in routes:
-        response = client.get("/swagger%s" % route)
-        check_response(response, content_type=content_type)
+@pytest.mark.parametrize("url, content_type", [
+    (api_reverse("schema-swagger-ui"), 'text/html'),
+    (api_reverse("schema-json", args=['.json']), 'application/json'),
+    (api_reverse("schema-json", args=['.yaml']), 'application/yaml'),
+])
+def test_swagger(client, url, content_type):
+    response = client.get(url)
+    check_response(response, content_type=content_type)
 
 
 @pytest.mark.django_db
 def test_redoc(client):
-    response = client.get("/redoc/")
+    response = client.get(api_reverse("schema-redoc"))
     check_response(response, content_type="text/html")

--- a/capstone/capapi/tests/test_cache.py
+++ b/capstone/capapi/tests/test_cache.py
@@ -2,9 +2,10 @@ from copy import deepcopy
 
 import pytest
 from django.http import SimpleCookie
-from django.urls import reverse
 
+from capapi.resources import api_reverse  # noqa -- this is dynamically used by test_cache_headers
 from capapi.tests.helpers import is_cached
+from capweb.helpers import reverse
 
 
 @pytest.mark.django_db
@@ -20,18 +21,18 @@ from capapi.tests.helpers import is_cached
     ("user-details",        True,   False,   {}),
 
     # api views are cached for both logged in and logged out
-    ("casemetadata-list",   True,   True,   {}),
-    ("casemetadata-list",   True,   True,   {"HTTP_ACCEPT": "text/html"}),
+    ("casemetadata-list",   True,   True,   {"reverse_func": "api_reverse"}),
+    ("casemetadata-list",   True,   True,   {"HTTP_ACCEPT": "text/html", "reverse_func": "api_reverse"}),
 
     # api views that depend on the user account are cached only for logged out
-    ("casemetadata-list",   True,   False,  {"data": {"full_case": "true"}}),
+    ("casemetadata-list",   True,   False,  {"data": {"full_case": "true"}, "reverse_func": "api_reverse"}),
 
     # bulk list cacheable only for logged-out users
     ("bulk-data",           True,   False,  {}),
 
     # bulk downloads are cached if public, or private requested by logged-out users
-    ("caseexport-download", True, True,     {"reverse_args": ["fixture_case_export"]}),
-    ("caseexport-download", True, False,    {"reverse_args": ["fixture_private_case_export"]}),
+    ("caseexport-download", True, True,     {"reverse_args": ["fixture_case_export"], "reverse_func": "api_reverse"}),
+    ("caseexport-download", True, False,    {"reverse_args": ["fixture_private_case_export"], "reverse_func": "api_reverse"}),
 ])
 @pytest.mark.parametrize("client_fixture_name", ["client", "auth_client"])
 def test_cache_headers(case, request, settings,
@@ -50,7 +51,11 @@ def test_cache_headers(case, request, settings,
     for i, arg in enumerate(reverse_args):
         if arg.startswith("fixture_"):
             reverse_args[i] = request.getfuncargvalue(arg.split('_', 1)[1]).pk
-    url = reverse(view_name, args=reverse_args)
+
+    # reverse from the view name, using get_kwargs['reverse_func'] or reverse() by default
+    reverse_func = get_kwargs.pop('reverse_func', 'reverse')
+    reverse_func = globals()[reverse_func]
+    url = reverse_func(view_name, args=reverse_args)
 
     # see if response is cached
     response = client.get(url, **get_kwargs)

--- a/capstone/capapi/tests/test_serializers.py
+++ b/capstone/capapi/tests/test_serializers.py
@@ -1,16 +1,14 @@
-import os
-
 import pytest
 from rest_framework.request import Request
 
 from capapi import serializers
+from capapi.resources import api_reverse
 
 
 @pytest.mark.django_db
-def test_CaseSerializerWithCasebody(api_url, api_request_factory, case, three_cases):
+def test_CaseSerializerWithCasebody(api_request_factory, case, three_cases):
     # can get single case data
-    url = os.path.join(api_url, "cases")
-    request = api_request_factory.get(url)
+    request = api_request_factory.get(api_reverse("casemetadata-list"))
     serializer_context = {'request': Request(request)}
 
     serialized = serializers.CaseSerializerWithCasebody(case, context=serializer_context)

--- a/capstone/capapi/urls.py
+++ b/capstone/capapi/urls.py
@@ -1,52 +1,16 @@
-from django.urls import path, re_path, include
+from django.urls import path
 from django.views.generic import TemplateView
-from rest_framework import routers, permissions
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
 
-from capapi.views import api_views, viz_views
+from capapi.views import viz_views
 
-
-router = routers.DefaultRouter()
-router.register('cases', api_views.CaseViewSet)
-router.register('citations', api_views.CitationViewSet)
-router.register('jurisdictions', api_views.JurisdictionViewSet)
-router.register('courts', api_views.CourtViewSet)
-router.register('volumes', api_views.VolumeViewSet)
-router.register('reporters', api_views.ReporterViewSet)
-router.register('bulk', api_views.CaseExportViewSet)
-
-schema_view = get_schema_view(
-    openapi.Info(
-        title="CAP API",
-        default_version='v1',
-        description="United States Caselaw",
-        terms_of_service="https://capapi.org/terms",
-        contact=openapi.Contact(email="lil@law.harvard.edu"),
-    ),
-    validators=['flex', 'ssv'],
-    public=True,
-    permission_classes=(permissions.AllowAny,),
-)
 
 urlpatterns = [
     ### pages ###
     # path('', doc_views.home, name='home'),
     path('robots.txt', TemplateView.as_view(template_name='robots.txt', content_type='text/plain'), name='robots'),
 
-    ### api ###
-    path('api/v1/', include(router.urls)),
-    # convenience pattern: catch all citations, redirect in CaseViewSet's retrieve
-    re_path(r'^api/v1/cases/(?P<id>[0-9A-Za-z\s\.]+)/$', api_views.CaseViewSet.as_view({'get': 'retrieve'}), name='casemetadata-get-cite'),
-
     ### data views ###
     path('data/', viz_views.totals_view, name='totals_view'),
     path('data/details/', viz_views.details_view, name='details_view'),
     path('data/details/<str:slug>', viz_views.get_details, name='get_details'),
-
-    ### Swagger/OpenAPI/ReDoc ###
-    re_path(r'^swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=None), name='schema-json'),
-    re_path(r'^swagger/$', schema_view.with_ui('swagger', cache_timeout=None), name='schema-swagger-ui'),
-    re_path(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=None), name='schema-redoc'),
-
 ]

--- a/capstone/capweb/helpers.py
+++ b/capstone/capweb/helpers.py
@@ -1,5 +1,6 @@
 import json
 import requests
+from django_hosts import reverse as django_hosts_reverse
 
 
 def get_data_from_lil_site(section="news"):
@@ -13,3 +14,9 @@ def get_data_from_lil_site(section="news"):
         end_index = -1
     data = json.loads(content.strip()[start_index + 1:end_index])
     return data[section]
+
+def reverse(*args, **kwargs):
+    """
+        This is a direct passthrough to django_hosts.reverse for now, but kept as a wrapper so we can tweak as needed.
+    """
+    return django_hosts_reverse(*args, **kwargs)

--- a/capstone/capweb/templates/api.html
+++ b/capstone/capweb/templates/api.html
@@ -1,7 +1,7 @@
 {% extends "main_base.html" %}
 {% load static %}
 {% load pipeline %}
-{% load full_url %}
+{% load api_url %}
 
 {% block title %} — API{% endblock %}
 
@@ -62,7 +62,7 @@
                    src="{% static "img/vacuum-seal.jpg" %}">
             </p>
             <a id="overview"></a>
-            <p><a href="{% url "api-root" %}" class="font-weight-bold">Browse the API</a></p>
+            <p><a href="{% api_url "api-root" %}" class="font-weight-bold">Browse the API</a></p>
             <p>
               The Caselaw Access Project API, also known as CAPAPI, serves all official US court cases
               published in books from 1658 to 2018. The collection includes over six million cases scanned from
@@ -75,11 +75,11 @@
               format with case text available as structured XML, presentation HTML, or plain text.
             </p>
             <p>
-              To get started with the API, you can <a href="{%url "api-root" %}">explore it in your browser,</a>
+              To get started with the API, you can <a href="{% api_url "api-root" %}">explore it in your browser,</a>
               or reach it from the command line. For example, here is a curl command to list cases from Illinois:</p>
             <blockquote>
               <code>
-                curl "{% full_url "casemetadata-list" %}?jurisdiction=ill"
+                curl "{% api_url "casemetadata-list" %}?jurisdiction=ill"
               </code>
             </blockquote>
             <p>
@@ -141,7 +141,7 @@
             </p>
             <blockquote>
               <code>
-                curl -H "Authorization: Token abcd12345" "{% full_url "casemetadata-list" %}?full_case=true"
+                curl -H "Authorization: Token abcd12345" "{% api_url "casemetadata-list" %}?full_case=true"
               </code>
             </blockquote>
             <p>
@@ -160,7 +160,7 @@
               Text format
               (default)
               (<code>body_format=text</code>)
-              (<a href="{% url "casemetadata-list" %}?jurisdiction=ill&full_case=true" %}">example query</a>)
+              (<a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true" %}">example query</a>)
             </h4>
             <p>
               The default text format is best for natural language processing. Example response data:
@@ -195,7 +195,7 @@
             <h4>
               XML format
               (<code>body_format=xml</code>)
-              (<a href="{% url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=xml" %}">example query</a>)
+              (<a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=xml" %}">example query</a>)
             </h4>
             <p>
               The XML format is best if your analysis requires more information about pagination, formatting, or page
@@ -208,7 +208,7 @@
             <h4>
               HTML format
               (<code>body_format=html</code>)
-              (<a href="{% url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html" %}">example query</a>)
+              (<a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html" %}">example query</a>)
             </h4>
             <p>
               The HTML format is best if you want to show readable, formatted caselaw to humans. It represents a
@@ -228,8 +228,8 @@
             <pre>{% filter force_escape %}
 {
   "count": 183149,
-  "next": "{% url "casemetadata-list" %}?body_format=html&cursor=cD0xODMyLTEyLTAx",
-  "previous": "{% url "casemetadata-list" %}?body_format=html&cursor=bz0xMCZyPTEmcD0xODI4LTEyLTAx"
+  "next": "{% api_url "casemetadata-list" %}?body_format=html&cursor=cD0xODMyLTEyLTAx",
+  "previous": "{% api_url "casemetadata-list" %}?body_format=html&cursor=bz0xMCZyPTEmcD0xODI4LTEyLTAx"
   ...
 }
             {% endfilter %}</pre>
@@ -341,8 +341,8 @@
                 Retrieve a single case, by its ID
               </dt>
               <dd class="example-link">
-                <a href="{% url "casemetadata-list" %}{{ case_id }}/">
-                  {% full_url "casemetadata-list" %}{{ case_id }}/</a>
+                <a href="{% api_url "casemetadata-list" %}{{ case_id }}/">
+                  {% api_url "casemetadata-list" %}{{ case_id }}/</a>
               </dd>
               <dd>
                 <p class="example-description">
@@ -354,8 +354,8 @@
                   <li class="list-group-item">
                     <lh>With HTML-formatted Case Body and Metadata</lh>
                     <ul>
-                      <li class="example-mod-url"><a href="{% url "casemetadata-list" %}{{ case_id }}/">
-                        {% full_url "casemetadata-list" %}{{ case_id }}/</a>
+                      <li class="example-mod-url"><a href="{% api_url "casemetadata-list" %}{{ case_id }}/">
+                        {% api_url "casemetadata-list" %}{{ case_id }}/</a>
                       </li>
                       <li class="example-mod-description">To ingest a JSON object with both metadata and a field
                         containing an easily stylable HTML case body, set the <code>body_format</code> parameter to
@@ -367,8 +367,8 @@
                     <lh>Raw original XML document, with METS data</lh>
                     <ul>
                       <li class="example-mod-url">
-                        <a href="{% url "casemetadata-list" %}{{ case_id }}/?full_case=true&body_format=xml">
-                          {% full_url "casemetadata-list" %}{{ case_id }}/?full_case=true&format=xml
+                        <a href="{% api_url "casemetadata-list" %}{{ case_id }}/?full_case=true&body_format=xml">
+                          {% api_url "casemetadata-list" %}{{ case_id }}/?full_case=true&format=xml
                         </a>
                       </li>
                       <li class="example-mod-description">To get the document by itself, without the JSON enclosure and
@@ -385,8 +385,8 @@
                 Retrieve a list of cases using a metadata filter
               </dt>
               <dd class="example-link">
-                <a href="{% url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}">
-                  {% full_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}
+                <a href="{% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}">
+                  {% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}
                 </a>
               </dd>
               <dd>
@@ -405,8 +405,8 @@
                     <lh>Add a date range filter</lh>
                     <ul>
                       <li class="example-mod-url">
-                        <a href="{% url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-12-30">
-                          {% full_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-06-15
+                        <a href="{% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-12-30">
+                          {% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-06-15
                         </a>
                       </li>
                       <li class="example-mod-description">You can combine any of these parameters to refine your search.
@@ -424,8 +424,8 @@
                 Simple Full-Text Search
               </dt>
               <dd class="example-link">
-                <a href="{% url "casemetadata-list" %}?search=insurance">
-                  {% full_url "casemetadata-list" %}?search=insurance
+                <a href="{% api_url "casemetadata-list" %}?search=insurance">
+                  {% api_url "casemetadata-list" %}?search=insurance
                 </a>
               </dd>
               <dd>
@@ -444,8 +444,8 @@
                     <lh>Add Search Term</lh>
                     <ul>
                       <li class="example-mod-url">
-                        <a href="{% url "casemetadata-list" %}?search=insurance Peoria">
-                          {% full_url "casemetadata-list" %}?search=insurance Peoria
+                        <a href="{% api_url "casemetadata-list" %}?search=insurance Peoria">
+                          {% api_url "casemetadata-list" %}?search=insurance Peoria
                         </a>
                       </li>
                       <li class="example-mod-description">You can narrow your search results by adding terms, separated
@@ -457,8 +457,8 @@
                     <lh>Filter Search With Metadata</lh>
                     <ul>
                       <li class="example-mod-url">
-                        <a href="{% url "casemetadata-list" %}?search=insurance Peoria&jurisdiction=ill">
-                          {% full_url "casemetadata-list" %}?search=insurance Peoria&jurisdiction=ill
+                        <a href="{% api_url "casemetadata-list" %}?search=insurance Peoria&jurisdiction=ill">
+                          {% api_url "casemetadata-list" %}?search=insurance Peoria&jurisdiction=ill
                         </a>
                       </li>
                       <li class="example-mod-description">These queries can be filtered using other metadata fields.
@@ -477,7 +477,7 @@
                 Traversing Pages of Results
               </dt>
               <dd class="example-link">
-                <a href="{% url "casemetadata-list" %}?offset=100">{% full_url "casemetadata-list" %}?offset=100</a>
+                <a href="{% api_url "casemetadata-list" %}?offset=100">{% api_url "casemetadata-list" %}?offset=100</a>
               </dd>
               <dd>
                 <p class="example-description">
@@ -491,8 +491,8 @@
                     <lh>Get smaller list of results</lh>
                     <ul>
                       <li class="example-mod-url">
-                        <a href="{% url "casemetadata-list" %}?offset=10&limit=10">
-                          {% full_url "casemetadata-list" %}?offset=20&limit=10
+                        <a href="{% api_url "casemetadata-list" %}?offset=10&limit=10">
+                          {% api_url "casemetadata-list" %}?offset=20&limit=10
                         </a>
                       </li>
                       <li class="example-mod-description">Combining the offset and limit parameters, you can get a
@@ -510,8 +510,8 @@
                 Get all reporters in a jurisdiction
               </dt>
               <dd class="example-link">
-                <a href="{% url "reporter-list" %}?jurisdictions=ark">
-                  {% full_url "reporter-list" %}?jurisdictions=ark
+                <a href="{% api_url "reporter-list" %}?jurisdictions=ark">
+                  {% api_url "reporter-list" %}?jurisdictions=ark
                 </a>
               </dd>
               <dd>
@@ -536,7 +536,7 @@
                 API Base
               </dt>
               <dd class="endpoint-link">
-                <a href="{%url "api-root" %}/">{{ request.build_absolute_uri }}v1/</a>
+                <a href="{% api_url "api-root" %}/">{{ request.build_absolute_uri }}v1/</a>
               </dd>
               <dd>
                 <p class="endpoint-description">
@@ -551,7 +551,7 @@
                 Case Browse/Search Endpoint
               </dt>
               <dd class="endpoint-link">
-                <a href="{% url "casemetadata-list" %}">{% full_url "casemetadata-list" %}</a>
+                <a href="{% api_url "casemetadata-list" %}">{% api_url "casemetadata-list" %}</a>
               </dd>
               <dd>
                 <p class="endpoint-description">
@@ -659,7 +659,7 @@
                 Single Case Endpoint
               </dt>
               <dd class="endpoint-link">
-                <a href="{% url "casemetadata-list" %}">{% full_url "casemetadata-list" %}</a>
+                <a href="{% api_url "casemetadata-list" %}">{% api_url "casemetadata-list" %}</a>
               </dd>
               <dd>
                 <p class="endpoint-description">
@@ -726,7 +726,7 @@
                 Reporters
               </dt>
               <dd>
-                <a href="{% url "reporter-list" %}">{% full_url "reporter-list" %}</a>
+                <a href="{% api_url "reporter-list" %}">{% api_url "reporter-list" %}</a>
                 <p class="endpoint-description">
                   This will return a list of reporter series.
                 </p>
@@ -796,7 +796,7 @@
                 Jurisdictions
               </dt>
               <dd>
-                <a href="{% url "jurisdiction-list" %}">{% full_url "jurisdiction-list" %}</a>
+                <a href="{% api_url "jurisdiction-list" %}">{% api_url "jurisdiction-list" %}</a>
                 <p class="endpoint-description">
                   This will return a list of jurisdictions.
                 </p>
@@ -868,7 +868,7 @@
                 Courts
               </dt>
               <dd>
-                <a href="{% url "court-list" %}">{% full_url "court-list" %}</a>
+                <a href="{% api_url "court-list" %}">{% api_url "court-list" %}</a>
                 <p class="endpoint-description">
                   This will return a list of courts.
                 </p>
@@ -934,7 +934,7 @@
                 Volumes
               </dt>
               <dd>
-                <a href="{% url "volumemetadata-list" %}">{% full_url "volumemetadata-list" %}</a>
+                <a href="{% api_url "volumemetadata-list" %}">{% api_url "volumemetadata-list" %}</a>
                 <p class="endpoint-description">
                   This will return a complete list of volumes.
                 </p>
@@ -970,7 +970,7 @@
                 Citations
               </dt>
               <dd>
-                <a href="{% url "citation-list" %}">{% full_url "citation-list" %}</a>
+                <a href="{% api_url "citation-list" %}">{% api_url "citation-list" %}</a>
                 <p class="endpoint-description">
                   This will return a list of citations.
                 </p>

--- a/capstone/capweb/templatetags/api_url.py
+++ b/capstone/capweb/templatetags/api_url.py
@@ -1,0 +1,9 @@
+from django import template
+from capapi import api_reverse
+
+register = template.Library()
+
+@register.simple_tag()
+def api_url(url_name, *args, **kwargs):
+    """ Like the {% url %} tag, but output includes the full domain. """
+    return api_reverse(url_name, args=args, kwargs=kwargs)

--- a/capstone/capweb/templatetags/full_url.py
+++ b/capstone/capweb/templatetags/full_url.py
@@ -1,9 +1,0 @@
-from django import template
-from rest_framework.reverse import reverse
-
-register = template.Library()
-
-@register.simple_tag(takes_context=True)
-def full_url(context, url_name, *args, **kwargs):
-    """ Like the {% url %} tag, but output includes the full domain. """
-    return reverse(url_name, args=args, kwargs=kwargs, request=context.request)

--- a/capstone/capweb/tests/test_ui.py
+++ b/capstone/capweb/tests/test_ui.py
@@ -1,12 +1,11 @@
 import pytest
 
 from bs4 import BeautifulSoup
-from rest_framework.reverse import reverse
 
 from django.conf import settings
 
 from capapi.tests.helpers import check_response
-
+from capweb.helpers import reverse
 
 
 @pytest.mark.django_db

--- a/capstone/config/hosts.py
+++ b/capstone/config/hosts.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+from django_hosts import patterns, host
+
+host_patterns = patterns('',
+    host(r'', settings.ROOT_URLCONF, name='default'),
+    host(r'api', 'capapi.api_urls', name='api'),
+)

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'simple_history',   # model versioning
     'bootstrap4',   # bootstrap form rendering
     'drf_yasg',   # API specification
+    'django_hosts',     # subdomain routing
 ]
 
 REST_FRAMEWORK = {
@@ -69,6 +70,9 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
 
+    # docs say this should come "first", though we're not putting it quite that early
+    'django_hosts.middleware.HostsRequestMiddleware',
+
     # cache middleware should come before:
     # - CsrfViewMiddleware, to skip caching on views that use csrf
     # - SessionMiddleware, to skip caching on views that set session cookies
@@ -82,9 +86,20 @@ MIDDLEWARE = [
     'capapi.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    # docs say this should come last
+    'django_hosts.middleware.HostsResponseMiddleware',
 ]
 
 ROOT_URLCONF = 'config.urls'
+
+# django_hosts settings
+ROOT_HOSTCONF = 'config.hosts'
+API_URLCONF = 'capapi.api_urls'  # solely so `./manage.py show_urls -c API_URLCONF` can work
+DEFAULT_HOST = 'default'
+PARENT_HOST = 'case.test:8000'
+
+SESSION_COOKIE_DOMAIN = '.case.test'
 
 TEMPLATES = [
     {
@@ -99,6 +114,9 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
+            'builtins': [
+                'django_hosts.templatetags.hosts_override',
+            ]
         },
     },
 ]

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -49,9 +49,10 @@ try:
     INSTALLED_APPS += (
         'debug_toolbar',
     )
-    MIDDLEWARE = [
-        'debug_toolbar.middleware.DebugToolbarMiddleware',
-    ] + MIDDLEWARE
+    MIDDLEWARE.insert(
+        MIDDLEWARE.index('django_hosts.middleware.HostsRequestMiddleware')+1,
+        'debug_toolbar.middleware.DebugToolbarMiddleware'
+    )
     INTERNAL_IPS = ['127.0.0.1']
 except ImportError:
     pass

--- a/capstone/config/settings/settings_travis.py
+++ b/capstone/config/settings/settings_travis.py
@@ -7,7 +7,7 @@ DATABASES['default'].setdefault('OPTIONS', {})
 DATABASES['default']['OPTIONS']['sslmode'] = 'disable'
 
 DEBUG = False
-ALLOWED_HOSTS = ['127.0.0.1']
+ALLOWED_HOSTS = ['*']
 
 # Use production django-pipeline storage. This works because Travis runs collectstatic.
 STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -33,6 +33,7 @@ whitenoise          # serve static assets
 django-simple-history   # model versioning
 django-partial-index    # create partial postgres indexes
 django-redis        # use redis as Django cache backend
+django-hosts        # URL routing across subdomains
 
 # Admin stuff
 pip-tools           # freeze requirements.txt

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -39,6 +39,7 @@ django-bulk-update==2.1.0
 django-compressor==2.1.1  # via django-libsass
 django-extensions==2.0.6
 django-filter==2.0.0
+django-hosts==3.0
 django-libsass==0.7
 django-partial-index==0.4.0
 django-pipeline==1.6.14


### PR DESCRIPTION
This moves the `/api/v1/` route to `api.example.com/v1/`. Requires various changes for various people:

**For programmers:** Be sure to use functions for generating URLs instead of hardcoding them. Use `capweb.helpers.reverse` (`{% url %}` in templates) to reverse non-api urls. Use `capapi.resources.api_reverse` (`{% api_url %}` in templates) to reverse api urls.

To find the name of URLs to reverse, use `./manage.py show_urls` or `./manage.py show_urls -c API_URLCONF`.

**For local dev:** Add to your hosts file:

    127.0.0.1       case.test
    127.0.0.1       api.case.test

You can then visit the dev server at `case.test:8000`.

**For deployment:**

Prod deployments require three settings changes:

    PARENT_HOST = 'example.com:8000'
    SESSION_COOKIE_DOMAIN = '.example.com'
    ALLOWED_HOSTS = ['example.com', 'api.example.com']

The server can then have either or both of `example.com` and `api.example.com` pointed to it.