### PR TITLE
Update pip requirements

### DIFF
--- a/capstone/capapi/forms.py
+++ b/capstone/capapi/forms.py
@@ -3,7 +3,7 @@ import re
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django import forms
 from django.utils.safestring import mark_safe
-from django.utils.translation import format_lazy
+from django.utils.text import format_lazy
 
 from capapi.models import CapUser, ResearchRequest, ResearchContract, HarvardContract
 from capweb.helpers import reverse, reverse_lazy

--- a/capstone/capapi/forms.py
+++ b/capstone/capapi/forms.py
@@ -3,7 +3,7 @@ import re
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
 from django import forms
 from django.utils.safestring import mark_safe
-from django.utils.translation import string_concat
+from django.utils.translation import format_lazy
 
 from capapi.models import CapUser, ResearchRequest, ResearchContract, HarvardContract
 from capweb.helpers import reverse, reverse_lazy
@@ -80,7 +80,8 @@ class ResearchContractForm(forms.ModelForm):
     name = forms.CharField(label='Full name of researcher')
     email = forms.EmailField(
         disabled=True,  # any email submitted by user will be ignored
-        help_text=string_concat(
+        help_text=format_lazy(
+            '{}{}{}',
             "For faster approval, make sure you are applying from a CAP account with an email address "
             "provided by your institution. If this is the wrong email address, <a href='",
             reverse_lazy('register'),

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -55,7 +55,7 @@ def test_jurisdiction_redirect(client, case, jurisdiction):
 ])
 def test_model_endpoint(request, client, fixture_name, detail_attr, comparison_attr):
     """ Generic test to kick the tires on -list and -detail for model endpoints. """
-    instance = request.getfuncargvalue(fixture_name)
+    instance = request.getfixturevalue(fixture_name)
     model = instance.__class__
     resource_name = model.__name__.lower()
 

--- a/capstone/capapi/tests/test_cache.py
+++ b/capstone/capapi/tests/test_cache.py
@@ -42,7 +42,7 @@ def test_cache_headers(case, request, settings,
     # set up variables
     get_kwargs = deepcopy(get_kwargs)  # avoid modifying between tests
     settings.SET_CACHE_CONTROL_HEADER = True
-    client = request.getfuncargvalue(client_fixture_name)
+    client = request.getfixturevalue(client_fixture_name)
     cache_expected = cache_if_logged_in if client._credentials else cache_if_logged_out
 
     # Resolve reverse_args. For example, if we see "fixture_case_export" we will fetch the "case_export" fixture
@@ -50,7 +50,7 @@ def test_cache_headers(case, request, settings,
     reverse_args = get_kwargs.pop('reverse_args', [])
     for i, arg in enumerate(reverse_args):
         if arg.startswith("fixture_"):
-            reverse_args[i] = request.getfuncargvalue(arg.split('_', 1)[1]).pk
+            reverse_args[i] = request.getfixturevalue(arg.split('_', 1)[1]).pk
 
     # reverse from the view name, using get_kwargs['reverse_func'] or reverse() by default
     reverse_func = get_kwargs.pop('reverse_func', 'reverse')

--- a/capstone/capapi/tests/test_user_views.py
+++ b/capstone/capapi/tests/test_user_views.py
@@ -150,7 +150,7 @@ def test_view_user_details(auth_user, auth_client):
 ])
 @pytest.mark.django_db
 def test_bulk_data_list(request, case_export, private_case_export, client_fixture, can_see_private):
-    client = request.getfuncargvalue(client_fixture)
+    client = request.getfixturevalue(client_fixture)
     public_url = api_reverse('caseexport-download', args=[case_export.pk])
     private_url = api_reverse('caseexport-download', args=[private_case_export.pk])
 
@@ -177,8 +177,8 @@ def check_zip_response(response):
 ])
 @pytest.mark.django_db
 def test_case_export_download(request, client_fixture, export_fixture, status_code):
-    client = request.getfuncargvalue(client_fixture)
-    export = request.getfuncargvalue(export_fixture)
+    client = request.getfixturevalue(client_fixture)
+    export = request.getfixturevalue(export_fixture)
     response = client.get(api_reverse('caseexport-download', args=[export.pk]))
     if status_code == 200:
         check_zip_response(response)

