### PR TITLE
Django reverse() cleanup

### DIFF
--- a/capstone/capapi/__init__.py
+++ b/capstone/capapi/__init__.py
@@ -1,7 +1,10 @@
+import django.shortcuts
+
 import rest_framework.request
 import rest_framework.reverse
 
 from capapi.resources import TrackingWrapper, api_reverse
+from capweb.helpers import reverse
 
 # Monkeypatch rest_framework.request.Request to track accesses to request.user attributes.
 # See capapi/middleware for rationale.
@@ -25,6 +28,8 @@ class CustomRequest(OriginalRequest):
 if OriginalRequest.__name__ != "CustomRequest":
     rest_framework.request.Request = CustomRequest
 
-
 # Monkeypatch rest_framework.reverse._reverse to use our api_reverse function
 rest_framework.reverse._reverse = api_reverse
+
+# Monkeypatch django.shortcuts.resolve_url to use our reverse function
+django.shortcuts.reverse = reverse

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -532,4 +532,4 @@ COMPRESS_VOLUMES_SKIP_EXISTING = True  # don't process volumes that already exis
 AWS_DEFAULT_ACL = 'private'
 
 # set the default login
-LOGIN_URL = 'capweb.login'
+LOGIN_URL = 'login'


### PR DESCRIPTION
Setting `LOGIN_URL = 'capweb.login'` doesn't seem to do the trick. This upgrades `capweb.reverse` to try all possible subdomains, which gets `LOGIN_URL = 'login'` working for the `/swagger` routes.