### PR TITLE
Page `<title>`s

### DIFF
--- a/capstone/capapi/templates/400.html
+++ b/capstone/capapi/templates/400.html
@@ -1,6 +1,8 @@
 {% extends "main_base.html" %}
 {% load pipeline %}
 
+{% block title %}400 Bad Request | {% endblock %}
+
 {% block content %}
   <div class="basic-page">
     <div class="full-content">

--- a/capstone/capapi/templates/403.html
+++ b/capstone/capapi/templates/403.html
@@ -1,6 +1,8 @@
 {% extends "main_base.html" %}
 {% load pipeline %}
 
+{% block title %}Permission denied | {% endblock %}
+
 {% block content %}
   <div class="basic-page">
     <div class="full-content">

--- a/capstone/capapi/templates/403_csrf.html
+++ b/capstone/capapi/templates/403_csrf.html
@@ -1,6 +1,8 @@
 {% extends "main_base.html" %}
 {% load pipeline %}
 
+{% block title %}CSRF verification failed | {% endblock %}
+
 {% block content %}
   <div class="basic-page">
     <div class="full-content">

--- a/capstone/capapi/templates/404.html
+++ b/capstone/capapi/templates/404.html
@@ -1,6 +1,8 @@
 {% extends "main_base.html" %}
 {% load pipeline %}
 
+{% block title %}404 Not Found | {% endblock %}
+
 {% block content %}
   <div class="basic-page">
     <div class="full-content">

--- a/capstone/capapi/templates/500.html
+++ b/capstone/capapi/templates/500.html
@@ -1,6 +1,8 @@
 {% extends "main_base.html" %}
 {% load pipeline %}
 
+{% block title %}500 Internal Server Error | {% endblock %}
+
 {% block content %}
   <div class="basic-page">
     <div class="full-content">

--- a/capstone/capapi/templates/bulk.html
+++ b/capstone/capapi/templates/bulk.html
@@ -1,7 +1,7 @@
 {% extends "main_base.html" %}
 {% load pipeline %}
 {% load static %}
-{% block title %} - Bulk Access {% endblock %}
+{% block title %}Bulk Access | {% endblock %}
 
 {% block extra_head %}
   {% stylesheet 'tools' %}

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -5,7 +5,7 @@
   {% stylesheet 'case' %}
 {% endblock %}
 
-{% block title %} | {{ title }}{% endblock %}
+{% block title %}{{ title }} | {% endblock %}
 
 {% block content %}
   <div class="container header-margin">

--- a/capstone/capapi/templates/error.html
+++ b/capstone/capapi/templates/error.html
@@ -1,6 +1,6 @@
 {% extends "main_base.html" %}
 
-{% block title %} | Error{% endblock %}
+{% block title %}Error | {% endblock %}
 
 {% block content %}
   {% load rest_framework %}

--- a/capstone/capapi/templates/registration/base.html
+++ b/capstone/capapi/templates/registration/base.html
@@ -1,7 +1,7 @@
 {% extends "main_base.html" %}
 {% load pipeline %}
 
-{% block title %} | {{ title }}{% endblock %}
+{% block title %}{{ title }} | {% endblock %}
 
 {% block extra_head %}
   {% stylesheet 'registration' %}

--- a/capstone/capapi/templates/registration/logged_out.html
+++ b/capstone/capapi/templates/registration/logged_out.html
@@ -1,7 +1,7 @@
 {% extends "registration/base.html" %}
 {% load static %}
 
-{% block title %} — Logged out{% endblock %}
+{% block title %}Logged out | {% endblock %}
 
 {% block meta_description %}
 You have been logged out

--- a/capstone/capapi/templates/registration/login.html
+++ b/capstone/capapi/templates/registration/login.html
@@ -2,7 +2,7 @@
 {% load bootstrap4 %}
 {% load static %}
 
-{% block title %} - Sign In{% endblock %}
+{% block title %}Sign In | {% endblock %}
 
 {% block meta_description %}
 Sign in to Caselaw Access Project

--- a/capstone/capapi/templates/registration/password_change_done.html
+++ b/capstone/capapi/templates/registration/password_change_done.html
@@ -1,7 +1,7 @@
 {% extends "registration/base.html" %}
 {% load static %}
 
-{% block title %} — Password change successful{% endblock %}
+{% block title %}Password change successful | {% endblock %}
 
 {% block meta_description %}
 Password change successful

--- a/capstone/capapi/templates/registration/password_change_form.html
+++ b/capstone/capapi/templates/registration/password_change_form.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load bootstrap4 %}
 
-{% block title %} — Password change{% endblock %}
+{% block title %}Password change | {% endblock %}
 
 {% block meta_description %}
 Password change form