--- a/capstone/capdb/tests/test_versioning.py
+++ b/capstone/capdb/tests/test_versioning.py
@@ -14,7 +14,7 @@ from scripts.helpers import parse_xml, serialize_xml
 @pytest.mark.django_db
 def test_versioning(versioned_fixture_name, request):
     # load initial volume_xml/case_xml/page_xml
-    versioned_instance = request.getfuncargvalue(versioned_fixture_name)
+    versioned_instance = request.getfixturevalue(versioned_fixture_name)
     original_instance = deepcopy(versioned_instance)
 
     # starts with no history

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -364,7 +364,7 @@ STORAGES = {
     'transfer_storage': {
         'class': 'CapS3Storage',
         'kwargs': {
-            'location': os.path.join(BASE_DIR, 'test_data/xfer'),
+            'location': os.path.join(BASE_DIR, 'test_data/xfer').lstrip('/'),
         }
     },
 }

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -14,9 +14,7 @@ flower              # monitoring
 # xml
 lxml
 xmltodict
-#pyquery
-# use this until https://github.com/gawel/pyquery/pull/183 lands:
--e git://github.com/jcushman/pyquery.git@115173a#egg=pyquery
+pyquery
 
 # database
 psycopg2            # postgres connector

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -57,7 +57,7 @@ beautifulsoup4
 django-extensions
 django-libsass
 django-pipeline
-djangorestframework-filters==1.0.0.dev0 #remove pinned version once 1.0.0 is released (12/26/18)
+djangorestframework-filters==1.0.0.dev0 # remove pinned version once 1.0.0 is released (noted: 12/26/18)
 djangorestframework
 django-bootstrap4   # render bootstrap forms in django templates
 drf-yasg            # expose API specification

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -57,7 +57,7 @@ beautifulsoup4
 django-extensions
 django-libsass
 django-pipeline
-djangorestframework-filters
+djangorestframework-filters==1.0.0.dev0 #remove pinned version once 1.0.0 is released (12/26/18)
 djangorestframework
 django-bootstrap4   # render bootstrap forms in django templates
 drf-yasg            # expose API specification

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -29,9 +29,7 @@ django-storages     # abstract file access
 boto3               # for django-storages to talk to s3
 django-bulk-update  # bulk update of models
 whitenoise          # serve static assets
-#django-model-utils  # FieldTracker for tracking changed fields on model instances
-# upgrade to master is blocking on https://github.com/jazzband/django-model-utils/issues/331
--e git://github.com/jcushman/django-model-utils.git@d34043f#egg=django-model-utils
+django-model-utils  # FieldTracker for tracking changed fields on model instances
 django-simple-history   # model versioning
 django-partial-index    # create partial postgres indexes
 django-redis        # use redis as Django cache backend
@@ -61,15 +59,13 @@ beautifulsoup4
 django-extensions
 django-libsass
 django-pipeline
-#djangorestframework-filters
-# switch back to next release post 8/1/18:
--e git://github.com/philipn/django-rest-framework-filters.git@c5ffc8276431cf49dddbcebab322b142843de4ef#egg=djangorestframework-filters
+djangorestframework-filters
 djangorestframework
 django-bootstrap4   # render bootstrap forms in django templates
 drf-yasg            # expose API specification
 flex                    # both used for spec validation
 swagger_spec_validator  # by drf-yasg
--e git://github.com/jcushman/email-normalize.git@6b5088bd05de247a9a33ad4e5c7911b676d6daf2#egg=email-normalize
+email-normalize
 
 # pdf generation
 PyPDF2
@@ -77,6 +73,6 @@ reportlab
 img2pdf
 
 # maintenance page
--e git://github.com/zTrix/webpage2html.git@9df878a#egg=webpage2html     # save target page as string
+webpage2html     # save target page as string
 termcolor   # required by webpage2html
 mincss      # remove unused css styles

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -27,7 +27,7 @@ django-storages     # abstract file access
 boto3               # for django-storages to talk to s3
 django-bulk-update  # bulk update of models
 whitenoise          # serve static assets
