### PR TITLE
Copy in DRF templates to tweak a11y for now.

### DIFF
--- a/capstone/capapi/templates/rest_framework/api.html
+++ b/capstone/capapi/templates/rest_framework/api.html
@@ -1,17 +1,258 @@
-{% extends "rest_framework/base.html" %}
+{% extends "layouts/full.html" %}
 {% load pipeline %}
 {% load static %}
-{% block style %}
+{% load i18n %}
+{% load rest_framework %}
+
+{% block extra_head %}
   {% stylesheet 'api' %}
-  {% javascript 'base' %}
 {% endblock %}
 
-{% block title %}{% if name == "Api Root" %}Root | {% elif name %}{{ name }} | {% endif %}API | Caselaw Access Project{% endblock %}
+{% block title %}{% if name == "Api Root" %}Root | {% elif name %}{{ name }} | {% endif %}API{% endblock %}
 
-{% block navbar %}
-  {% include "includes/nav.html" %}
+{% block content %}
+  <div class="container">
+    {% block breadcrumbs %}
+      <ul class="breadcrumb">
+        {% for breadcrumb_name, breadcrumb_url in breadcrumblist %}
+          {% if forloop.last %}
+            <li class="active"><a href="{{ breadcrumb_url }}">{{ breadcrumb_name }}</a></li>
+          {% else %}
+            <li><a href="{{ breadcrumb_url }}">{{ breadcrumb_name }}</a></li>
+          {% endif %}
+        {% empty %}
+          {% block breadcrumbs_empty %}&nbsp;{% endblock breadcrumbs_empty %}
+        {% endfor %}
+      </ul>
+    {% endblock %}
+
+    <!-- Content -->
+    <div id="content">
+
+      {% if 'GET' in allowed_methods %}
+        <form id="get-form" class="pull-right">
+          <fieldset>
+            {% if api_settings.URL_FORMAT_OVERRIDE %}
+              <div class="btn-group format-selection">
+                <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
+
+                <button class="btn btn-primary dropdown-toggle js-tooltip" data-toggle="dropdown" title="Specify a format for the GET request">
+                  <span class="caret"></span>
+                </button>
+                <ul class="dropdown-menu">
+                  {% for format in available_formats %}
+                    <li>
+                      <a class="js-tooltip format-option" href="{% add_query_param request api_settings.URL_FORMAT_OVERRIDE format %}" rel="nofollow" title="Make a GET request on the {{ name }} resource with the format set to `{{ format }}`">{{ format }}</a>
+                    </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% else %}
+              <a class="btn btn-primary js-tooltip" href="{{ request.get_full_path }}" rel="nofollow" title="Make a GET request on the {{ name }} resource">GET</a>
+            {% endif %}
+          </fieldset>
+        </form>
+      {% endif %}
+
+      {% if options_form %}
+        <form class="button-form" action="{{ request.get_full_path }}" data-method="OPTIONS">
+          <button class="btn btn-primary js-tooltip" title="Make an OPTIONS request on the {{ name }} resource">OPTIONS</button>
+        </form>
+      {% endif %}
+
+      {% if delete_form %}
+        <button class="btn btn-danger button-form js-tooltip" title="Make a DELETE request on the {{ name }} resource" data-toggle="modal" data-target="#deleteModal">DELETE</button>
+
+        <!-- Delete Modal -->
+        <div class="modal fade" id="deleteModal" tabindex="-1" role="dialog" aria-labelledby="delete-modal-label" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-body">
+                <h4 id="delete-modal-label" class="text-center">Are you sure you want to delete this {{ name }}?</h4>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                <form class="button-form" action="{{ request.get_full_path }}" data-method="DELETE">
+                  <button class="btn btn-danger">Delete</button>
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+
+      {% if extra_actions %}
+        <div class="dropdown" style="float: right; margin-right: 10px">
+          <button class="btn btn-default" id="extra-actions-menu" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+            {% trans "Extra Actions" %}
+            <span class="caret"></span>
+          </button>
+          <ul class="dropdown-menu" aria-labelledby="extra-actions-menu">
+            {% for action_name, url in extra_actions|items %}
+            <li><a href="{{ url }}">{{ action_name }}</a></li>
+            {% endfor %}
+          </ul>
+        </div>
+      {% endif %}
+
+      {% if filter_form %}
+        <button style="float: right; margin-right: 10px" data-toggle="modal" data-target="#filtersModal" class="btn btn-default">
+          <span class="glyphicon glyphicon-wrench" aria-hidden="true"></span>
+          {% trans "Filters" %}
+        </button>
+      {% endif %}
+    </div>
+
+    <div class="content-main">
+      <div class="page-header">
+        <h1>{{ name }}</h1>
+      </div>
+      <div style="float:left">
+        {% block description %}
+          {% if name == "Api Root"%}{% else %}{{ description }}{% endif %}
+        {% endblock %}
+      </div>
+
+      {% if paginator %}
+        <nav style="float: right">
+          {% get_pagination_html paginator %}
+        </nav>
+      {% endif %}
+
+      <div class="request-info" style="clear: both" aria-label="{% trans "request info" %}">
+        <pre class="prettyprint"><b>{{ request.method }}</b> {{ request.get_full_path }}</pre>
+      </div>
+
+      <div class="response-info" aria-label="{% trans "response info" %}">
+        <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
+  <b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
+
+  </span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
+      </div>
+    </div>
+
+    {% if display_edit_forms %}
+      {% if post_form or raw_data_post_form %}
+        <div {% if post_form %}class="tabbable"{% endif %}>
+          {% if post_form %}
+            <ul class="nav nav-tabs form-switcher">
+              <li>
+                <a name='html-tab' href="#post-object-form" data-toggle="tab">HTML form</a>
+              </li>
+              <li>
+                <a name='raw-tab' href="#post-generic-content-form" data-toggle="tab">Raw data</a>
+              </li>
+            </ul>
+          {% endif %}
+
+          <div class="well tab-content">
+            {% if post_form %}
+              <div class="tab-pane" id="post-object-form">
+                {% with form=post_form %}
+                  <form action="{{ request.get_full_path }}" method="POST" enctype="multipart/form-data" class="form-horizontal" novalidate>
+                    <fieldset>
+                      {% csrf_token %}
+                      {{ post_form }}
+                      <div class="form-actions">
+                        <button class="btn btn-primary" title="Make a POST request on the {{ name }} resource">POST</button>
+                      </div>
+                    </fieldset>
+                  </form>
+                {% endwith %}
+              </div>
+            {% endif %}
+
+            <div {% if post_form %}class="tab-pane"{% endif %} id="post-generic-content-form">
+              {% with form=raw_data_post_form %}
+                <form action="{{ request.get_full_path }}" method="POST" class="form-horizontal">
+                  <fieldset>
+                    {% include "rest_framework/raw_data_form.html" %}
+                    <div class="form-actions">
+                      <button class="btn btn-primary" title="Make a POST request on the {{ name }} resource">POST</button>
+                    </div>
+                  </fieldset>
+                </form>
+              {% endwith %}
+            </div>
+          </div>
+        </div>
+      {% endif %}
+
+      {% if put_form or raw_data_put_form or raw_data_patch_form %}
+        <div {% if put_form %}class="tabbable"{% endif %}>
+          {% if put_form %}
+            <ul class="nav nav-tabs form-switcher">
+              <li>
+                <a name='html-tab' href="#put-object-form" data-toggle="tab">HTML form</a>
+              </li>
+              <li>
+                <a  name='raw-tab' href="#put-generic-content-form" data-toggle="tab">Raw data</a>
+              </li>
+            </ul>
+          {% endif %}
+
+          <div class="well tab-content">
+            {% if put_form %}
+              <div class="tab-pane" id="put-object-form">
+                <form action="{{ request.get_full_path }}" data-method="PUT" enctype="multipart/form-data" class="form-horizontal" novalidate>
+                  <fieldset>
+                    {{ put_form }}
+                    <div class="form-actions">
+                      <button class="btn btn-primary js-tooltip" title="Make a PUT request on the {{ name }} resource">PUT</button>
+                    </div>
+                  </fieldset>
+                </form>
+              </div>
+            {% endif %}
+
+            <div {% if put_form %}class="tab-pane"{% endif %} id="put-generic-content-form">
+              {% with form=raw_data_put_or_patch_form %}
+                <form action="{{ request.get_full_path }}" data-method="PUT" class="form-horizontal">
+                  <fieldset>
+                    {% include "rest_framework/raw_data_form.html" %}
+                    <div class="form-actions">
+                      {% if raw_data_put_form %}
+                        <button class="btn btn-primary js-tooltip" title="Make a PUT request on the {{ name }} resource">PUT</button>
+                      {% endif %}
+                      {% if raw_data_patch_form %}
+                      <button data-method="PATCH" class="btn btn-primary js-tooltip" title="Make a PATCH request on the {{ name }} resource">PATCH</button>
+                        {% endif %}
+                    </div>
+                  </fieldset>
+                </form>
+              {% endwith %}
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    {% endif %}
+
+  </div><!-- /.container -->
+
+  {% if filter_form %}
+    {{ filter_form }}
+  {% endif %}
+
+  {% block script %}
+    <script>
+      window.drf = {
+        csrfHeaderName: "{{ csrf_header_name|default:'X-CSRFToken' }}",
+        csrfCookieName: "{{ csrf_cookie_name|default:'csrftoken' }}"
+      };
+    </script>
+    <script src="{% static "rest_framework/js/jquery-3.3.1.min.js" %}"></script>
+    <script src="{% static "rest_framework/js/ajax-form.js" %}"></script>
+    <script src="{% static "rest_framework/js/csrf.js" %}"></script>
+    <script src="{% static "rest_framework/js/bootstrap.min.js" %}"></script>
+    <script src="{% static "rest_framework/js/prettify-min.js" %}"></script>
+    <script src="{% static "rest_framework/js/default.js" %}"></script>
+    <script>
+      $(document).ready(function() {
+        $('form').ajaxForm();
+      });
+    </script>
+  {% endblock %}
 {% endblock %}
 
