### PR TITLE
"See API" shouldn't point to bulk data

### DIFF
--- a/capstone/capweb/templates/tools.html
+++ b/capstone/capweb/templates/tools.html
@@ -71,7 +71,7 @@
                   metadata, full-text search, or individual cases.
               </p>
               <a class="btn btn-default"
-                 href="{% url "bulk-data" %}">See API</a>
+                 href="{% url "api" %}">See API</a>
               <br/><br/>
             </div>
 


### PR DESCRIPTION
Points this button-link on tools > overview to the api docs. I could imagine it pointing to the api root: up to you folks!

![image](https://user-images.githubusercontent.com/11020492/45847234-60fe7400-bcf8-11e8-8758-626d3ccf37b5.png)

Reject if desired.

