### PR TITLE
Set CORS policy in middleware

### DIFF
--- a/capstone/capapi/middleware.py
+++ b/capstone/capapi/middleware.py
@@ -92,3 +92,16 @@ class AuthenticationMiddleware(DjangoAuthenticationMiddleware):
         request.user = TrackingWrapper(request.user)
         request.user.ip_address = request.META.get('HTTP_X_FORWARDED_FOR')  # used by user IP auth checks
 
+
+### access control header middleware ###
+
+def access_control_middleware(get_response):
+    """
+        Set `Access-Control-Allow-Origin: *` for API responses.
+    """
+    def middleware(request):
+        response = get_response(request)
+        if request.host.name == 'api':
+            response["Access-Control-Allow-Origin"] = "*"
+        return response
+    return middleware

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -86,6 +86,7 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'capapi.middleware.AuthenticationMiddleware',
+    'capapi.middleware.access_control_middleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -6,9 +6,6 @@ SECRET_KEY = 'k2#@_q=1$(__n7#(zax6#46fu)x=3&^lz&bwb8ol-_097k_rj5'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-# add CORS headers to make the case browser work
-CORS_ORIGIN_ALLOW_ALL = True
-
 # don't require celery listener
 CELERY_TASK_ALWAYS_EAGER = True
 # propagate exceptions
@@ -64,9 +61,5 @@ try:
     INTERNAL_IPS = ['127.0.0.1']
 except ImportError:
     pass
-
-INSTALLED_APPS += ( 'corsheaders', )
-MIDDLEWARE += ('corsheaders.middleware.CorsMiddleware',)
-
 
 NGRAMS_FEATURE = True

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -36,7 +36,6 @@ django-simple-history   # model versioning
 django-partial-index    # create partial postgres indexes
 django-redis        # use redis as Django cache backend
 django-hosts        # URL routing across subdomains
-django_cors_headers # enables CORS for testing locally 
 django-webpack-loader   # include assets from webpack
 
 # Admin stuff

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -38,7 +38,6 @@ django-appconf==1.0.2     # via django-compressor
 django-bootstrap4==0.0.6
 django-bulk-update==2.1.0
 django-compressor==2.1.1  # via django-libsass
-django-cors-headers==2.4.0
 django-extensions==2.0.6
 django-filter==2.0.0
 django-hosts==3.0


### PR DESCRIPTION
This sets `Access-Control-Allow-Origin: *` on all requests to the API subdomain, which is safe because CORS requests with `*` response can't be credentialed.

* Drops requirement for `django_cors_headers`, which doesn't handle the domain-specific behavior.
* Drops requirement for nginx config on stage and prod.