--- a/capstone/capapi/templates/registration/password_reset_complete.html
+++ b/capstone/capapi/templates/registration/password_reset_complete.html
@@ -1,7 +1,7 @@
 {% extends "registration/base.html" %}
 {% load static %}
 
-{% block title %} — Password reset complete{% endblock %}
+{% block title %}Password reset complete | {% endblock %}
 
 {% block meta_description %}
 Password reset complete

--- a/capstone/capapi/templates/registration/password_reset_confirm.html
+++ b/capstone/capapi/templates/registration/password_reset_confirm.html
@@ -1,7 +1,7 @@
 {% extends "registration/base.html" %}
 {% load bootstrap4 %}
 
-{% block title %} — Password reset{% endblock %}
+{% block title %}Password reset | {% endblock %}
 
 {% block meta_description %}
 Password reset

--- a/capstone/capapi/templates/registration/password_reset_done.html
+++ b/capstone/capapi/templates/registration/password_reset_done.html
@@ -1,6 +1,6 @@
 {% extends "registration/base.html" %}
 {% load static %}
-{% block title %} — Password reset success{% endblock %}
+{% block title %}Password reset success | {% endblock %}
 
 {% block meta_description %}
 Password reset successful

--- a/capstone/capapi/templates/registration/password_reset_form.html
+++ b/capstone/capapi/templates/registration/password_reset_form.html
@@ -2,7 +2,7 @@
 {% load bootstrap4 %}
 {% load static %}
 
-{% block title %} — Reset password form {% endblock %}
+{% block title %}Reset password form | {% endblock %}
 
 {% block meta_description %}
 Reset password for Caselaw Access Project

--- a/capstone/capapi/templates/registration/register.html
+++ b/capstone/capapi/templates/registration/register.html
@@ -2,7 +2,7 @@
 {% load bootstrap4 %}
 {% load static %}
 
-{% block title %} — Register {% endblock %}
+{% block title %}Register | {% endblock %}
 
 {% block meta_description %}
 Register to the Caselaw Access Project

--- a/capstone/capapi/templates/registration/resend-nonce.html
+++ b/capstone/capapi/templates/registration/resend-nonce.html
@@ -2,7 +2,7 @@
 {% load bootstrap4 %}
 {% load static %}
 
-{% block title %} — Verify Your Email{% endblock %}
+{% block title %}Verify Your Email | {% endblock %}
 
 {% block meta_description %}
 Verify your email address

--- a/capstone/capapi/templates/registration/sign-up-success.html
+++ b/capstone/capapi/templates/registration/sign-up-success.html
@@ -1,6 +1,6 @@
 {% extends "registration/base.html" %}
 {% load static %}
-{% block title %} — Registration success{% endblock %}
+{% block title %}Registration success | {% endblock %}
 
 {% block meta_description %}
 You have successfully registered to use the Caselaw Access Project API

--- a/capstone/capapi/templates/registration/user-details.html
+++ b/capstone/capapi/templates/registration/user-details.html
@@ -2,7 +2,7 @@
 {% load static %}
 {% load pipeline %}
 
-{% block title %} — Your Account{% endblock %}
+{% block title %}Your Account | {% endblock %}
 {% block extra_head %}
   {% javascript 'base' %}
   {% stylesheet 'registration' %}

--- a/capstone/capapi/templates/registration/verified.html
+++ b/capstone/capapi/templates/registration/verified.html
@@ -1,6 +1,6 @@
 {% extends "registration/base.html" %}
 
-{% block title %} — Verified! {% endblock %}
+{% block title %}Verified! | {% endblock %}
 
 {% block meta_description %}
 You are a verified user of the Caselaw Access Project API guide

--- a/capstone/capapi/templates/rest_framework/api.html
+++ b/capstone/capapi/templates/rest_framework/api.html
@@ -6,6 +6,12 @@
   {% javascript 'base' %}
 {% endblock %}
 
+{% block title %}{% if name == "Api Root" %}Root | {% elif name %}{{ name }} | {% endif %}API | Caselaw Access Project{% endblock %}
+
 {% block navbar %}
   {% include "includes/nav.html" %}
+{% endblock %}
+
+{% block description %}
+  {% if name == "Api Root"%}{% else %}{{ block.super }}{% endif %}
 {% endblock %}

--- a/capstone/capweb/templates/about.html
+++ b/capstone/capweb/templates/about.html
@@ -6,7 +6,7 @@
   {% stylesheet 'about' %}
 {% endblock %}
 
-{% block title %} — About{% endblock %}
+{% block title %}About | {% endblock %}
 
 {% block meta_description %}
 About the Caselaw Access Project

