### PR TITLE
Provide default count for admin if count times out

### DIFF
--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -120,6 +120,13 @@ class CachedCountQuerySet(QuerySet):
             return value
 
 
+class CachedCountDefaultQuerySet(CachedCountQuerySet):
+    """ Like CachedCountQuerySet, but returns default_count if counting times out. """
+    default_count = 1000000
+    def count(self):
+        return super().count() or self.default_count
+
+
 def api_reverse(viewname, args=None, kwargs=None, request=None, format=None, **extra):
     """
         Same as `django.urls.reverse`, but uses api_urls.py for routing, and includes full domain name.

--- a/capstone/capdb/admin.py
+++ b/capstone/capdb/admin.py
@@ -3,7 +3,7 @@ from django.forms.widgets import Textarea
 from django.utils.text import normalize_newlines
 from simple_history.admin import SimpleHistoryAdmin
 
-from capapi.resources import CachedCountQuerySet
+from capapi.resources import CachedCountDefaultQuerySet
 from .models import VolumeXML, CaseXML, PageXML, TrackingToolLog, VolumeMetadata, Reporter, ProcessStep, BookRequest, \
     TrackingToolUser, SlowQuery, Jurisdiction, CaseMetadata, CaseExport, Citation
 
@@ -39,10 +39,13 @@ class ReadonlyInlineMixin(object):
 
 
 class CachedCountMixin(object):
-    """ Mixin for ModelAdmin to use cached .count() queries. """
+    """
+        Mixin for ModelAdmin to use cached .count() queries.
+        Admin will report 1000000 entries if the real number is not available.
+    """
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        qs.__class__ = CachedCountQuerySet
+        qs.__class__ = CachedCountDefaultQuerySet
         return qs
 
 


### PR DESCRIPTION
Admin will show 1000000 entries if fetching the correct number takes too long. Fixes #721