### PR TITLE
Ngram performance tweaks

### DIFF
--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -56,11 +56,7 @@ class CitationViewSet(BaseViewSet):
 
 class CaseViewSet(BaseViewSet):
     serializer_class = serializers.CaseSerializer
-    queryset = models.CaseMetadata.objects.filter(
-        duplicative=False,
-        jurisdiction__isnull=False,
-        court__isnull=False,
-    ).select_related(
+    queryset = models.CaseMetadata.objects.in_scope().select_related(
         'volume',
         'reporter',
     ).prefetch_related(

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -690,6 +690,15 @@ class Court(CachedLookupMixin, AutoSlugMixin, models.Model):
 case_metadata_partial_index_where = "jurisdiction_id IS NOT NULL AND court_id IS NOT NULL AND NOT duplicative"
 
 
+
+class CaseMetadataQuerySet(models.QuerySet):
+    def in_scope(self):
+        """
+            Return cases accessible from API
+        """
+        return self.filter(duplicative=False, jurisdiction__isnull=False, court__isnull=False)
+
+
 class CaseMetadata(models.Model):
     case_id = models.CharField(max_length=64, null=True, db_index=True)
     first_page = models.CharField(max_length=255, null=True, blank=True)
@@ -758,6 +767,8 @@ class CaseMetadata(models.Model):
             name_abbreviation=self.court_name_abbreviation,
         )
 
+    objects = CaseMetadataQuerySet.as_manager()
+
     def __str__(self):
         return self.case_id
 
@@ -775,7 +786,6 @@ class CaseMetadata(models.Model):
 
     def full_cite(self):
         return "%s, %s (%s)" % (self.name_abbreviation, ", ".join(cite.cite for cite in self.citations.all()), self.decision_date.year)
-
 
 
 class CaseXML(BaseXMLModel):

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -758,6 +758,7 @@ def count_chars_in_all_cases(path="/tmp/counts"):
 
 
 @task
-def ngram_jurisdictions():
+def ngram_jurisdictions(replace_existing=False):
+    """ Generate ngrams for all jurisdictions. If replace_existing is False (default), only jurisdiction-years without existing ngrams will be indexed. """
     from scripts.ngrams import ngram_jurisdictions
-    ngram_jurisdictions()
+    ngram_jurisdictions(replace_existing=bool(replace_existing))


### PR DESCRIPTION
- `fab ngram_jurisdictions` will, by default, only run for jurisdiction-years that haven't yet been indexed, so it's safe to restart the job.
- Use indexed queries for trimming start and end years.
- Use batch bulk_create