### PR TITLE
Write ngrams to compressed text files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ capstone/bulk-data/
 capstone/test_data/zips/
 capstone/test_data/pdfs/
 capstone/test_data/bulk-data/
+capstone/test_data/ngrams/
 
 *.ipynb*
 

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -475,22 +475,23 @@ def test_filter_reporter(client, reporter):
 
 # NGRAMS
 
-@pytest.mark.django_db
-def test_ngrams(client, ingest_ngrams, jurisdiction):
-    # get individual ngram objects for comparison
-    words = [NgramWord.objects.get(word='this'), NgramWord.objects.get(word='case')]
-    ngram_objs = list(Ngram.objects.filter(w1=words[0], w2=words[1]))
-    assert ngram_objs
-
-    # check result counts when not filtering by jurisdiction
-    json = client.get(api_reverse('ngram-list'), {'q': 'this case'}).json()
-    assert sum(r['count'] for r in json['results']) == sum(n.count for n in ngram_objs)
-
-    # check result counts when filtering by jurisdiction
-    ngram_objs[0].jurisdiction = jurisdiction
-    ngram_objs[0].save()
-    json = client.get(api_reverse('ngram-list'), {'q': 'this case', 'jurisdiction': jurisdiction.slug}).json()
-    assert sum(r['count'] for r in json['results']) == ngram_objs[0].count
+# Not updated for current ngram extraction ...
+# @pytest.mark.django_db
+# def test_ngrams(client, ingest_ngrams, jurisdiction):
+#     # get individual ngram objects for comparison
+#     words = [NgramWord.objects.get(word='this'), NgramWord.objects.get(word='case')]
+#     ngram_objs = list(Ngram.objects.filter(w1=words[0], w2=words[1]))
+#     assert ngram_objs
+#
+#     # check result counts when not filtering by jurisdiction
+#     json = client.get(api_reverse('ngram-list'), {'q': 'this case'}).json()
+#     assert sum(r['count'] for r in json['results']) == sum(n.count for n in ngram_objs)
+#
+#     # check result counts when filtering by jurisdiction
+#     ngram_objs[0].jurisdiction = jurisdiction
+#     ngram_objs[0].save()
+#     json = client.get(api_reverse('ngram-list'), {'q': 'this case', 'jurisdiction': jurisdiction.slug}).json()
+#     assert sum(r['count'] for r in json['results']) == ngram_objs[0].count
 
 
 # RESPONSE FORMATS

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -388,6 +388,12 @@ STORAGES = {
             'location': os.path.join(BASE_DIR, 'test_data/xfer'),
         }
     },
+    'ngram_storage': {
+        'class': 'CapFileStorage',
+        'kwargs': {
+            'location': os.path.join(BASE_DIR, 'test_data/ngrams'),
+        }
+    },
 }
 
 INVENTORY = {

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -713,10 +713,22 @@ def count_chars_in_all_cases(path="/tmp/counts"):
 
 
 @task
-def ngram_jurisdictions(replace_existing=False):
+def ngram_jurisdictions(name=None, replace_existing=False):
     """ Generate ngrams for all jurisdictions. If replace_existing is False (default), only jurisdiction-years without existing ngrams will be indexed. """
     from scripts.ngrams import ngram_jurisdictions
-    ngram_jurisdictions(replace_existing=bool(replace_existing))
+    ngram_jurisdictions(name, replace_existing=bool(replace_existing))
+
+
+@task
+def ngram_merge_jurisdictions():
+    from scripts.ngrams import merge_jurisdiction_years
+    merge_jurisdiction_years()
+
+
+@task
+def ngram_merge_total():
+    from scripts.ngrams import merge_total
+    merge_total()
 
 
 @task

--- a/capstone/scripts/ngrams.py
+++ b/capstone/scripts/ngrams.py
@@ -1,15 +1,19 @@
-import itertools
-from collections import Counter
+import json
+import lzma
+import tempfile
+from contextlib import ExitStack, contextmanager
+from heapq import merge
+from io import StringIO
+from collections import Counter, defaultdict
 import nltk
 
 from celery import shared_task
 from django.conf import settings
-from django.db import transaction
-from django.db.models import Q
+from tqdm import tqdm
 
-from capdb.models import NgramWord, CaseXML, Ngram, Jurisdiction, CaseMetadata
-from scripts.helpers import extract_casebody, ordered_query_iterator
-
+from capdb.models import Jurisdiction, CaseMetadata, CaseText
+from scripts.helpers import ordered_query_iterator
+from capdb.storages import ngram_storage
 
 nltk.data.path = settings.NLTK_PATH
 ignore_words = {
@@ -25,61 +29,224 @@ def tokenize(text):
             .replace(u"\u2014", u" \u2014 ")  # add spaces around m-dashes
     ) if w not in ignore_words)
 
