### PR TITLE
Supply alt text for wordcloud images

### DIFF
--- a/capstone/capweb/templates/gallery/wordclouds.html
+++ b/capstone/capweb/templates/gallery/wordclouds.html
@@ -32,9 +32,11 @@ Caselaw Access Project gallery
         <ul class="list-inline">
         {% for wordcloud in wordclouds %}
           <li class="list-item-inline wordcloud-item">
-            <a href="{% static "" %}img/wordclouds/{{ wordcloud }}"><img class=""
-                    src="{% static "" %}img/wordclouds/{{ wordcloud }}"/>
-            <p class="year">{{ wordcloud|truncatechars:7}}</p>
+            <a href="{% static "" %}img/wordclouds/{{ wordcloud }}">
+              <img class=""
+                   src="{% static "" %}img/wordclouds/{{ wordcloud }}"
+                   alt=""/>
+              <p class="year">{{ wordcloud|truncatechars:7}}</p>
             </a>
           </li>
         {% endfor %}


### PR DESCRIPTION
If an image is inside a link, it's alt text will supply the link text, but otherwise serves no purpose. In this case, these links have a different text: the year. You want that to be read, rather than any text associated with the image. If you don't supply any alt text at all, many screen readers will read the name of the file instead AND the year. So, use a blank alt text.