### PR TITLE
Docs tweaks

### DIFF
--- a/capstone/capweb/templates/about.html
+++ b/capstone/capweb/templates/about.html
@@ -240,7 +240,7 @@
       {% for news_item in news %}
         <li class="item-set">
           <p class="item-title">
-            <a href="{{ news_item.url }}" target="_blank">{{ news_item.title }}</a>
+            <a href="{{ news_item.url }}">{{ news_item.title }}</a>
           </p>
           <span class="item-origin">
               {{ news_item.publication }}
@@ -263,7 +263,7 @@
     <ul>
       <li class="item-set">
         <span class="item-name">
-          <a href="https://lil.law.harvard.edu/" target="_blank">
+          <a href="https://lil.law.harvard.edu/">
             LIL
           </a>
         </span>
@@ -274,7 +274,7 @@
       </li>
       <li class="item-set">
         <span class="item-name">
-          <a href="https://law.harvard.edu/library" target="_blank">
+          <a href="https://law.harvard.edu/library">
             Harvard Law School Library
           </a>
         </span>
@@ -286,7 +286,7 @@
 
       <li class="item-set">
         <span class="item-name">
-          <a href="https://cyber.law.harvard.edu" target="_blank">
+          <a href="https://cyber.law.harvard.edu">
             Berkman-Klein Center
           </a>
         </span>
@@ -298,19 +298,22 @@
 
       <li class="item-set">
         <span class="item-name">
-          <a href="www.ravellaw.com/" target="_blank">
+          <a href="https://www.ravellaw.com/">
             Ravel Law
           </a>
         </span>
         <span class="color-red">&bull;</span>
         <span>
-          Ravel has partnered with the Harvard Law Library and LIL since the beginning of the Caselaw Access Project. Ravel funded the digitization effort and now offers free public access to the entire corpus through their search interface at <a href="https://home.ravellaw.com" target="_blank">https://home.ravellaw.com</a> and their non-commercial API at <a href="https://home.ravellaw.com/api" target="_blank">https://home.ravellaw.com/api</a>.
+          Ravel has partnered with the Harvard Law Library and LIL since the beginning of the Caselaw Access Project.
+          Ravel funded the digitization effort and now offers free public access to the entire corpus through their
+          <a href="https://home.ravellaw.com">search interface</a> and their
+          <a href="https://home.ravellaw.com/api">non-commercial API</a>.
         </span>
       </li>
 
       <li class="item-set">
         <span class="item-name">
-          <a href="https://www.classaction.org/" target="_blank">
+          <a href="https://www.classaction.org/">
             ClassAction.org
           </a>
         </span>
@@ -322,7 +325,7 @@
 
       <li class="item-set">
         <span class="item-name">
-          <a href="https://www.cloudflare.com/" target="_blank">
+          <a href="https://www.cloudflare.com/">
             Cloudflare
           </a>
         </span>
@@ -344,7 +347,7 @@
           <li class="item-set">
                 <span class="item-name">
                   {% if contributor.hash %}
-                    <a href="https://lil.law.harvard.edu/about/#{{ contributor.hash }}" target="_blank">
+                    <a href="https://lil.law.harvard.edu/about/#{{ contributor.hash }}">
                       {{ contributor.name }}
                     </a>
                   {% else %}

