### PR TITLE
Switch to python3.5-stretch

### DIFF
--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-stretch
+FROM python:3.5-stretch
 ENV PYTHONUNBUFFERED 1
 
 # pip


### PR DESCRIPTION
It looks like there is a 3.5-stretch now! https://github.com/docker-library/python/tree/master/3.5/stretch

In https://github.com/harvard-lil/capstone/pull/688 you mentioned a desire to keep versions as close to lockstep as possible