### PR TITLE
Add maintenance page export function

### DIFF
--- a/capstone/capweb/helpers.py
+++ b/capstone/capweb/helpers.py
@@ -68,3 +68,12 @@ def reverse(*args, **kwargs):
             # raise NoReverseMatch only after testing final host
             if i == len(hosts)-1:
                 raise
+
+
+def show_toolbar_callback(request):
+    """
+        Whether to show django-debug-toolbar.
+        This adds an optout for urls with ?no_toolbar
+    """
+    from debug_toolbar.middleware import show_toolbar
+    return False if 'no_toolbar' in request.GET else show_toolbar(request)

--- a/capstone/capweb/views.py
+++ b/capstone/capweb/views.py
@@ -70,11 +70,10 @@ def gallery(request):
 def maintenance_mode(request):
     return render(request, "error_page.html", {
         "type": "Maintenance",
-        "title": "Well this isn't ideal...",
-        "middle": "You've caught us at a bad time.",
-        "bottom": "We're performing some critical maintenance that just couldn't wait, and we needed to take the site "
-                  "down to do it.",
-        "action": "Please bear with us! We are working on getting the site back up and running as quickly as we can.",
+        "title": "${title}",
+        "middle": "${middle}",
+        "bottom": "${bottom}",
+        "action": "${action}",
     })
 
 def wordclouds(request):

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -53,6 +53,9 @@ try:
         MIDDLEWARE.index('django_hosts.middleware.HostsRequestMiddleware')+1,
         'debug_toolbar.middleware.DebugToolbarMiddleware'
     )
+    DEBUG_TOOLBAR_CONFIG = {
+        'SHOW_TOOLBAR_CALLBACK': 'capweb.helpers.show_toolbar_callback'
+    }
     INTERNAL_IPS = ['127.0.0.1']
 except ImportError:
     pass

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -73,3 +73,8 @@ swagger_spec_validator  # by drf-yasg
 PyPDF2
 reportlab
 img2pdf
+
+# maintenance page
+-e git://github.com/zTrix/webpage2html.git@9df878a#egg=webpage2html     # save target page as string
+termcolor   # required by webpage2html
+mincss      # remove unused css styles

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -8,6 +8,7 @@
 -e git+git://github.com/philipn/django-rest-framework-filters.git@c5ffc8276431cf49dddbcebab322b142843de4ef#egg=djangorestframework-filters
 -e git+git://github.com/jcushman/email-normalize.git@6b5088bd05de247a9a33ad4e5c7911b676d6daf2#egg=email-normalize
 -e git+git://github.com/jcushman/pyquery.git@115173a#egg=pyquery
+-e git+git://github.com/zTrix/webpage2html.git@9df878a#egg=webpage2html
 amqp==2.2.2               # via kombu
 apipkg==1.4               # via execnet
 asn1crypto==0.22.0        # via cryptography
@@ -32,7 +33,7 @@ coreapi==2.3.3            # via drf-yasg, openapi-codec
 coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==4.4.1           # via pytest-cov
 cryptography==2.3         # via moto, paramiko
-cssselect==1.0.1
+cssselect==1.0.1          # via mincss
 django-appconf==1.0.2     # via django-compressor
 django-bootstrap4==0.0.6
 django-bulk-update==2.1.0
@@ -79,6 +80,7 @@ libsasscompiler==0.1.5
 lxml==3.7.3
 markupsafe==1.0           # via jinja2
 mccabe==0.6.1             # via flake8
+mincss==0.11.6
 mirakuru==0.8.2           # via pytest-redis
 mock==2.0.0               # via moto
 more-itertools==4.3.0     # via pytest
@@ -127,6 +129,7 @@ s3transfer==0.1.10        # via boto3
 six==1.10.0               # via bcrypt, cryptography, django-extensions, docker, docker-pycreds, drf-yasg, fabric3, faker, flex, libsass, mock, more-itertools, moto, nltk, pathlib2, pip-tools, pynacl, pytest, python-dateutil, python-jose, responses, swagger-spec-validator, websocket-client
 strict-rfc3339==0.7       # via flex
 swagger-spec-validator==2.1.0
+termcolor==1.1.0
 tornado==5.0.2            # via flower
 tqdm==4.11.2
 uritemplate==3.0.0        # via coreapi, drf-yasg

--- a/capstone/static/css/scss/_a11y.scss
+++ b/capstone/static/css/scss/_a11y.scss
@@ -1,5 +1,3 @@
-@import "variables";
-
 .skip {
   position: absolute;
   left: -999em;

--- a/capstone/static/css/scss/_elements.scss
+++ b/capstone/static/css/scss/_elements.scss
@@ -1,5 +1,3 @@
-@import '_variables.scss';
-
 // buttons
 .btn {
   font-family: $font-sans-serif;

--- a/capstone/static/css/scss/_nav.scss
+++ b/capstone/static/css/scss/_nav.scss
@@ -1,5 +1,3 @@
-@import 'variables';
-
 /* nav branding */
 .branding > a {
   border-bottom: 0 !important;

--- a/capstone/static/css/scss/footer.scss
+++ b/capstone/static/css/scss/footer.scss
@@ -1,5 +1,3 @@
-@import "variables";
-
 footer {
   z-index: 999;
   font-size: 18px;


### PR DESCRIPTION
- Update the maintenance page to use placeholder variables
- Add `fab url_to_js_string` to save the maintenance page to `maintenance.html` as a standalone file (you have to be running the dev server locally) 

Once exported, the file can be copied with `pbcopy < maintenance.html` and pasted into the Cloudflare worker.