### PR TITLE
Addition - Public Bulk Data - Dataverse + Kaggle

### DIFF
--- a/capstone/capapi/templates/bulk.html
+++ b/capstone/capapi/templates/bulk.html
@@ -20,6 +20,7 @@
       <p>Click a link to download.</p>
       {% include "includes/download_list.html" with zips=exports.public %}
     </div>
+<p>Explore our Illinois Public Bulk Data on <a href="https://dataverse.harvard.edu/dataverse/caselawaccess">Harvard Dataverse</a> and <a href="https://www.kaggle.com/harvardlil/caselaw-dataset-illinois">Kaggle</a>.<p>
   {% endif %}
   <div class="page-section">
     <h2 class="subtitle">


### PR DESCRIPTION
Addition to highlight bulk data availability on Harvard Dataverse and Kaggle.