--- a/capstone/capweb/templates/api.html
+++ b/capstone/capweb/templates/api.html
@@ -3,7 +3,7 @@
 {% load pipeline %}
 {% load api_url %}
 
-{% block title %} — API{% endblock %}
+{% block title %}API Docs — {% endblock %}
 
 {% block extra_head %}
   {% stylesheet 'tools' %}
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block meta_description %}
-  Caselaw Access Project API
+  Caselaw Access Project API Docs
 {% endblock %}
 
 {% block content %}

--- a/capstone/capweb/templates/contact.html
+++ b/capstone/capweb/templates/contact.html
@@ -6,7 +6,7 @@
   {% stylesheet 'contact' %}
 {% endblock %}
 
-{% block title %} — Contact{% endblock %}
+{% block title %}Contact | {% endblock %}
 
 {% block meta_description %}
 Caselaw Access Project contact

--- a/capstone/capweb/templates/contact_success.html
+++ b/capstone/capweb/templates/contact_success.html
@@ -7,7 +7,7 @@
   {% stylesheet 'contact' %}
 {% endblock %}
 
-{% block title %} — Contact{% endblock %}
+{% block title %}Contact | {% endblock %}
 
 {% block meta_description %}
 Caselaw Access Project contact

--- a/capstone/capweb/templates/gallery.html
+++ b/capstone/capweb/templates/gallery.html
@@ -6,7 +6,7 @@
   {% stylesheet 'gallery' %}
 {% endblock %}
 
-{% block title %} — Gallery{% endblock %}
+{% block title %}Gallery | {% endblock %}
 
 {% block meta_description %}
 Caselaw Access Project gallery

--- a/capstone/capweb/templates/gallery/limericks.html
+++ b/capstone/capweb/templates/gallery/limericks.html
@@ -7,7 +7,7 @@
   {% stylesheet 'gallery' %}
 {% endblock %}
 
-{% block title %} — Gallery{% endblock %}
+{% block title %}Gallery | {% endblock %}
 
 {% block meta_description %}
 Caselaw Access Project gallery

--- a/capstone/capweb/templates/gallery/wordclouds.html
+++ b/capstone/capweb/templates/gallery/wordclouds.html
@@ -6,7 +6,7 @@
   {% stylesheet 'gallery' %}
 {% endblock %}
 
-{% block title %} — Gallery{% endblock %}
+{% block title %}Gallery | {% endblock %}
 
 {% block meta_description %}
 Caselaw Access Project gallery

--- a/capstone/capweb/templates/main_base.html
+++ b/capstone/capweb/templates/main_base.html
@@ -19,7 +19,7 @@
     <meta name="msapplication-TileImage" content="{% static "img/favicon/mstile-150x150.png" %}">
     <meta name="theme-color" content="#ffffff">
 
-    <title>Caselaw Access Project{% block title %}{% endblock title %}</title>
+    <title>{% block title %}{% endblock title %}Caselaw Access Project</title>
     <meta name="robots" content="noindex">
     <meta name="description" content="{% block meta_description %}Explore American Caselaw{% endblock meta_description %}">
 

--- a/capstone/capweb/templates/terms-of-use.html
+++ b/capstone/capweb/templates/terms-of-use.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 
-{% block title %} - Terms of Service{% endblock %}
+{% block title %}Terms of Service | {% endblock %}
 
 {% block meta_description %}
   Caselaw Access Project Terms of Use

--- a/capstone/capweb/templates/tools.html
+++ b/capstone/capweb/templates/tools.html
@@ -6,7 +6,7 @@
   {% stylesheet 'tools' %}
 {% endblock %}
 
-{% block title %} — Tools{% endblock %}
+{% block title %}Tools | {% endblock %}
 
 {% block meta_description %}
   Caselaw Access Project Tools


### PR DESCRIPTION
This PR:

- arranges the page titles so they proceed from specific to general ("About | Caselaw Access Project") rather than general to specific ("Caselaw Access Project | About"), which is generally considered better for accessibility and UX. It helps when you have lots of tabs open (see pic), it helps make more-obviously-distinct entries in your browser history, and, probably most helpful, it prevents people using screenreaders from having to listen to your branding information on every page load before the actual title of the page.

- uses a vertical pipe rather than an em-dash as separator so that more characters can fit in a browser's tab list

- adds titles for HTTP error pages

- customizes the titles on the HTML API views to reference CAP API, rather than DRF (DRF default is `{% if name %}{{ name }} – {% endif %}Django REST framework`

![image](https://user-images.githubusercontent.com/11020492/45887811-95bb0b80-bd8a-11e8-8223-d911ac96a8e5.png)