--- a/capstone/capweb/templates/api.html
+++ b/capstone/capweb/templates/api.html
@@ -385,11 +385,11 @@
     <dl>
       {# ====> single case <==== #}
       <dt>
-        Retrieve a single case, by its ID
+        Retrieve a single case by ID
       </dt>
       <dd class="example-link">
-        <a href="{% api_url "casemetadata-list" %}{{ case_id }}/">
-          {% api_url "casemetadata-list" %}{{ case_id }}/</a>
+        <a href="{% api_url "casemetadata-detail" case_id %}">
+          {% api_url "casemetadata-detail" case_id %}</a>
       </dd>
       <dd>
         <p>
@@ -401,8 +401,8 @@
           <li class="list-group-item">
             <h5 class="list-header">Standalone HTML-formatted Case</h5>
             <ul>
-              <li class="example-mod-url"><a href="{% api_url "casemetadata-list" %}{{ case_id }}/?full_case=true&format=html">
-                {% api_url "casemetadata-list" %}{{ case_id }}/?full_case=true&format=html</a>
+              <li class="example-mod-url"><a href="{% api_url "casemetadata-detail" case_id %}?full_case=true&format=html">
+                {% api_url "casemetadata-detail" case_id %}?full_case=true&format=html</a>
               </li>
               <li class="example-mod-description">This will return a lightly styled, standalone HTML
                 representation of the case with no accompanying metadata.
@@ -414,8 +414,8 @@
           <li class="list-group-item">
             <h5 class="list-header">Plain Text Case in JSON container with metadata</h5>
             <ul>
-              <li class="example-mod-url"><a href="{% api_url "casemetadata-list" %}{{ case_id }}/">
-                {% api_url "casemetadata-list" %}{{ case_id }}/</a>
+              <li class="example-mod-url"><a href="{% api_url "casemetadata-detail" case_id %}">
+                {% api_url "casemetadata-detail" case_id %}</a>
               </li>
               <li class="example-mod-description">This will return a lightly styled, standalone HTML
                 representation of the case with no accompanying metadata.
@@ -426,8 +426,8 @@
             <h5 class="list-header">Raw original XML document, with METS data</h5>
             <ul>
               <li class="example-mod-url">
-                <a href="{% api_url "casemetadata-list" %}{{ case_id }}/?full_case=true&body_format=xml">
-                  {% api_url "casemetadata-list" %}{{ case_id }}/?full_case=true&format=xml
+                <a href="{% api_url "casemetadata-detail" case_id %}?full_case=true&body_format=xml">
+                  {% api_url "casemetadata-detail" case_id %}?full_case=true&format=xml
                 </a>
               </li>
               <li class="example-mod-description">To get the document by itself, without the JSON enclosure and
@@ -672,7 +672,7 @@
         Single Case Endpoint
       </dt>
       <dd class="endpoint-link">
-        <a href="{% api_url "casemetadata-list" %}">{% api_url "casemetadata-list" %}</a>
+        <a href="{% api_url "casemetadata-detail" case_id %}">{% api_url "casemetadata-detail" case_id %}</a>
       </dd>
       <dd>
         <p class="endpoint-description">
@@ -684,17 +684,18 @@
             <h5 class="list-header"><code class="parameter-name">full_case</code></h5>
             <ul>
               <li class="param-data-type"><code>true</code> or <code>false</code></li>
-              <li class="param-description"> When set to <code>true</code>, this parameter loads the case body.
-                It is
-                required for setting both <code>body_format</code> and <code>format</code>.
+              <li class="param-description">
+                When set to <code>true</code>, this parameter loads the case body.
+                It is required for setting both <code>body_format</code> and <code>format</code>.
+              </li>
             </ul>
           </li>
           <li class="list-group-item">
             <h5 class="list-header"><code class="parameter-name">body_format</code></h5>
             <ul>
               <li class="param-data-type"><code>html</code> or <code>xml</code></li>
-              <li class="param-description"> This will return a JSON enclosure with metadata, and a field
-                containing the case in XML or HTML.
+              <li class="param-description">
+                This will return a JSON enclosure with metadata, and a field containing the case in XML or HTML.
               </li>
             </ul>
           </li>
@@ -702,9 +703,8 @@
             <h5 class="list-header"><code class="parameter-name">format</code></h5>
             <ul>
               <li class="param-data-type"><code>html</code> or <code>xml</code></li>
-              <li class="param-description"> This will return the case in HTML or its original XML with no JSON
-                enclosure or
-                Metadata
+              <li class="param-description">
+                This will return the case in HTML or its original XML with no JSON enclosure or metadata.
               </li>
             </ul>
           </li>

--- a/capstone/static/css/scss/_nav.scss
+++ b/capstone/static/css/scss/_nav.scss
@@ -4,7 +4,6 @@
 // via https://stackoverflow.com/a/28824157/307769
 :target::before {
   content: "";
-  display: block;
   height: 60px; /* fixed header height*/
   margin: -60px 0 0; /* negative fixed header height */
 }

--- a/capstone/static/css/scss/docs.scss
+++ b/capstone/static/css/scss/docs.scss
@@ -1,9 +1,5 @@
-@import 'bootstrap/_functions.scss';
-@import 'bootstrap/_variables.scss';
-@import 'bootstrap/mixins';
-
 @import "variables";
-@import "nav";
+
 nav {
   padding: 0;
   width: 100%;


### PR DESCRIPTION
Fixing a couple of random issues that came up during geeks hour -- link to Ravel from About page, and case detail link in API docs. Also dropping some redundant CSS and misc minor cleanup.