### PR TITLE
Correctly handle node_modules in Docker setup

### DIFF
--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -17,8 +17,10 @@ RUN pip install -U pip \
 
 # nodejs
 RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
+COPY package.json /app
 COPY package-lock.json /app
 RUN apt-get update \
     && apt-get install -y nodejs \
     && npm install \
+    && rm package.json \
     && rm package-lock.json

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -23,8 +23,6 @@ services:
         build: .
         image: capstone:0.2
         volumes:
-            - .:/app
-            - ../services:/services
             # NAMED VOLUMES
             # Use a named, persistent volume so that the node_modules directory,
             # which is created during the image's build process, and which our
@@ -34,6 +32,10 @@ services:
             # Use a delegated volume for this instance's redis (used by tests)
             # to hopefully smooth I/O performance issues. Necessary?
             - test_redis:/var/lib/redis:delegated
+            # MOUNTS
+            - .:/app
+            - ../services:/services
+
         depends_on:
             - redis
             - db
@@ -48,6 +50,10 @@ services:
         build: .
         image: capstone:0.2
         volumes:
+            # NAMED VOLUMES
+            - node_modules:/app/node_modules:delegated
+            - test_redis:/var/lib/redis:delegated
+            # MOUNTS
             - .:/app
             - ../services:/services
         depends_on:


### PR DESCRIPTION
My string of incomplete PRs continues.....

Last PR only worked due to an oversight: I had the node_modules dir locally.

This PR, I am 99.999%, properly keeps node_modules inside the image/containers.