--e git://github.com/jcushman/django-model-utils.git@6b88c888d3e39aa1ebd72f834d08f44dd6997515#egg=django-model-utils # remove pinned version once a new version is released (noted: 12/26/18)
+-e git://github.com/jazzband/django-model-utils.git@6b88c888d3e39aa1ebd72f834d08f44dd6997515#egg=django-model-utils # remove pinned version once a new version is released (noted: 12/26/18)
 django-simple-history   # model versioning
 django-partial-index    # create partial postgres indexes
 django-redis        # use redis as Django cache backend

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -27,7 +27,7 @@ django-storages     # abstract file access
 boto3               # for django-storages to talk to s3
 django-bulk-update  # bulk update of models
 whitenoise          # serve static assets
-django-model-utils  # FieldTracker for tracking changed fields on model instances
+-e git://github.com/jcushman/django-model-utils.git@6b88c888d3e39aa1ebd72f834d08f44dd6997515#egg=django-model-utils # remove pinned version once a new version is released (noted: 12/26/18)
 django-simple-history   # model versioning
 django-partial-index    # create partial postgres indexes
 django-redis        # use redis as Django cache backend

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -4,6 +4,7 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+-e git+git://github.com/jazzband/django-model-utils.git@6b88c888d3e39aa1ebd72f834d08f44dd6997515#egg=django-model-utils
 amqp==2.3.2               # via kombu
 apipkg==1.5               # via execnet
 asn1crypto==0.24.0        # via cryptography
@@ -36,7 +37,6 @@ django-extensions==2.1.4
 django-filter==2.0.0      # via djangorestframework-filters
 django-hosts==3.0
 django-libsass==0.7
-django-model-utils==3.1.2
 django-partial-index==0.5.2
 django-pipeline==1.6.14
 django-redis==4.10.0

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -9,137 +9,138 @@
 -e git+git://github.com/jcushman/email-normalize.git@6b5088bd05de247a9a33ad4e5c7911b676d6daf2#egg=email-normalize
 -e git+git://github.com/jcushman/pyquery.git@115173a#egg=pyquery
 -e git+git://github.com/zTrix/webpage2html.git@9df878a#egg=webpage2html
-amqp==2.2.2               # via kombu
-apipkg==1.4               # via execnet
-asn1crypto==0.22.0        # via cryptography
-atomicwrites==1.1.5       # via pytest
-attrs==17.4.0             # via pytest
+amqp==2.3.2               # via kombu
+apipkg==1.5               # via execnet
+asn1crypto==0.24.0        # via cryptography
+atomicwrites==1.2.1       # via pytest
+attrs==18.2.0             # via pytest
 aws-xray-sdk==0.95        # via moto
-babel==2.5.3              # via flower
-bagit==1.6.4
-bcrypt==3.1.4             # via paramiko
-beautifulsoup4==4.6.0
-billiard==3.5.0.3         # via celery
-boto3==1.7.48
-boto==2.47.0              # via moto
-botocore==1.10.48         # via boto3, moto, s3transfer
-celery[redis,sqs]==4.2.0
-certifi==2017.4.17        # via requests
-cffi==1.10.0              # via bcrypt, cryptography, pynacl
-chardet==3.0.3            # via requests
+babel==2.6.0              # via flower
+bagit==1.7.0
+bcrypt==3.1.5             # via paramiko
+beautifulsoup4==4.6.3
+billiard==3.5.0.5         # via celery
+boto3==1.9.71
+boto==2.49.0              # via moto
+botocore==1.12.71         # via boto3, moto, s3transfer
+celery[redis,sqs]==4.2.1
+certifi==2018.11.29       # via requests
+cffi==1.11.5              # via bcrypt, cryptography, pynacl
+chardet==3.0.4            # via requests
 click==6.7                # via flex, pip-tools
-cookies==2.2.1            # via moto, responses
-coreapi==2.3.3            # via drf-yasg, openapi-codec
+coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
-coverage==4.4.1           # via pytest-cov
-cryptography==2.3         # via moto, paramiko
-cssselect==1.0.1          # via mincss
+coverage==4.5.2           # via pytest-cov
+cryptography==2.4.2       # via moto, paramiko
+cssselect==1.0.3          # via mincss
 django-appconf==1.0.2     # via django-compressor
