### PR TITLE
Add .bullets list style

### DIFF
--- a/capstone/capweb/templates/about.html
+++ b/capstone/capweb/templates/about.html
@@ -96,7 +96,7 @@ About the Caselaw Access Project
                 Scope limits
               </h2>
               <p>CAP does not include:</p>
-              <ul>
+              <ul class="bullets">
                 <li>
                   New cases as they are published. We currently include volumes published through
                   June, 2018, and may or may not include additional volumes in the future.

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -55,6 +55,14 @@ ol.alpha > li {
   list-style-type: lower-alpha;
   padding-left: 1rem;
 }
+
+ul.bullets {
+  padding-left: 1.5em !important;
+  li {
+    list-style-type: circle;
+  }
+}
+
 section {
   width: 100%;
 }
@@ -410,7 +418,7 @@ li.item-set {
       @include make-col(8);
     }
   }
-  p {
+  p, ul {
     margin-bottom: 2rem;
   }
 }


### PR DESCRIPTION
I have some `<li>` elements in the About text that want normal bullet styling.

My favorite way to do this would be to remove the top-level `ul {padding-left: 0;} li {list-style: none;}`, and adjust list styles case-by-case. But since that's a bigger change, maybe a good compromise is to revert to default styles within `.page-section`?