### PR TITLE
Fix up ordering on endpoints

### DIFF
--- a/capstone/capapi/pagination.py
+++ b/capstone/capapi/pagination.py
@@ -23,12 +23,10 @@ class CapPagination(CursorPagination):
 
     def get_ordering(self, request, queryset, view):
         """ Derive ordering from queryset, rather than hardcoding as CursorPagination does. """
-        ordering = queryset.query.order_by
+        ordering = queryset.query.order_by or queryset.model._meta.ordering
 
-        assert isinstance(ordering, (str, list, tuple)), (
-            'Invalid ordering. Expected string or tuple, but got {type}'.format(
-                type=type(ordering).__name__
-            )
+        assert ordering and isinstance(ordering, (str, list, tuple)), (
+            'Invalid ordering. Expected string or tuple, but got %s' % (ordering,)
         )
 
         return ordering

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -23,13 +23,13 @@ class BaseViewSet(viewsets.ReadOnlyModelViewSet):
 class JurisdictionViewSet(BaseViewSet):
     serializer_class = serializers.JurisdictionSerializer
     filterset_class = filters.JurisdictionFilter
-    queryset = models.Jurisdiction.objects.all()
+    queryset = models.Jurisdiction.objects.order_by('name', 'pk')
     lookup_field = 'slug'
 
 
 class VolumeViewSet(BaseViewSet):
     serializer_class = serializers.VolumeSerializer
-    queryset = models.VolumeMetadata.objects.all().select_related(
+    queryset = models.VolumeMetadata.objects.order_by('pk').select_related(
         'reporter'
     ).prefetch_related('reporter__jurisdictions')
 
@@ -37,13 +37,13 @@ class VolumeViewSet(BaseViewSet):
 class ReporterViewSet(BaseViewSet):
     serializer_class = serializers.ReporterSerializer
     filterset_class = filters.ReporterFilter
-    queryset = models.Reporter.objects.all().prefetch_related('jurisdictions')
+    queryset = models.Reporter.objects.order_by('full_name', 'pk').prefetch_related('jurisdictions')
 
 
 class CourtViewSet(BaseViewSet):
     serializer_class = serializers.CourtSerializer
     filterset_class = filters.CourtFilter
-    queryset = models.Court.objects.all().select_related('jurisdiction')
+    queryset = models.Court.objects.order_by('name', 'pk').select_related('jurisdiction')
     lookup_field = 'slug'
 
 
@@ -117,7 +117,7 @@ class CaseViewSet(BaseViewSet):
 
 class CaseExportViewSet(BaseViewSet):
     serializer_class = serializers.CaseExportSerializer
-    queryset = models.CaseExport.objects.all()
+    queryset = models.CaseExport.objects.order_by('pk')
     filterset_class = filters.CaseExportFilter
 
     def list(self, request, *args, **kwargs):

--- a/capstone/capweb/templates/about.html
+++ b/capstone/capweb/templates/about.html
@@ -112,6 +112,9 @@ About the Caselaw Access Project
                   Parallel versions of cases from regional reporters, unless those cases were
                   designated by a court as official.
                 </li>
+                <li>
+                  Cases officially published in digital form, such as recent cases from Illinois and Arkansas.
+                </li>
               </ul>
               <p>
                 Cases published after 1922 are redacted of potentially-copyrighted material added by publishers.


### PR DESCRIPTION
- Make our custom pagination better about noisily complaining about endpoints with missing ordering fields
- Add deterministic ordering to all endpoints

I also threw in a tweak to about.html that I had lying around, because 🤷‍♂️