-django-bootstrap4==0.0.6
-django-bulk-update==2.1.0
-django-compressor==2.1.1  # via django-libsass
-django-extensions==2.0.6
+django-bootstrap4==0.0.7
+django-bulk-update==2.2.0
+django-compressor==2.2    # via django-libsass
+django-extensions==2.1.4
 django-filter==2.0.0
 django-hosts==3.0
 django-libsass==0.7
-django-partial-index==0.4.0
+django-partial-index==0.5.2
 django-pipeline==1.6.14
-django-redis==4.9.0
-django-simple-history==2.1.1
-django-storages==1.6.6
+django-redis==4.10.0
+django-simple-history==2.6.0
+django-storages==1.7.1
 django-webpack-loader==0.6.0
-django==2.0.8
-djangorestframework==3.8.2
-dnspython==1.15.0
-docker-pycreds==0.3.0     # via docker
-docker==3.4.1             # via moto
-docutils==0.13.1          # via botocore
-drf-yasg==1.7.1
+django==2.1.4
+djangorestframework==3.9.0
+dnspython==1.16.0
+docker-pycreds==0.4.0     # via docker
+docker==3.6.0             # via moto
+docutils==0.14            # via botocore
+drf-yasg==1.12.0
 ecdsa==0.13               # via python-jose
-execnet==1.4.1            # via pytest-xdist
+execnet==1.5.0            # via pytest-xdist
 fabric3==1.14.post1
 factory-boy==2.11.1
-faker==0.8.4              # via factory-boy
-first==2.0.1              # via pip-tools
-flake8==3.4.1
-flex==6.13.1
+faker==1.0.1              # via factory-boy
+flake8==3.6.0
+flex==6.13.2
 flower==0.9.2
-future==0.16.0            # via drf-yasg, python-jose
-idna==2.5                 # via cryptography, requests
-img2pdf==0.3.0
+future==0.17.1            # via python-jose
+idna==2.8                 # via cryptography, requests
+img2pdf==0.3.2
 inflection==0.3.1         # via drf-yasg, pytest-factoryboy
 itypes==1.1.0             # via coreapi
-jinja2==2.9.6             # via coreschema, moto
-jmespath==0.9.2           # via boto3, botocore
+jinja2==2.10              # via coreschema, moto
+jmespath==0.9.3           # via boto3, botocore
 jsondiff==1.1.1           # via moto
-jsonpickle==0.9.6         # via aws-xray-sdk
+jsonpickle==1.0           # via aws-xray-sdk
 jsonpointer==1.14         # via flex
 jsonschema==2.6.0         # via swagger-spec-validator
-kombu==4.2.1              # via celery
-libsass==0.14.5           # via django-libsass, libsasscompiler
+kombu==4.2.2              # via celery
+libsass==0.16.1           # via django-libsass, libsasscompiler
 libsasscompiler==0.1.5
-lxml==3.7.3
-markupsafe==1.0           # via jinja2
+lxml==4.2.5
+markupsafe==1.1.0         # via jinja2
 mccabe==0.6.1             # via flake8
 mincss==0.11.6
-mirakuru==0.8.2           # via pytest-redis
+mirakuru==1.1.0           # via pytest-redis
 mock==2.0.0               # via moto
 more-itertools==4.3.0     # via pytest
-moto==1.3.6
-mysqlclient==1.3.10
+moto==1.3.7
+mysqlclient==1.3.14
 netaddr==0.7.19
-nltk==3.3.0
-openapi-codec==1.3.2      # via drf-yasg
+nltk==3.4
 paramiko==2.4.2           # via fabric3
-pathlib2==2.3.2           # via pytest
-pbr==4.2.0                # via mock
-pillow==5.2.0             # via img2pdf, reportlab
-pip-tools==2.0.1
-pluggy==0.7.1             # via pytest
+pathlib2==2.3.3           # via pytest
+pbr==5.1.1                # via mock
+pillow==5.3.0             # via img2pdf, reportlab
+pip-tools==3.2.0
+pluggy==0.8.0             # via pytest
 port-for==0.4             # via pytest-redis
