### PR TITLE
Navbar in-page anchor tweaks

### DIFF
--- a/capstone/static/css/scss/_nav.scss
+++ b/capstone/static/css/scss/_nav.scss
@@ -1,3 +1,14 @@
+/* extra space */
+
+// stop fixed navbar from overlapping in-page anchor targets
+// via https://stackoverflow.com/a/28824157/307769
+:target::before {
+  content: "";
+  display: block;
+  height: 60px; /* fixed header height*/
+  margin: -60px 0 0; /* negative fixed header height */
+}
+
 /* nav branding */
 .branding > a {
   border-bottom: 0 !important;

--- a/capstone/static/js/custom.js
+++ b/capstone/static/js/custom.js
@@ -51,26 +51,6 @@ let selectedNavStyling = function() {
   $('#nav-' + path).find('a').addClass('selected');
 };
 
-let setupSidebarMenuStickiness = function() {
-  let navHeight = $('#main-nav').height();
-  let sidebarMenu = $('#sidebar-menu');
-  let stickOn = false;
-
-  window.addEventListener('scroll', function() {
-    if (window.pageYOffset > navHeight) {
-      if (!stickOn) {
-        sidebarMenu.addClass("sticky");
-        stickOn = true;
-      }
-    } else {
-      if (stickOn) {
-        sidebarMenu.removeClass("sticky");
-        stickOn = false;
-      }
-    }
-  });
-};
-
 let setupSidebarHighlighting = function () {
   let listGroup = $('.list-group-item');
   let subtitles = $('.subtitle');
@@ -86,31 +66,35 @@ let setupSidebarHighlighting = function () {
   })
 };
 
-let setupNavStickiness = function() {
-  let nav = $('#main-nav');
-  let navHeight = nav.height();
-  let halfNavHeight = navHeight/2;
+let setupScrollStickiness = function() {
+  const nav = $('#main-nav');
+  const sidebarMenu = $('#sidebar-menu');
+  const navHeight = nav.height();
+  const halfNavHeight = navHeight/2;
   let stickOn = false;
-  window.addEventListener('scroll', function() {
+  const handleScroll = function() {
     if (window.pageYOffset > halfNavHeight) {
       if (!stickOn) {
+        sidebarMenu.addClass("sticky");
         nav.addClass("sticky");
         stickOn = true;
       }
     } else {
       if (stickOn) {
+        sidebarMenu.removeClass("sticky");
         nav.removeClass("sticky");
         stickOn = false;
       }
     }
-  });
+  };
+  window.addEventListener('scroll', handleScroll);
+  handleScroll();  // handle case where page is already scrolled on load
 };
 
 
 $(function() {
   selectedNavStyling();
-  setupNavStickiness();
-  setupSidebarMenuStickiness();
+  setupScrollStickiness();
   setupSidebarHighlighting();
   setupDropdown();
   setupBurgerAction();


### PR DESCRIPTION
A couple of tweaks when loading an in-page link, such as a word in the glossary:

* Use a CSS rule to stop the target from getting hidden behind the navbar -- fixes #587 
* Apply scroll-event styles to navbar and sidebar