-{% block description %}
-  {% if name == "Api Root"%}{% else %}{{ block.super }}{% endif %}
+{% block footer %}
 {% endblock %}

--- a/capstone/capapi/templates/rest_framework/filters/base.html
+++ b/capstone/capapi/templates/rest_framework/filters/base.html
@@ -1,0 +1,16 @@
+<div class="modal fade" id="filtersModal" tabindex="-1" role="dialog" aria-label="filters" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Filters</h4>
+    </div>
+      <div class="modal-body">
+          {% for element in elements %}
+          {% if not forloop.first %}<hr/>{% endif %}
+          {{ element }}
+          {% endfor %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -1,5 +1,5 @@
 {% load static %}
-<a class="skip" href="#main">Skip to main content</a>
+<a class="skip" href="#{{ skip_target | default:'main'}}">Skip to main content</a>
 <!-- On small screens, show logo on its own row -->
 <div class="row branding-standalone">
   <div class="branding">

--- a/capstone/capweb/templates/includes/nav.html
+++ b/capstone/capweb/templates/includes/nav.html
@@ -1,5 +1,5 @@
 {% load static %}
-<a class="skip" href="#{{ skip_target | default:'main'}}">Skip to main content</a>
+<a class="skip" href="#main">Skip to main content</a>
 <!-- On small screens, show logo on its own row -->
 <div class="row branding-standalone">
   <div class="branding">


### PR DESCRIPTION
Fixes https://github.com/harvard-lil/capstone/issues/509 in a ham-handed way, by using cap's own `layouts/full.html` as the template base, and then pasting in most of DRF's base template, and then making accessibility fixes. There are some infelicities upstream in DRF that can't be fixed neatly by us overriding particular blocks. I'll plan to submit a PR to DRF, and readdress our markup when it lands.