-psutil==5.4.0             # via mirakuru
-psycopg2==2.7.1
-py==1.5.2                 # via pytest, pytest-xdist
-pyaml==16.12.2            # via moto
-pyasn1==0.2.3             # via paramiko
-pycodestyle==2.3.1        # via flake8
-pycparser==2.17           # via cffi
-pycryptodome==3.6.6       # via python-jose
-pycurl==7.43.0
-pyflakes==1.5.0           # via flake8
-pynacl==1.2.1             # via paramiko
+psutil==5.4.8             # via mirakuru
+psycopg2==2.7.6.1
+py==1.7.0                 # via pytest
+pyaml==18.11.0            # via moto
+pyasn1==0.4.4             # via paramiko
+pycodestyle==2.4.0        # via flake8
+pycparser==2.19           # via cffi
+pycryptodome==3.7.2       # via python-jose
+pycurl==7.43.0.2
+pyflakes==2.0.0           # via flake8
+pynacl==1.3.0             # via paramiko
 pypdf2==1.26.0
-pytest-cov==2.5.1
-pytest-django==3.3.3
-pytest-factoryboy==2.0.1
+pytest-cov==2.6.0
+pytest-django==3.4.4
+pytest-factoryboy==2.0.2
+pytest-forked==0.2        # via pytest-xdist
 pytest-redis==1.3.2
-pytest-xdist==1.16.0
-pytest==3.7.0             # via pytest-cov, pytest-django, pytest-factoryboy, pytest-redis, pytest-xdist
-python-dateutil==2.6.0    # via botocore, faker, moto
+pytest-xdist==1.25.0
+pytest==4.0.2             # via pytest-cov, pytest-django, pytest-factoryboy, pytest-forked, pytest-redis, pytest-xdist
+python-dateutil==2.7.5    # via botocore, faker, moto
 python-jose==2.0.2        # via moto
-pytz==2017.2              # via babel, celery, django, flower, moto
-pyyaml==3.12              # via flex, pyaml
+pytz==2018.7              # via babel, celery, django, flower, moto
+pyyaml==3.13              # via flex, pyaml, swagger-spec-validator
 rcssmin==1.0.6            # via django-compressor
-redis==2.10.6
-reportlab==3.5.2
-requests==2.20.0          # via aws-xray-sdk, coreapi, docker, flex, moto, responses
-responses==0.9.0          # via moto
-rfc3987==1.3.7            # via flex
+redis==3.0.1
+reporters-db==1.0.19
+reportlab==3.5.12
+requests==2.21.0          # via aws-xray-sdk, coreapi, docker, flex, moto, responses
+responses==0.10.5         # via moto
+rfc3987==1.3.8            # via flex
 rjsmin==1.0.12            # via django-compressor
-ruamel.yaml==0.15.37      # via drf-yasg
-s3transfer==0.1.10        # via boto3
-six==1.10.0               # via bcrypt, cryptography, django-extensions, docker, docker-pycreds, drf-yasg, fabric3, faker, flex, libsass, mock, more-itertools, moto, nltk, pathlib2, pip-tools, pynacl, pytest, python-dateutil, python-jose, responses, swagger-spec-validator, websocket-client
+ruamel.yaml==0.15.81      # via drf-yasg
+s3transfer==0.1.13        # via boto3
+singledispatch==3.4.0.3   # via nltk
+six==1.12.0               # via bcrypt, cryptography, django-extensions, docker, docker-pycreds, drf-yasg, fabric3, faker, flex, libsass, mock, more-itertools, moto, nltk, pathlib2, pip-tools, pynacl, pytest, pytest-xdist, python-dateutil, python-jose, reporters-db, responses, singledispatch, swagger-spec-validator, websocket-client
 strict-rfc3339==0.7       # via flex
-swagger-spec-validator==2.1.0
+swagger-spec-validator==2.4.1
 termcolor==1.1.0
-tornado==5.0.2            # via flower
-tqdm==4.11.2
+text-unidecode==1.2       # via faker
+tornado==5.1.1            # via flower
+tqdm==4.28.1
 uritemplate==3.0.0        # via coreapi, drf-yasg
