### PR TITLE
Stop counts after 2 seconds, and calculate in background

### DIFF
--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -423,6 +423,8 @@ API_CASE_FILE_TYPE = '.xml'
 # CACHES
 CACHED_COUNT_TIMEOUT = 60*60*24*7  # 'count' value in API responses is cached for up to 7 days
 CACHED_LIL_DATA_TIMEOUT = 60*60*24  # news and contributor data from LIL site is cached once a day
+LIVE_COUNT_TIME_LIMIT = 2  # number of seconds to try to generate a count while preparing an API response
+TASK_COUNT_TIME_LIMIT = 120  # number of seconds to try to generate a count in background task
 
 # DATA VISUALIZATION
 DATA_COUNT_DIR = '/tmp/count-data'

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -87,7 +87,7 @@ def django_assert_num_queries(pytestconfig):
             query_counts = defaultdict(int)
             for q in context.captured_queries:
                 query_type = q['sql'].split(" ",1)[0].lower()
-                if query_type not in ('savepoint', 'release'):
+                if query_type not in ('savepoint', 'release', 'set', 'show'):
                     query_counts[query_type] += 1
             if expected_counts != query_counts:
                 msg = "Unexpected queries: expected %s, got %s" % (expected_counts, dict(query_counts))


### PR DESCRIPTION
- When preparing API response, long-running count query gets killed after 2 seconds and returns `null` in API response
- Counts that don't finish immediately are calculated and cached in a background task

Limitation of this solution: the `null` value will be cached by Cloudflare for 24 hours, so for the first 24 hours after calculating a value in the background we'll still show `null` for that particular page. I think it's better than nothing for now, though.

DEPLOYMENT NOTES:

Calculating values in the background requires celery to be running on the API server.