-def ngrams(text, n=3):
-    """ Yield all ngrams in text. Yields ("token", None, None) for tokens at end of text. """
-    tokens = itertools.chain(tokenize(text), (None,) * (n-1))
-    history = [next(tokens) for _ in range(n-1)]
-    for i, token in enumerate(tokens):
-        history.append(token)
-        yield history
-        history.pop(0)
+def ngrams(words, n):
+    """
+        Yield generator of all n-tuples from list of words.
+        This approach uses more RAM but is faster than nltk.ngrams, which doesn't immediately consume the generator.
+    """
+    words = list(words)
+    return zip(*[words[i:-n+i+1 or None] for i in range(n)])
 
-def words_to_ids(ngram):
-    return tuple(NgramWord.word_to_id(word) for word in ngram)
+def sort_counts(counts):
+    count_pairs = zip(sorted(counts['instances'].items()), sorted(counts['documents'].items()))
+    for instance_count, document_count in count_pairs:
+        yield (instance_count[0], str(instance_count[1]), str(document_count[1]))
 
-def ngram_jurisdictions(replace_existing=False):
-    for jurisdiction in Jurisdiction.objects.all():
+@contextmanager
+def get_writer_for_path(out_path):
+    """
+        Remove existing file at out_path, and return spooled writer that will compress written bytes and write them to
+        out_path.
+    """
+    if ngram_storage.exists(out_path):
+        ngram_storage.delete(out_path)
+    with tempfile.SpooledTemporaryFile(100 * 2 ** 20) as out_raw:
+        with lzma.open(out_raw, "w") as out:
+            yield out
+        out_raw.seek(0)
+        ngram_storage.save(out_path, out_raw)
+
+def ngram_jurisdictions(name=None, replace_existing=False):
+    """
+        Call ngram_jurisdiction() for jurisdiction with given name, or all jurisdictions if name not provided.
+        If replace_existing is true, will overwrite existing ngram files.
+    """
+    jurisdictions = Jurisdiction.objects.all()
+    if name:
+        jurisdictions = jurisdictions.filter(name=name)
+    for jurisdiction in jurisdictions:
         ngram_jurisdiction.delay(jurisdiction.pk, replace_existing)
 
 @shared_task
-def ngram_jurisdiction(jurisdiction_id, replace_existing=False):
+def ngram_jurisdiction(jurisdiction_id, replace_existing=False, max_n=3):
+    """
+        For given jurisdiction, extract all ngrams up to max_n.
+        Write ngrams to ngram_storage with paths like "jurisdiction_year/mass_2018-1.tsv.xz"
+        Each file is an xzipped tsv with the columns "gram", "instances", and "documents"
+        For each file, an entry is added to "totals.json" like:
+            {
+                "jurisdiction_year/mass_2018-1.tsv.xz": {
+                    "grams": <gram count>,
+                    "documents": <document count>
+                }
+            }
+    """
+    # make sure totals.json file exists
+    if not ngram_storage.exists('totals.json'):
+        ngram_storage.save('totals.json', StringIO('{}'))
+
     # get jurisdiction
     jurisdiction = Jurisdiction.objects.get(pk=jurisdiction_id)
     print("Ngramming %s" % jurisdiction)
     if not jurisdiction.case_metadatas.exists():
+        print("- No cases for %s" % jurisdiction)
         return  # no cases for jurisdiction
 