-urllib3==1.24.1           # via requests
+urllib3==1.24.1           # via botocore, requests
 validate-email==1.3       # via flex
 vine==1.1.4               # via amqp
-websocket-client==0.48.0  # via docker
-werkzeug==0.12.2          # via moto
-whitenoise==3.3.1
+websocket-client==0.54.0  # via docker
+werkzeug==0.14.1          # via moto
+whitenoise==4.1.2
 wrapt==1.10.11
 xmltodict==0.11.0

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -33,7 +33,7 @@ django-bootstrap4==0.0.7
 django-bulk-update==2.2.0
 django-compressor==2.2    # via django-libsass
 django-extensions==2.1.4
-django-filter==1.1.0      # via djangorestframework-filters
+django-filter==2.0.0      # via djangorestframework-filters
 django-hosts==3.0
 django-libsass==0.7
 django-model-utils==3.1.2
@@ -44,7 +44,7 @@ django-simple-history==2.6.0
 django-storages==1.7.1
 django-webpack-loader==0.6.0
 django==2.1.4
-djangorestframework-filters==0.10.2.post0
+djangorestframework-filters==1.0.0.dev0
 djangorestframework==3.9.0
 dnspython==1.16.0         # via email-normalize
 docker-pycreds==0.4.0     # via docker

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -4,11 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
--e git+git://github.com/jcushman/django-model-utils.git@d34043f#egg=django-model-utils
--e git+git://github.com/philipn/django-rest-framework-filters.git@c5ffc8276431cf49dddbcebab322b142843de4ef#egg=djangorestframework-filters
--e git+git://github.com/jcushman/email-normalize.git@6b5088bd05de247a9a33ad4e5c7911b676d6daf2#egg=email-normalize
--e git+git://github.com/jcushman/pyquery.git@115173a#egg=pyquery
--e git+git://github.com/zTrix/webpage2html.git@9df878a#egg=webpage2html
 amqp==2.3.2               # via kombu
 apipkg==1.5               # via execnet
 asn1crypto==0.24.0        # via cryptography
@@ -32,15 +27,16 @@ coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
 coverage==4.5.2           # via pytest-cov
 cryptography==2.4.2       # via moto, paramiko
-cssselect==1.0.3          # via mincss
+cssselect==1.0.3          # via mincss, pyquery
 django-appconf==1.0.2     # via django-compressor
 django-bootstrap4==0.0.7
 django-bulk-update==2.2.0
 django-compressor==2.2    # via django-libsass
 django-extensions==2.1.4
-django-filter==2.0.0
+django-filter==1.1.0      # via djangorestframework-filters
 django-hosts==3.0
 django-libsass==0.7
+django-model-utils==3.1.2
 django-partial-index==0.5.2
 django-pipeline==1.6.14
 django-redis==4.10.0
@@ -48,13 +44,15 @@ django-simple-history==2.6.0
 django-storages==1.7.1
 django-webpack-loader==0.6.0
 django==2.1.4
+djangorestframework-filters==0.10.2.post0
 djangorestframework==3.9.0
-dnspython==1.16.0
+dnspython==1.16.0         # via email-normalize
 docker-pycreds==0.4.0     # via docker
 docker==3.6.0             # via moto
 docutils==0.14            # via botocore
 drf-yasg==1.12.0
 ecdsa==0.13               # via python-jose
+email-normalize==0.2.1
 execnet==1.5.0            # via pytest-xdist
 fabric3==1.14.post1
 factory-boy==2.11.1
@@ -106,6 +104,7 @@ pycurl==7.43.0.2
 pyflakes==2.0.0           # via flake8
 pynacl==1.3.0             # via paramiko
 pypdf2==1.26.0
+pyquery==1.4.0
 pytest-cov==2.6.0
 pytest-django==3.4.4
 pytest-factoryboy==2.0.2
@@ -119,7 +118,6 @@ pytz==2018.7              # via babel, celery, django, flower, moto
 pyyaml==3.13              # via flex, pyaml, swagger-spec-validator
 rcssmin==1.0.6            # via django-compressor
 redis==3.0.1
-reporters-db==1.0.19
 reportlab==3.5.12
 requests==2.21.0          # via aws-xray-sdk, coreapi, docker, flex, moto, responses
 responses==0.10.5         # via moto
