### PR TITLE
Harvard ip fix

### DIFF
--- a/capstone/capapi/__init__.py
+++ b/capstone/capapi/__init__.py
@@ -1,32 +1,8 @@
 import django.shortcuts
-
-import rest_framework.request
 import rest_framework.reverse
 
-from capapi.resources import TrackingWrapper, api_reverse
+from capapi.resources import api_reverse
 from capweb.helpers import reverse
-
-# Monkeypatch rest_framework.request.Request to track accesses to request.user attributes.
-# See capapi/middleware for rationale.
-# This has to happen in __init__ because we have to monkeypatch DRF's Request object before it is imported by
-# other modules.
-
-OriginalRequest = rest_framework.request.Request
-
-class CustomRequest(OriginalRequest):
-
-    @OriginalRequest.user.setter
-    def user(self, value):
-        """
-            Override DRF's Request.user setter to wrap the value in TrackingWrapper() so we can check later how it's
-            accessed. "OriginalRequest.user.fset(self, value)" is equivalent to "super().user = value", except that
-            super() doesn't work for overriding properties as opposed to methods.
-        """
-        OriginalRequest.user.fset(self, TrackingWrapper(value))
-
-# make sure we only patch once if this module is re-imported
-if OriginalRequest.__name__ != "CustomRequest":
-    rest_framework.request.Request = CustomRequest
 
 # Monkeypatch rest_framework.reverse._reverse to use our api_reverse function
 rest_framework.reverse._reverse = api_reverse

--- a/capstone/capapi/authentication.py
+++ b/capstone/capapi/authentication.py
@@ -1,0 +1,24 @@
+import rest_framework.authentication
+
+from .resources import wrap_user
+
+
+class WrapUserMixin:
+    def authenticate(self, request):
+        """
+            Ensure that users fetched via DRF auth will have wrap_user() called on them.
+            This is also done in capapi.middleware.AuthenticationMiddleware for regular Django auth.
+        """
+        user_and_token = super().authenticate(request)
+        if not user_and_token:
+            return None
+        user, token = user_and_token
+        user = wrap_user(request, user)
+        return user, token
+
+
+# apply WrapUserMixin to each authentication backend
+class TokenAuthentication(WrapUserMixin, rest_framework.authentication.TokenAuthentication):
+    pass
+class SessionAuthentication(WrapUserMixin, rest_framework.authentication.SessionAuthentication):
+    pass

--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -103,7 +103,7 @@ class CapUser(PermissionsMixin, AbstractBaseUser):
         """ Return True if X-Forwarded-For header is a Harvard IP address. """
         if not hasattr(self, '_is_harvard_ip'):
             try:
-                ip = IPAddress(getattr(self, 'ip_address'))  # set by AuthenticationMiddleware
+                ip = IPAddress(self.ip_address)  # set by AuthenticationMiddleware
             except AddrFormatError:
                 self._is_harvard_ip = False
             else:

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -124,10 +124,10 @@ class CaseAllowanceMixin:
 
             # update the info for the existing user model, in case it's changed since the request began
             if not request.user.unlimited_access_in_effect():
-                user.update_case_allowance(save=False)  # for SiteLimits, make sure we start with up-to-date user.case_allowance_remaining
-                allowance_before = user.case_allowance_remaining
                 request.user.case_allowance_remaining = user.case_allowance_remaining
                 request.user.case_allowance_last_updated = user.case_allowance_last_updated
+                request.user.update_case_allowance(save=False)  # for SiteLimits, make sure we start with up-to-date case_allowance_remaining
+                allowance_before = request.user.case_allowance_remaining
 
             result = super().data
 

