### PR TITLE
Add bulk docs

### DIFF
--- a/capstone/capapi/templates/bulk.html
+++ b/capstone/capapi/templates/bulk.html
@@ -21,7 +21,7 @@
                  aria-hidden="true"
                  src='{% static "img/red-arrow-right.svg" %}'
                  class="decorative-arrow"/>
-            Bulk Downloads
+            <span class="color-red">Bulk</span> Downloads
           </h1>
         </div>
       </div> <!-- row -->
@@ -30,6 +30,9 @@
         {# ==============> MENU <============== #}
         <div class="sidebar-menu"></div>
         <div class="content">
+          <div class="page-section">
+            See our <a href="{% url "bulk-docs" %}">bulk data docs</a> for an explanation of these files.
+          </div>
           {% if exports.public %}
             <div class="page-section">
               <h2 class="subtitle">

--- a/capstone/capapi/tests/test_cache.py
+++ b/capstone/capapi/tests/test_cache.py
@@ -28,7 +28,7 @@ from capweb.helpers import reverse
     ("casemetadata-list",   True,   False,  {"data": {"full_case": "true"}, "reverse_func": "api_reverse"}),
 
     # bulk list cacheable only for logged-out users
-    ("bulk-data",           True,   False,  {}),
+    ("bulk-download",           True,   False,  {}),
 
     # bulk downloads are cached if public, or private requested by logged-out users
     ("caseexport-download", True, True,     {"reverse_args": ["fixture_case_export"], "reverse_func": "api_reverse"}),

--- a/capstone/capapi/tests/test_user_views.py
+++ b/capstone/capapi/tests/test_user_views.py
@@ -159,7 +159,7 @@ def test_bulk_data_list(request, case_export, private_case_export, client_fixtur
     public_url = api_reverse('caseexport-download', args=[case_export.pk])
     private_url = api_reverse('caseexport-download', args=[private_case_export.pk])
 
-    response = client.get(reverse('bulk-data'))
+    response = client.get(reverse('bulk-download'))
     check_response(response)
     content = response.content.decode()
     assert public_url in content

--- a/capstone/capweb/templates/api.html
+++ b/capstone/capweb/templates/api.html
@@ -27,8 +27,8 @@
             <span class="color-red">CAP</span> API
           </h1>
         </div>
-
       </div>
+
       <div class="row">
         {# ==============> MENU <============== #}
         <nav class="list-group sidebar-menu" aria-label="table of contents">
@@ -79,8 +79,9 @@
               <a href="#beginners">Beginner's Introduction to APIs</a>.
             </p>
           </div>
+
+          {# ==============> REGISTER  <============== #}
           <div class="page-section">
-            {# ==============> REGISTER  <============== #}
             <a id="registration"></a>
             <h3 class="subtitle">Registration</h3>
               <p>
@@ -92,9 +93,10 @@
               <a href="{% url "register" %}">Click here to register for an API key</a> if you need to access case text
               from non-<a href="#def-whitelisted">whitelisted</a> jurisdictions.
             </p>
+          </div>
 
+          {# ==============> AUTHENTICATION <============== #}
           <div class="page-section">
-            {# ==============> AUTHENTICATION <============== #}
             <a id="authentication"></a>
             <h3 class="subtitle">Authentication</h3>
             <p>
@@ -140,7 +142,7 @@
             </p>
           </div>
 
-                      {# ====> Paginate <==== #}
+          {# ====> PAGINATION <==== #}
           <div class="page-section">
             <a id="pagination"></a>
             <h3 class="subtitle">Pagination</h3>
@@ -159,11 +161,8 @@
 }{% endfilter %}</pre>
           </div>
 
-
-
-
+          {# ==============> DATA FORMATS <============== #}
           <div class="page-section">
-            {# ==============> DATA FORMATS <============== #}
             <a id="dataformats"></a>
             <h3 class="subtitle">Case Text Formats</h3>
             <p>
@@ -190,7 +189,7 @@
             <dl>
               <dt>Text Format (default)</dt>
               <dd class="example-link">
-                <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true" %}">
+                <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true">
                 {% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true"
                 </a>
               </dd>
@@ -244,7 +243,7 @@
 
               <dt>HTML Format</dt>
               <dd class="example-link">
-                <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html" %}">
+                <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html">
                 {% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html"
                 </a></dd>
               <dd>
@@ -257,13 +256,10 @@
     "data": "<section class=\"casebody\" data-firstpage=\"538\" data-lastpage=\"543\"> ..."{% endfilter %}</pre>
               </dd>
             </dl>
-
-
           </div>
 
+          {# ==============> ACCESS LIMITS <============== #}
           <div class="page-section">
-
-            {# ==============> ACCESS LIMITS <============== #}
             <a id="limits"></a>
             <h3 class="subtitle">Access Limits</h3>
             <p>
@@ -391,7 +387,8 @@
                       </li>
                     </ul>
                   </li>
-                  <ul class="parameter-list">
+                </ul>
+                <ul class="parameter-list">
                   <li class="list-group-item">
                     <h5 class="list-header">Plain Text Case in JSON container with metadata</h5>
                     <ul>
@@ -529,6 +526,7 @@
               </dd>
             </dl>
           </div>
+
           {# ==============> ENDPOINTS <============== #}
           <div class="page-section">
             <a id="endpoints"></a>
@@ -1021,7 +1019,7 @@
               The next part is a list of words, separated by periods, between the initial double-slash, and before the
               subsequent single slash. Many people generically refer to this as the domain, which is only partly true,
               but the reason why that's not entirely true isn't really important for our purposes; the important
-              consideration here is that it points to a specific <a href="#def-server"server</a>, which is just another
+              consideration here is that it points to a specific <a href="#def-server">server</a>, which is just another
               computer on the internet.
             </p>
             <pre><code>/search</code></pre>
@@ -1325,7 +1323,7 @@
 
             </dl>
           </div>
-        </p>
+        </div>
       </div>
     </div>
   </div>

--- a/capstone/capweb/templates/bulk_docs.html
+++ b/capstone/capweb/templates/bulk_docs.html
@@ -1,0 +1,193 @@
+{% extends "main_base.html" %}
+{% load static %}
+{% load pipeline %}
+{% load api_url %}
+
+{% block title %}Bulk Download Docs — {% endblock %}
+
+{% block extra_head %}
+  {% stylesheet 'tools' %}
+  {% stylesheet 'api' %}
+{% endblock %}
+
+{% block meta_description %}
+  Caselaw Access Project Bulk Downloads
+{% endblock %}
+
+{% block content %}
+  <div class="basic-page">
+    <div class="full-content">
+      <div class="row">
+        <div class="page-title">
+          <h1>
+            <img alt=""
+                 aria-hidden="true"
+                 src='{% static "img/red-arrow-right.svg" %}'
+                 class="decorative-arrow"/>
+            <span class="color-red">Bulk</span> Downloads
+          </h1>
+        </div>
+
+      </div>
+      <div class="row">
+        {# ==============> MENU <============== #}
+        <nav class="list-group sidebar-menu" aria-label="table of contents">
+          <ul>
+            <li><a class="list-group-item" href="#introduction">Introduction</a></li>
+            <li><a class="list-group-item" href="#requesting-access">Requesting Access</a></li>
+            <li><a class="list-group-item" href="#downloading">Downloading</a></li>
+            <li><a class="list-group-item" href="#api-equivalence">API Equivalence</a></li>
+            <li><a class="list-group-item" href="#data-format">Data Format</a></li>
+            <li><a class="list-group-item" href="#examples">Using Bulk Data</a></li>
+          </ul>
+        </nav>
+        {# ==============> CONTENT <============== #}
+        <div class="content">
+
+          {# ==============> INTRODUCTION <============== #}
+          <div class="page-section">
+            <a id="introduction"></a>
+            <p>
+              <img class="img-fluid"
+                   alt="Two volumes of caselaw labeled with identifying metadata and wrapped in air-tight plastic are cradled in a metal storage crate"
+                   src="{% static "img/reporters.jpg" %}">
+            </p>
+            <h2 class="subtitle">Introduction</h2>
+            <p>
+              Our <a href="{% url "bulk-download" %}">bulk data files</a> contain the same information that is available
+              via <a href="{% url "api" %}">our API</a>,
+              but are much faster to download if you want to interact with a large number of cases. Each file contains
+              all of the cases from a single jurisdiction or reporter.
+            </p>
+          </div>
+
+          {# ==============> REQUESTING  <============== #}
+          <div class="page-section">
+            <a id="requesting-access"></a>
+            <h3 class="subtitle">Requesting Access</h3>
+            <p>
+              Bulk data files for our whitelisted jurisdictions (currently Illinois and Arkansas) are
+              <a href="{% url "bulk-download" %}">available to everyone</a>
+              without a login.
+            </p>
+            <p>
+              Bulk data files for the remaining jurisdictions are available to research scholars. For a research
+              scholar account, please <a href="{% url "contact" %}">contact us</a> with your CAPAPI account email, academic
+              affiliations if any, and research goals.
+            </p>
+            <p>
+              See our  <a href="{% url "about" %}#usage">About page</a> for details on our data access restrictions.
+            </p>
+          </div>
+
+          {# ==============> GETTING  <============== #}
+          <div class="page-section">
+            <a id="downloading"></a>
+            <h3 class="subtitle">Downloading</h3>
+            <p>
+              You can download bulk data <a href="{% url "bulk-download" %}">manually from our website</a>, or
+              <a href="{% api_url "caseexport-list" %}">use the API</a> if you are fetching many files at once.
+            </p>
+            <p>
+              To download all cases via the API,
+              <a href="{% api_url "caseexport-list" %}?body_format=text&filter_type=jurisdiction">use the body_format and
+                filter_type parameters to the <code>/bulk/</code> endpoint</a> to select all cases, sorted by jurisdiction,
+              of your desired body_format.
+            </p>
+          </div>
+
+          {# ==============> API EQUIVALENCE  <============== #}
+          <div class="page-section">
+            <a id="api-equivalence"></a>
+            <h3 class="subtitle">API Equivalence</h3>
+            <p>
+              Each file that we offer for download is equivalent to a particular query to our API. For example, the file
+              "Illinois-20180829-text.zip" contains all cases that would be returned by
+              <a href="{% api_url "casemetadata-list" %}?full_case=true&jurisdiction=ill&body_format=text">an API query</a>
+              with <code>full_case=true&jurisdiction=ill&body_format=text</code>. We offer files for each possible
+              <code>jurisdiction</code> value and each possible <code>reporter</code> value, combined with
+              <code>body_format=text</code> and <code>body_format=xml</code>.
+            </p>
+            <p>
+              The JSON objects returned by the API and in bulk files differ only in that bulk JSON objects do not include
+              <code>"url"</code> fields, which can be reconstructed from object IDs.
+            </p>
+          </div>
+
+          {# ==============> FORMAT  <============== #}
+          <div class="page-section">
+            <a id="data-format"></a>
+            <h3 class="subtitle">Data Format</h3>
+            <p>
+              Bulk data files are provided as zipped directories. Each directory is in
+              <a href="https://en.wikipedia.org/wiki/BagIt">BagIt format</a>, with a layout like this:
+            </p>
+            <ul class="bullets">
+              <li>
+                Illinois-20180829-text/
+                <ul>
+                  <li>bag-info.txt</li>
+                  <li>bagit.txt</li>
+                  <li>manifest-sha512.txt</li>
+                  <li>
+                    data/
+                    <ul>
+                      <li>data.jsonl.xz</li>
+                    </ul>
+                  </li>
+                </ul>
+              </li>
+            </ul>
+            <p>
+              Because the zip file provides no additional compression, we recommend uncompressing it for convenience and
+              keeping the uncompressed directory on disk.
+            </p>
+            <p>
+              Caselaw data is stored within the <code>data/data.jsonl.xz</code> file. The <code>.jsonl.xz</code> suffix
+              indicates that the file is compressed with xzip, and is a text file where each line represents a JSON object.
+            </p>
+          </div>
+
+          {# ==============> USING DATA  <============== #}
+          <div class="page-section">
+            <a id="examples"></a>
+            <h3 class="subtitle">Using Bulk Data</h3>
+            <p>
+              The <code>data.jsonl.xz</code> file can be unzipped using third-party GUI programs like
+              <a href="https://theunarchiver.com/">The Unarchiver</a> (Mac) or
+              <a href="https://www.7-zip.org/">7-zip</a> (Windows), or from the command line with a command like
+              <code>unxz -k data/data.jsonl.xz</code>.
+            </p>
+            <p>
+              However, this increases the disk space needed by about 500%, and in most cases is unnecessary. Instead
+              we recommend interacting directly with the compressed files.
+            </p>
+            <p>
+              To read the file from the command line, run:
+            </p>
+            <pre class="code-block">xzcat data/data.jsonl.xz | less</pre>
+            <p>
+              If you install <a href="https://stedolan.github.io/jq/download/">jq</a> you can get nicely formatted output ...
+            </p>
+            <pre class="code-block">xzcat data/data.jsonl.xz | jq | less</pre>
+            <p>
+              .. or run more sophisticated queries. For example, to extract the name of each case:
+            </p>
+            <pre class="code-block">xzcat data/data.jsonl.xz | jq .name | less</pre>
+            <p>
+              You can also interact directly with the compressed files from code. The following example prints
+              the name of each case using Python:
+            </p>
+            <pre class="code-block">
+import lzma, json
+
+with lzma.open("data/data.jsonl.xz") as in_file:
+    for line in in_file:
+        case = json.loads(str(line, 'utf8'))
+        print(case['name'])</pre>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -40,7 +40,7 @@
         <div class="dropdown-menu" aria-labelledby="navbar-dropdown-tools">
           <a class="dropdown-item" href="{% url "tools" %}">Overview</a>
           <a class="dropdown-item" href="{% url "api" %}">API</a>
-          <a class="dropdown-item" href="{% url "bulk-data" %}">Bulk Data</a>
+          <a class="dropdown-item" href="{% url "bulk-docs" %}">Bulk Data</a>
         </div>
       </li>
       <li class="nav-item dropdown" id="nav-gallery">

--- a/capstone/capweb/templates/index.html
+++ b/capstone/capweb/templates/index.html
@@ -1,6 +1,7 @@
 {% extends "main_base.html" %}
 {% load static %}
 {% load pipeline %}
+{% load api_url %}
 
 {% block extra_head %}
   {% stylesheet 'index' %}
@@ -152,15 +153,16 @@
 
           <h3>
             <span class="section-symbol color-red" aria-hidden="true">&#167;</span>
-            <a href="{% url "bulk-data" %}">
+            <a href="{% url "bulk-docs" %}">
               Bulk data
             </a>
           </h3>
           <p>Download whole zip files of whitelisted jurisdictions like Illinois.</p>
-          <br/>
-          <a href="/tools"
-             class="btn btn-default"
-             >Browse tools</a>
+          <p>
+            <a href="/tools"
+               class="btn btn-default"
+               >Browse tools</a>
+          </p>
         </div>
       </div>
     </div>

--- a/capstone/capweb/templates/tools.html
+++ b/capstone/capweb/templates/tools.html
@@ -1,6 +1,7 @@
 {% extends "main_base.html" %}
 {% load static %}
 {% load pipeline %}
+{% load api_url %}
 
 {% block extra_head %}
   {% stylesheet 'tools' %}
@@ -50,14 +51,9 @@
               </p>
               <h2 class="subtitle">Introduction</h2>
               <p>
-                <span class="highlighted">
-                    Information is only useful if it's accessible.
-                </span>
-              </p>
-              <p>
                 The capstone of the Caselaw Access Project is a robust set of tools which facilitate access to the cases
                   and their associated metadata. We currently offer two ways to access the data: our
-                  <a href="{% url "api" %}">API</a>, and <a href="{% url "bulk-data" %}">bulk downloads</a>.
+                  <a href="{% url "api" %}">API</a>, and <a href="{% url "bulk-docs" %}">bulk downloads</a>.
               </p>
             </div>
             {# ==============> API  <============== #}
@@ -70,16 +66,17 @@
                   Our open-source API is the best option for anybody interested in programmatically accessing our
                   metadata, full-text search, or individual cases.
               </p>
-              <a class="btn btn-default"
-                 href="{% url "api" %}">See API</a>
-              <br/><br/>
+              <ul>
+                <li><a href="{% api_url "api-root" %}">Browse the API</a></li>
+                <li><a href="{% url "api" %}">API docs</a></li>
+              </ul>
             </div>
 
             {# ==============> BULK!! <============== #}
             <div class="page-section">
               <a name="bulk"></a>
               <h2 class="subtitle">
-                <a href="{% url "bulk-data" %}">Bulk Downloads</a>
+                <a href="{% url "bulk-docs" %}">Bulk Downloads</a>
               </h2>
               <p>
                 If you need a large collection of cases, you will probably be best served by our bulk data downloads.
@@ -89,8 +86,10 @@
                   information. Those interested in licensing this data case for commercial use should
                   <a href="http://info.ravellaw.com/contact-us-form">contact Ravel Law</a> for more information.
               </p>
-              <a class="btn btn-default"
-                 href="{% url "bulk-data" %}">See bulk downloads</a>
+              <ul>
+                <li><a href="{% url "bulk-download" %}">Download bulk files</a></li>
+                <li><a href="{% url "bulk-docs" %}">Bulk file docs</a></li>
+              </ul>
             </div>
           </div>
         </div>

--- a/capstone/capweb/urls.py
+++ b/capstone/capweb/urls.py
@@ -20,7 +20,8 @@ urlpatterns = [
                                             content_type='text/plain'), name='robots'),
 
     ### bulk data ###
-    path('bulk-access/', user_views.bulk, name='bulk-data'),
+    path('bulk/', TemplateView.as_view(template_name='bulk_docs.html'), name='bulk-docs'),
+    path('bulk/download/', user_views.bulk, name='bulk-download'),
 
     path('terms', TemplateView.as_view(template_name='terms-of-use.html',
                                        extra_context={'hide_footer': True}), name='terms'),

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -56,7 +56,7 @@ ol.alpha > li {
   padding-left: 1rem;
 }
 
-ul.bullets {
+ul.bullets, ul.bullets ul {
   padding-left: 1.5em !important;
   li {
     list-style-type: circle;

--- a/capstone/static/js/custom.js
+++ b/capstone/static/js/custom.js
@@ -47,7 +47,7 @@ let selectedNavStyling = function() {
   let path = window.location.pathname.split('/')[1];
   path = path.split('#')[0];
   path = path === 'user' ? 'account': path;
-  path = path === 'bulk-access' || path === 'api' ? 'tools': path;
+  path = path === 'bulk' || path === 'api' ? 'tools': path;
   $('#nav-' + path).find('a').addClass('selected');
 };
 


### PR DESCRIPTION
- Make bulk the same as API, where the menu goes to docs, with links to the actual data from there
- Add links on the tools overview page so you can go directly to docs or content for API and bulk
- I threw in a little cleanup of the html structure for API docs, discovered while cloning for bulk docs