@@ -128,7 +126,7 @@ rjsmin==1.0.12            # via django-compressor
 ruamel.yaml==0.15.81      # via drf-yasg
 s3transfer==0.1.13        # via boto3
 singledispatch==3.4.0.3   # via nltk
-six==1.12.0               # via bcrypt, cryptography, django-extensions, docker, docker-pycreds, drf-yasg, fabric3, faker, flex, libsass, mock, more-itertools, moto, nltk, pathlib2, pip-tools, pynacl, pytest, pytest-xdist, python-dateutil, python-jose, reporters-db, responses, singledispatch, swagger-spec-validator, websocket-client
+six==1.12.0               # via bcrypt, cryptography, django-extensions, docker, docker-pycreds, drf-yasg, fabric3, faker, flex, libsass, mock, more-itertools, moto, nltk, pathlib2, pip-tools, pynacl, pytest, pytest-xdist, python-dateutil, python-jose, responses, singledispatch, swagger-spec-validator, websocket-client
 strict-rfc3339==0.7       # via flex
 swagger-spec-validator==2.4.1
 termcolor==1.1.0
@@ -139,6 +137,7 @@ uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.1           # via botocore, requests
 validate-email==1.3       # via flex
 vine==1.1.4               # via amqp
+webpage2html==0.3.6
 websocket-client==0.54.0  # via docker
 werkzeug==0.14.1          # via moto
 whitenoise==4.1.2

