### PR TITLE
Use volume_barcode_from_folder to parse volume folder names

### DIFF
--- a/capstone/scripts/compress_volumes.py
+++ b/capstone/scripts/compress_volumes.py
@@ -21,7 +21,8 @@ from django.conf import settings
 from django.template.defaultfilters import filesizeformat
 
 from capdb.storages import ingest_storage, captar_storage, get_storage, CaptarStorage, CapS3Storage, CapFileStorage, private_ingest_storage
-from scripts.helpers import copy_file, parse_xml, resolve_namespace, serialize_xml, HashingFile
+from scripts.helpers import copy_file, parse_xml, resolve_namespace, serialize_xml, HashingFile, \
+    volume_barcode_from_folder
 
 # logging
 # disable boto3 info logging -- see https://github.com/boto/boto3/issues/521
@@ -623,7 +624,7 @@ def sample_images(count=100):
         current_vol = next(volumes, "")
         while current_vol:
             next_vol = next(volumes, "")
-            if current_vol.split("_", 1)[0] != next_vol.split("_", 1)[0]:
+            if volume_barcode_from_folder(current_vol) != volume_barcode_from_folder(next_vol):
                 yield current_vol
             current_vol = next_vol
 
@@ -631,7 +632,7 @@ def sample_images(count=100):
     volumes = list(get_volumes())
     for vol in random.sample(volumes, min(len(volumes), count)):
         print("Sampling", vol)
-        id = vol.split('_', 1)[0]
+        id = volume_barcode_from_folder(vol)
         for i in [0,1]:
             img_name = "%s_00050_%s.tif" % (id, i)
             copy_file(

--- a/capstone/scripts/validate_private_volumes.py
+++ b/capstone/scripts/validate_private_volumes.py
@@ -8,6 +8,7 @@ from django.utils.encoding import force_str
 
 from capdb.models import VolumeMetadata
 from capdb.storages import private_ingest_storage
+from scripts.helpers import volume_barcode_from_folder
 from scripts.ingest_by_manifest import wipe_redis_db, read_inventory_files, get_unique_volumes_from_queue, \
     get_s3_items_by_type_from_queue, validate_volmets, report_errors, store_error
 
@@ -87,7 +88,7 @@ def process_report():
             parts = line.strip().split("\t")
             volume_folder, error_code, details = parts[0], parts[1], parts[2:]
             expected_volumes.discard(volume_folder)
-            processed_vols.add(volume_folder)
+            processed_vols.add(volume_barcode_from_folder(volume_folder))
             if error_code == 'ok':
                 continue
             error = {'error_code': error_code}
@@ -99,7 +100,7 @@ def process_report():
         errors[missed_volume] = {'error_code': 'in inventory report but not processed'}
 
     db_vols = VolumeMetadata.objects.exclude(ingest_status='skip').filter(xml_publication_year__gte=1923).values_list('pk', flat=True)
-    missing_vols = set(db_vols) - set(i.split('_')[0] for i in processed_vols)
+    missing_vols = set(db_vols) - processed_vols
     for missed_volume in missing_vols:
         errors[missed_volume] = {'error_code': 'in database but not in S3'}
 


### PR DESCRIPTION
This patches another 7 places where we were incorrectly parsing volume folders with underscores in the barcode, like `Cal4th_063_redacted`. Most importantly it might pick up some additional CAPTAR pdf volumes -- though we can wait on re-running if we're asking for those to be reworked to include the PDFs in the METS.