### PR TITLE
Update Django to 2.0.10; drf-yasg to 1.13.0; pyyaml to 4.2b4. Drop flex.

### DIFF
--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -24,7 +24,7 @@ mysqlclient         # mysql connector
 redis               # redis connector
 
 # Django stuff
-django==2.0.8          # Fix issues related to 2.1.x branch (https://github.com/harvard-lil/capstone/issues/745)
+django<2.1             # Fix issues related to 2.1.x branch (https://github.com/harvard-lil/capstone/issues/745)
 django-storages==1.6.6 # Fix issues related to 1.7.x branch (https://github.com/harvard-lil/capstone/issues/745)
 boto3==1.7.84          # Fix issues related to 1.9.x branch (https://github.com/harvard-lil/capstone/issues/745)
 whitenoise             # serve static assets
@@ -63,8 +63,8 @@ djangorestframework-filters==1.0.0.dev0 # Remove pinned version on next release 
 djangorestframework
 django-bootstrap4   # render bootstrap forms in django templates
 drf-yasg            # expose API specification
-flex                    # both used for spec validation
-swagger_spec_validator  # by drf-yasg
+swagger_spec_validator  # optional package for schema validation by drf-yasg
+pyyaml==4.2b4       # only an indirect dependency; included here to pin beta version until 4.x released, as 3.x shows security warning on github
 -e git://github.com/jcushman/email-normalize.git@6b5088bd05de247a9a33ad4e5c7911b676d6daf2#egg=email-normalize # Fix issues related to https://github.com/gmr/email-normalize/pull/3 (https://github.com/harvard-lil/capstone/issues/745)
 
 # pdf generation

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -25,7 +25,7 @@ celery[redis,sqs]==4.2.1
 certifi==2018.11.29       # via requests
 cffi==1.11.5              # via bcrypt, cryptography, pynacl
 chardet==3.0.4            # via requests
-click==6.7                # via flex, pip-tools
+click==6.7                # via pip-tools
 cookies==2.2.1            # via moto
 coreapi==2.3.3            # via drf-yasg
 coreschema==0.0.4         # via coreapi, drf-yasg
@@ -45,21 +45,20 @@ django-redis==4.10.0
 django-simple-history==2.7.0
 django-storages==1.6.6
 django-webpack-loader==0.6.0
-django==2.0.8
+django==2.0.10
 djangorestframework-filters==1.0.0.dev0
 djangorestframework==3.9.1
 dnspython==1.16.0
 docker-pycreds==0.4.0     # via docker
 docker==3.7.0             # via moto
 docutils==0.14            # via botocore
-drf-yasg==1.12.1
+drf-yasg==1.13.0
 ecdsa==0.13               # via python-jose
 execnet==1.5.0            # via pytest-xdist
 fabric3==1.14.post1
 factory-boy==2.11.1
 faker==1.0.2              # via factory-boy
 flake8==3.4.1
-flex==6.13.2
 flower==0.9.2
 future==0.17.1            # via python-jose
 idna==2.8                 # via requests
@@ -70,7 +69,6 @@ jinja2==2.10              # via coreschema, moto
 jmespath==0.9.3           # via boto3, botocore
 jsondiff==1.1.1           # via moto
 jsonpickle==1.1           # via aws-xray-sdk
-jsonpointer==1.14         # via flex
 jsonschema==2.6.0         # via swagger-spec-validator
 kombu==4.2.2.post1        # via celery
 libsass==0.17.0           # via django-libsass, libsasscompiler
@@ -115,27 +113,24 @@ pytest==3.7.0
 python-dateutil==2.7.5    # via botocore, faker, moto
 python-jose==2.0.2        # via moto
 pytz==2018.9              # via babel, celery, django, flower, moto
-pyyaml==3.13              # via flex, pyaml, swagger-spec-validator
+pyyaml==4.2b4
 rcssmin==1.0.6            # via django-compressor
 redis==3.0.1
 reportlab==3.5.13
-requests==2.21.0          # via aws-xray-sdk, coreapi, docker, flex, moto, responses
+requests==2.21.0          # via aws-xray-sdk, coreapi, docker, moto, responses
 responses==0.10.5         # via moto
-rfc3987==1.3.8            # via flex
 rjsmin==1.0.12            # via django-compressor
 ruamel.yaml==0.15.87      # via drf-yasg
 s3transfer==0.1.13        # via boto3
 singledispatch==3.4.0.3   # via nltk
-six==1.12.0               # via bcrypt, cryptography, django-extensions, docker, docker-pycreds, drf-yasg, fabric3, faker, flex, libsass, mock, more-itertools, moto, nltk, pathlib2, pip-tools, pynacl, pytest, pytest-xdist, python-dateutil, python-jose, responses, singledispatch, swagger-spec-validator, websocket-client
+six==1.12.0               # via bcrypt, cryptography, django-extensions, docker, docker-pycreds, drf-yasg, fabric3, faker, libsass, mock, more-itertools, moto, nltk, pathlib2, pip-tools, pynacl, pytest, pytest-xdist, python-dateutil, python-jose, responses, singledispatch, swagger-spec-validator, websocket-client
 soupsieve==1.7.3          # via beautifulsoup4
-strict-rfc3339==0.7       # via flex
 swagger-spec-validator==2.4.3
 text-unidecode==1.2       # via faker
 tornado==5.1.1            # via flower
 tqdm==4.29.1
 uritemplate==3.0.0        # via coreapi, drf-yasg
 urllib3==1.24.1           # via requests
-validate-email==1.3       # via flex
 vine==1.2.0               # via amqp
 webpage2html==0.3.6
 websocket-client==0.54.0  # via docker


### PR DESCRIPTION
* Bump Django to latest minor version (2.0.10)
* Bump drf-yasg to 1.13.0, which drops unsupported optional package `flex`
* Drop `flex` from our requirements.in
* Bump pyyaml to beta version (4.2b4) to avoid security warning