--- a/capstone/setup.cfg
+++ b/capstone/setup.cfg
@@ -27,4 +27,3 @@ omit =
     */tests/*
     manage.py
     */settings/*
-

--- a/capstone/setup.cfg
+++ b/capstone/setup.cfg
@@ -3,6 +3,7 @@
 DJANGO_SETTINGS_MODULE = config.settings
 redis_exec = redis-server
 norecursedirs = node_modules
+addopt = -W ignore::RemovedInPytest4Warning
 
 
 ## http://flake8.pycqa.org/en/latest/user/configuration.html

--- a/capstone/setup.cfg
+++ b/capstone/setup.cfg
@@ -3,7 +3,6 @@
 DJANGO_SETTINGS_MODULE = config.settings
 redis_exec = redis-server
 norecursedirs = node_modules
-addopt = -W ignore::RemovedInPytest4Warning
 
 
 ## http://flake8.pycqa.org/en/latest/user/configuration.html
@@ -28,3 +27,4 @@ omit =
     */tests/*
     manage.py
     */settings/*
+

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -260,7 +260,7 @@ def private_case_export():
 @pytest.fixture
 def redis_patch(request):
     import pytest_redis.factories
-    with pytest.warns(pytest.warning_types.RemovedInPytest4Warning):
+    with pytest.warns(pytest.RemovedInPytest4Warning):
         capdb.storages.redis_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_DEFAULT_DB)(request)
         capdb.storages.redis_ingest_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_INGEST_DB)(request)
     return capdb.storages.redis_client, capdb.storages.redis_ingest_client

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -222,24 +222,19 @@ def api_request_factory():
 
 @pytest.fixture()
 def admin_user(db, django_user_model, django_username_field):
-    """A Django admin user.
-    This uses an existing user with username "admin", or creates a new one with
-    password "password".
-    """
+    # Overwrite of pytest's Django admin_user fixture because
+    # we're using email as username_field
     UserModel = django_user_model
     username_field = django_username_field
 
     try:
-        user = UserModel._default_manager.get(**{username_field: "admin"})
+        user = UserModel._default_manager.get(**{username_field: "admin@example.com"})
     except UserModel.DoesNotExist:
         extra_fields = {}
-        if username_field != "username":
-            extra_fields[username_field] = "admin"
         user = UserModel._default_manager.create_superuser(
-            "admin", "admin@example.com", "password", **extra_fields
+            "admin", "test_admin_user@example.com", "password", **extra_fields
         )
     return user
-
 
 @pytest.fixture()
 def staff_user(cap_user):

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -260,9 +260,8 @@ def private_case_export():
 @pytest.fixture
 def redis_patch(request):
     import pytest_redis.factories
-    with pytest.warns(pytest.RemovedInPytest4Warning):
-        capdb.storages.redis_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_DEFAULT_DB)(request)
-        capdb.storages.redis_ingest_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_INGEST_DB)(request)
+    capdb.storages.redis_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_DEFAULT_DB)(request)
+    capdb.storages.redis_ingest_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_INGEST_DB)(request)
     return capdb.storages.redis_client, capdb.storages.redis_ingest_client
 
 

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -219,22 +219,6 @@ def contract_approver_auth_client():
 def api_request_factory():
     return APIRequestFactory()
 
-
-@pytest.fixture()
-def admin_user(db, django_user_model, django_username_field):
-    # Overwrite of pytest's Django admin_user fixture because
-    # we're using email as username_field
-    UserModel = django_user_model
-    username_field = django_username_field
-
-    try:
-        user = UserModel._default_manager.get(**{username_field: 'admin@example.com'})
-    except UserModel.DoesNotExist:
-        extra_fields = {}
-        user = UserModel._default_manager.create_superuser(
-            'test_admin_user@example.com', 'password', **extra_fields)
-    return user
-
 @pytest.fixture()
 def staff_user(cap_user):
     cap_user.is_staff = True

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -219,6 +219,28 @@ def contract_approver_auth_client():
 def api_request_factory():
     return APIRequestFactory()
 
+
+@pytest.fixture()
+def admin_user(db, django_user_model, django_username_field):
+    """A Django admin user.
+    This uses an existing user with username "admin", or creates a new one with
+    password "password".
+    """
+    UserModel = django_user_model
+    username_field = django_username_field
+
+    try:
+        user = UserModel._default_manager.get(**{username_field: "admin"})
+    except UserModel.DoesNotExist:
+        extra_fields = {}
+        if username_field != "username":
+            extra_fields[username_field] = "admin"
+        user = UserModel._default_manager.create_superuser(
+            "admin", "admin@example.com", "password", **extra_fields
+        )
+    return user
+
+
 @pytest.fixture()
 def staff_user(cap_user):
     cap_user.is_staff = True

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -260,8 +260,9 @@ def private_case_export():
 @pytest.fixture
 def redis_patch(request):
     import pytest_redis.factories
-    capdb.storages.redis_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_DEFAULT_DB)(request)
-    capdb.storages.redis_ingest_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_INGEST_DB)(request)
+    with pytest.warns(pytest.RemovedInPytest4Warning):
+        capdb.storages.redis_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_DEFAULT_DB)(request)
+        capdb.storages.redis_ingest_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_INGEST_DB)(request)
     return capdb.storages.redis_client, capdb.storages.redis_ingest_client
 
 

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -260,9 +260,9 @@ def private_case_export():
 @pytest.fixture
 def redis_patch(request):
     import pytest_redis.factories
-
-    capdb.storages.redis_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_DEFAULT_DB)(request)
-    capdb.storages.redis_ingest_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_INGEST_DB)(request)
+    with pytest.warns(pytest.warning_types.RemovedInPytest4Warning):
+        capdb.storages.redis_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_DEFAULT_DB)(request)
+        capdb.storages.redis_ingest_client = pytest_redis.factories.redisdb('redis_proc', db=settings.REDIS_INGEST_DB)(request)
     return capdb.storages.redis_client, capdb.storages.redis_ingest_client
 
 


### PR DESCRIPTION
pip-compile --output-file requirements.txt requirements.in

Other changes:
* [Fix to support change in CapS3Storage](https://github.com/jschneier/django-storages/commit/138030190a229ce998ba8c08c1a747de43b7e21c)
* [Fix to support deprecation of calling pytest fixture functions directly](https://github.com/pytest-dev/pytest/commit/011f88f7e77b8b2e6de01d2c5588dda47c77093b)
* [Fix to support deprecation of string_concat](https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.translation.string_concat)
* [Fix to support deprecation of getfuncargvalue](https://docs.pytest.org/en/latest/reference.html#_pytest.fixtures.FixtureRequest.getfixturevalue)
* [Fix to support improved admin_user fixture](https://github.com/pytest-dev/pytest-django/pull/676)