### PR TITLE
Subdomains configurable from settings

### DIFF
--- a/capstone/config/hosts.py
+++ b/capstone/config/hosts.py
@@ -1,7 +1,5 @@
 from django.conf import settings
 from django_hosts import patterns, host
 
-host_patterns = patterns('',
-    host(r'', settings.ROOT_URLCONF, name='default'),
-    host(r'api', 'capapi.api_urls', name='api'),
-)
+hosts = [host(config["subdomain"], config["urlconf"], name=name) for name, config in settings.HOSTS.items()]
+host_patterns = patterns('', *hosts)

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -93,13 +93,22 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'config.urls'
 
-# django_hosts settings
+### subdomain settings
 ROOT_HOSTCONF = 'config.hosts'
-API_URLCONF = 'capapi.api_urls'  # solely so `./manage.py show_urls -c API_URLCONF` can work
-DEFAULT_HOST = 'default'
 PARENT_HOST = 'case.test:8000'
-
-SESSION_COOKIE_DOMAIN = '.case.test'
+SESSION_COOKIE_DOMAIN = '.case.test'  # make sure cookies are visible from all hosts
+DEFAULT_HOST = 'default'  # which key from HOSTS is used by default if no host is specified for reverse()
+# used in config.hosts to set up our subdomains:
+HOSTS = {
+    'default': {
+        'subdomain': '',
+        'urlconf': 'config.urls',
+    },
+    'api': {
+        'subdomain': 'api',
+        'urlconf': 'capapi.api_urls',
+    },
+}
 
 TEMPLATES = [
     {

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -18,6 +18,7 @@ try:
 except Exception as e:
     print("WARNING: Can't configure Django -- tasks depending on Django will fail:\n%s" % e)
 
+from django.core import management
 from django.db import connections
 from django.utils.encoding import force_str
 from django.conf import settings
@@ -42,6 +43,14 @@ def run_django(port="127.0.0.1:8000"):
 def test():
     """ Run tests with coverage report. """
     local("pytest --fail-on-template-vars --cov --cov-report=")
+
+@task
+def show_urls():
+    """ Show routable URLs and their names, across all subdomains. """
+    for name, host in settings.HOSTS.items():
+        settings.URLCONF = host["urlconf"]
+        print("\nURLs for %s (%s):\n" % (name, host["urlconf"]))
+        management.call_command('show_urls', urlconf='URLCONF')
 
 @task
 def sync_with_s3():


### PR DESCRIPTION
This should let you get everything running for stage without fourth-level subdomains:

```
PARENT_HOST = 'capapi.org'
SESSION_COOKIE_DOMAIN = '.capapi.org'
HOSTS["default"]["subdomain"] = 'stage'
HOSTS["api"]["subdomain"] = 'stage-api'
```