--- a/capstone/capapi/tests/test_cache.py
+++ b/capstone/capapi/tests/test_cache.py
@@ -9,42 +9,41 @@ from capweb.helpers import reverse
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("view_name, cache_if_logged_out, cache_if_logged_in, get_kwargs", [
-    # docs pages are cached for both logged in and logged out
-    ("home",                True,   True,  {}),
+@pytest.mark.parametrize("view_name, cache_clients, get_kwargs", [
+    # docs pages are cached for both logged in and logged out, but not for token auth
+    ("home",                ["client", "auth_client"],                        {}),
 
     # pages with csrf tokens are not cached for logged out or logged in
-    ("login",               False,  False,  {}),
-    ("register",            False,  False,  {}),
+    ("login",               [],                                               {}),
+    ("register",            [],                                               {}),
 
     # login-only pages are not cached for either (because we don't cache redirects for logged-out user)
-    ("user-details",        False,   False,   {}),
+    ("user-details",        [],                                               {}),
 
     # api views are cached for both logged in and logged out
-    ("casemetadata-list",   True,   True,   {"reverse_func": "api_reverse"}),
-    ("casemetadata-list",   True,   True,   {"HTTP_ACCEPT": "text/html", "reverse_func": "api_reverse"}),
+    ("casemetadata-list",   ["client", "auth_client", "token_auth_client"],   {"reverse_func": "api_reverse"}),
+    ("casemetadata-list",   ["client", "auth_client", "token_auth_client"],   {"HTTP_ACCEPT": "text/html", "reverse_func": "api_reverse"}),
 
     # api views that depend on the user account are cached only for logged out
-    ("casemetadata-list",   True,   False,  {"data": {"full_case": "true"}, "reverse_func": "api_reverse"}),
+    ("casemetadata-list",   ["client"],                                       {"data": {"full_case": "true"}, "reverse_func": "api_reverse"}),
 
     # bulk list cacheable only for logged-out users
-    ("bulk-download",           True,   False,  {}),
+    ("bulk-download",       ["client"],                                       {}),
 
     # bulk downloads are cached if public
-    ("caseexport-download", True, True,     {"reverse_args": ["fixture_case_export"], "reverse_func": "api_reverse"}),
+    ("caseexport-download", ["client", "auth_client", "token_auth_client"],   {"reverse_args": ["fixture_case_export"], "reverse_func": "api_reverse"}),
     # bulk downloads are not cached if private
-    ("caseexport-download", False, False,    {"reverse_args": ["fixture_private_case_export"], "reverse_func": "api_reverse"}),
+    ("caseexport-download", [],                                               {"reverse_args": ["fixture_private_case_export"], "reverse_func": "api_reverse"}),
 ])
-@pytest.mark.parametrize("client_fixture_name", ["client", "auth_client"])
+@pytest.mark.parametrize("client_fixture_name", ["client", "auth_client", "token_auth_client"])
 def test_cache_headers(case, request, settings,
                        client_fixture_name,
-                       view_name, cache_if_logged_out, cache_if_logged_in, get_kwargs):
+                       view_name, cache_clients, get_kwargs):
 
     # set up variables
     get_kwargs = deepcopy(get_kwargs)  # avoid modifying between tests
     settings.SET_CACHE_CONTROL_HEADER = True
     client = request.getfuncargvalue(client_fixture_name)
-    cache_expected = cache_if_logged_in if client._credentials else cache_if_logged_out
 
     # Resolve reverse_args. For example, if we see "fixture_case_export" we will fetch the "case_export" fixture
     # and insert its ID as an argument to reverse().
@@ -62,6 +61,7 @@ def test_cache_headers(case, request, settings,
     response = client.get(url, **get_kwargs)
     cache_actual = is_cached(response)
 
+    cache_expected = client_fixture_name in cache_clients
     assert cache_actual == cache_expected, "Checking %s with %s, expected %scached but found %scached." % (
         url,
         client_fixture_name,

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -55,8 +55,8 @@ REST_FRAMEWORK = {
         'rest_framework_filters.backends.RestFrameworkFilterBackend',
     ),
     'DEFAULT_AUTHENTICATION_CLASSES': (
-        'rest_framework.authentication.TokenAuthentication',
-        'rest_framework.authentication.SessionAuthentication',
+        'capapi.authentication.TokenAuthentication',
+        'capapi.authentication.SessionAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'capapi.permissions.IsSafeMethodsUser',

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -188,12 +188,18 @@ def client():
 
 @pytest.fixture
 def auth_client(auth_user):
-    """ Return client authenticated as auth_user. """
-    # API auth
+    """ Return client authenticated as auth_user, via Django session. """
+    client = CapClient()
+    client.force_login(user=auth_user)
+    # make user available to tests
+    client.auth_user = auth_user
+    return client
+
+@pytest.fixture
+def token_auth_client(auth_user):
+    """ Return client authenticated as auth_user, via token. """
     client = CapClient()
     client.credentials(HTTP_AUTHORIZATION='Token ' + auth_user.get_api_key())
-    # Django auth
-    client.force_login(user=auth_user)
     # make user available to tests
     client.auth_user = auth_user
     return client


### PR DESCRIPTION
This fixes the problem where we get 500 errors for Harvard-IP unlimited users who hit the API with token-based authentication.

* Refactor our user-object wrapping so it uses a consistent helper function, which is called both by `AuthenticationMiddleware` and the DRF authentication backends.
* Remove previous monkey-patch way of wrapping DRF user object.
* Make sure to use request.user instead of newly-fetched user in case endpoint.
* Expand tests:
  * Separate fixtures for token auth and Django auth
  * Use both auth methods in test_cache
  * Add test for Harvard IP access via both fixtures