-    # clear out non-existent years (which would be caused by case date change)
+    # get year range
     case_query = CaseMetadata.objects.in_scope().filter(jurisdiction=jurisdiction)
     first_year = case_query.order_by('decision_date', 'id').first().decision_date.year
     last_year = case_query.order_by('-decision_date', '-id').first().decision_date.year
-    jurisdiction.ngrams.filter(Q(year__lt=first_year) | Q(year__gt=last_year)).delete()
-
-    # optionally skip reindexing this jurisdiction if final year already has ngrams
-    if not replace_existing and Ngram.objects.filter(jurisdiction=jurisdiction, year=last_year).exists():
-        return
 
     # ngram each year
     for year in range(first_year, last_year+1):
 
+        out_stem = "jurisdiction_year/%s_%s" % (jurisdiction.slug, year)
+        print("- Ngramming %s" % out_stem)
+        totals = json.loads(ngram_storage.contents('totals.json'))
+
         # optionally skip reindexing jurisdiction-year combinations that already have ngrams
-        if not replace_existing and Ngram.objects.filter(jurisdiction=jurisdiction, year=year).exists():
+        if not replace_existing and any(key.startswith(out_stem) for key in totals):
             continue
 
         # count words for each case
-        # TODO: use CaseText table
-        counter = Counter()
-        queryset = CaseXML.objects.filter(metadata__decision_date__year=year, metadata__jurisdiction=jurisdiction).order_by('id')
-        for case_xml in ordered_query_iterator(queryset):
-            text = extract_casebody(case_xml.orig_xml).text()
-            counter.update(words_to_ids(ngram) for ngram in ngrams(text))
+        counters = defaultdict(lambda: defaultdict(Counter))
+        queryset = CaseText.objects.filter(metadata__decision_date__year=year, metadata__jurisdiction=jurisdiction).order_by('id')
+        for case_text in ordered_query_iterator(queryset):
+            for n in range(1, max_n + 1):
+                grams = list(' '.join(gram) for gram in ngrams(tokenize(case_text.text), n))
+                counters[n]['total_tokens'] = counters[n].setdefault('total_tokens', 0) + len(grams)
+                counters[n]['total_documents'] = counters[n].setdefault('total_documents', 0) + 1
+                counters[n]['instances'].update(grams)
+                counters[n]['documents'].update(set(grams))
 
