### PR TITLE
Get tests passing in Docker env

### DIFF
--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -1,11 +1,24 @@
 FROM python:3.5-stretch
 ENV PYTHONUNBUFFERED 1
 
+# Get build dependencies and packages required by the app
+# pytest-redis requires a local redis instance)
+# https://github.com/ClearcodeHQ/pytest-redis/issues/108)
+RUN apt-get update \
+    && apt-get install -y redis-server
+
 # pip
 RUN mkdir /app
 WORKDIR /app
-ADD requirements.txt /app/
-RUN pip install -U pip; pip install -r requirements.txt --src /usr/local/src
+COPY requirements.txt /app
+RUN pip install -U pip \
+    && pip install -r requirements.txt --src /usr/local/src \
+    && rm requirements.txt
 
-# code
-ADD . /app/
+# nodejs
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
+COPY package-lock.json /app
+RUN apt-get update \
+    && apt-get install -y nodejs \
+    && npm install \
+    && rm package-lock.json

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -361,6 +361,12 @@ STORAGES = {
             'location': os.path.join(BASE_DIR, 'test_data/bulk-data'),
         },
     },
+    'transfer_storage': {
+        'class': 'CapS3Storage',
+        'kwargs': {
+            'location': os.path.join(BASE_DIR, 'test_data/xfer'),
+        }
+    },
 }
 
 INVENTORY = {

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -426,7 +426,6 @@ REDIS_DEFAULT_DB = 0
 REDIS_INGEST_DB = 1         # database for temporary data created during the S3 ingest process
 REDIS_DJANGO_CACHE_DB = 2   # database for django's cache framework
 
-
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
@@ -527,21 +526,21 @@ NEW_RESEARCHER_FEATURE = True
 HARVARD_RESEARCHER_FEATURE = True
 
 HARVARD_IP_RANGES = """
-    12.0.48.0/20 
-    12.6.208.0/20 
-    65.112.0.0/20 
-    67.134.204.0/22 
-    128.103.0.0/16 
-    134.174.0.0/16 
-    140.247.0.0/16 
-    192.5.66.0/24 
-    192.54.223.0/24 
-    192.131.102.0/24 
-    199.94.0.0/19 
-    199.94.32.0/20 
-    199.94.48.0/24 
-    199.94.60.0/22 
-    206.191.184.0/21 
+    12.0.48.0/20
+    12.6.208.0/20
+    65.112.0.0/20
+    67.134.204.0/22
+    128.103.0.0/16
+    134.174.0.0/16
+    140.247.0.0/16
+    192.5.66.0/24
+    192.54.223.0/24
+    192.131.102.0/24
+    199.94.0.0/19
+    199.94.32.0/20
+    199.94.48.0/24
+    199.94.60.0/22
+    206.191.184.0/21
     206.253.200.0/21
 """.split()
 

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -8,7 +8,7 @@ services:
         environment:
             POSTGRES_PASSWORD: password
         volumes:
-          - db_data:/var/lib/postgresql/data
+          - db_data:/var/lib/postgresql/data:delegated
     redis:
         image: redis:4
 #    rabbit:
@@ -21,10 +21,20 @@ services:
 ##        mem_limit: 128M
     worker:
         build: .
-        image: capstone:0.1
+        image: capstone:0.2
         volumes:
             - .:/app
             - ../services:/services
+            # NAMED VOLUMES
+            # Use a named, persistent volume so that the node_modules directory,
+            # which is created during the image's build process, and which our
+            # code presently expects to be nested inside the /app directory,
+            # isn't wiped out when mounting our code in ./app code to
+            # the container. We can consider restructuring the project instead.
+            - node_modules:/app/node_modules:delegated
+            # Use a delegated volume for this instance's redis (used by tests)
+            # to hopefully smooth I/O performance issues
+            - test_redis:/var/lib/redis:delegated
         depends_on:
             - redis
             - db
@@ -37,7 +47,7 @@ services:
           - "api.case.test:127.0.0.1"
     web:
         build: .
-        image: capstone:0.1
+        image: capstone:0.2
         volumes:
             - .:/app
             - ../services:/services
@@ -57,3 +67,5 @@ services:
 
 volumes:
     db_data:
+    node_modules:
+    test_redis:

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -29,11 +29,10 @@ services:
             # Use a named, persistent volume so that the node_modules directory,
             # which is created during the image's build process, and which our
             # code presently expects to be nested inside the /app directory,
-            # isn't wiped out when mounting our code in ./app code to
-            # the container. We can consider restructuring the project instead.
+            # isn't wiped out when mounting our code.
             - node_modules:/app/node_modules:delegated
             # Use a delegated volume for this instance's redis (used by tests)
-            # to hopefully smooth I/O performance issues
+            # to hopefully smooth I/O performance issues. Necessary?
             - test_redis:/var/lib/redis:delegated
         depends_on:
             - redis


### PR DESCRIPTION
- installs node and npm packages
- installs a local redis on the web/worker image for use by pytest-redis, which cannot be configured to use a remote redis at this time.....
- uses named volumes and the `:delegated` to smooth heavy I/O. Might not be necessary for the local redis, but so far as I can tell harmless
- does not `ADD` code to the image, since up-to-date code is supplied via mounted volumes

Note that tests pass even when the worker containers crash. (Perma doesn't test it's celery workers either)