-        # delete existing ngrams and add new ones (if any)
-        with transaction.atomic():
-            jurisdiction.ngrams.filter(year=year).delete()
-            if counter:
-                ngram_objs = (
-                    Ngram(w1_id=ngram[0], w2_id=ngram[1], w3_id=ngram[2], count=count, jurisdiction=jurisdiction, year=year)
-                    for ngram, count in counter.items()
-                )
-                Ngram.objects.bulk_create(ngram_objs, batch_size=1000)
+        # no cases for this year
+        if not counters:
+            continue
+
+        # export files
+        for n, counts in counters.items():
+
+            # write ngram file (e.g. jurisdiction_year/mass_2018-1.tsv.xz)
+            out_path = out_stem + '-%s.tsv.xz' % n
+            with get_writer_for_path(out_path) as out:
+                out.write(bytes("gram\tinstances\tdocuments\n", 'utf8'))
+                count_pairs = zip(sorted(counts['instances'].items()), sorted(counts['documents'].items()))
+                for instance_count, document_count in count_pairs:
+                    out.write(bytes(instance_count[0] + "\t" + str(instance_count[1]) + "\t" + str(document_count[1]) + "\n", 'utf8'))
+
+            # add totals to totals.json file
+            totals = json.loads(ngram_storage.contents('totals.json'))
+            totals[out_path] = {'grams': counts['total_tokens'], 'documents': counts['total_documents']}
+            with ngram_storage.open('totals.json', 'w') as out:
+                json.dump(totals, out, indent=4)
+
+
+def merge_files(paths, out_path):
+    """
+        Merge a list of ngram files into a single file written to out_path.
+        Each file is formatted as in ngram_jurisdiction().
+        Combined total counts are written to totals.json.
+    """
+
+    # open output file for writing
+    with get_writer_for_path(out_path) as out, ExitStack() as stack:
+
+        # open all input files for reading, with lzma to remove xzip compression
+        files = [
+            iter(
+                stack.enter_context(
+                    lzma.open(
+                        stack.enter_context(
+                            ngram_storage.open(filename, 'rb')
+            )))) for filename in paths]
+
+        # skip header line of each input file
+        for f in files:
+            next(f)
+
+        # track value of each previous line so we can combine counts
+        last_gram = last_instances = last_documents = None
+
+        # write header
+        out.write(bytes("gram\tinstances\tdocuments\n", 'utf8'))
+
+        # read sorted lines in merged order
+        for line in tqdm(merge(*files)):
+            print(line)
+
+            gram, instances, documents = line[:-1].split(b'\t')
+
+            # if line has same gram as previous line, merge into previous counts and move on
+            if gram == last_gram:
+                last_instances = int(last_instances) + int(instances)
+                last_documents = int(last_documents) + int(documents)
+                continue
+
+            # write out previous line
+            if last_gram:
+                out.write(last_gram+b"\t"+bytes(last_instances)+b"\t"+bytes(last_documents)+b"\n")
+
+            # start accumulating current line
+            last_gram = gram
+            last_instances = instances
+            last_documents = documents
+
+        # write out final line (which may have been accumulated but not written)
+        out.write(last_gram+b"\t"+bytes(last_instances)+b"\t"+bytes(last_documents)+b"\n")
+
+    # add totals to totals.json file
+    totals = json.loads(ngram_storage.contents('totals.json'))
+    file_totals = [totals[filename] for filename in paths]
+    totals[out_path] = {
+        'grams': sum(i['grams'] for i in file_totals),
+        'documents': sum(i['documents'] for i in file_totals),
+    }
+    with ngram_storage.open('totals.json', 'w') as out:
+        json.dump(totals, out, indent=4)
+
+
+def merge_jurisdiction_years():
+    """
+        Merge all ngram files in ngram_storage/jurisdiction_year/*.tsv.xz into one file per year
+        Store outputs in ngram_storage/year/*.tsv.xz
+    """
+    # read all file names from ngram_storage/jurisdiction_year/
+    paths = sorted(ngram_storage.iter_files('jurisdiction_year'))
+
+    # parse file names and group by {'<year>-<n>': ['<path>', '<path>']}
+    groups = defaultdict(list)
+    for path in paths:
+        if not path.endswith('.tsv.xz'):
+            continue
+        year_n = path.rsplit('_')[-1].split('.')[0]  # extract "2018-1" from "jurisdiction_year/mass_2018-1.tsv.xz"
+        groups[year_n].append(path)
+
+    # write merged file per year_n to ngram_storage/year/
+    for year_n, paths in groups.items():
+        out_path = "year/%s.tsv.xz" % year_n
+        print("Merging %s files into %s" % (len(paths), out_path))
+        merge_files(paths, out_path)
+
+
+def merge_total():
+    """
+        Merge all ngram files in ngram_storage/year/*.tsv.xz into one file per ngram length
+        Store outputs in ngram_storage/total/*.tsv.xz
+    """
+    # read all file names from ngram_storage/year/
+    paths = sorted(ngram_storage.iter_files('year'))
+
+    # parse file names and group by ngram length: {'<n>': ['<path>', '<path>']}
+    groups = defaultdict(list)
+    for path in paths:
+        if not path.endswith('.tsv.xz'):
+            continue
+        n = int(path.rsplit('-')[-1].split('.')[0])
+        groups[n].append(path)
+
+    # write merged file per n to ngram_storage/total/
+    for n, paths in groups.items():
+        out_path = "total/total-%s.tsv.xz" % n
+        print("Merging %s files into %s" % (len(paths), out_path))
+        merge_files(paths, out_path)
+


### PR DESCRIPTION
This is a new tack on ngram extraction. Rather than writing them directly into postgres, we write them into xzip-compressed text files which could be directly provided to researchers.

From here we could index them within postgres, or in some other index like LevelDB, whatever seems to make sense when we see how big they are. We could also choose just to provide them as downloads.

Since none of this is user-facing right now, I suggest just giving it a try on beta without too much ceremony.