### PR TITLE
showing black+whitelisted cases in a similar way

### DIFF
--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -8,6 +8,8 @@ from rest_framework import renderers
 
 from capweb.helpers import cache_func
 from scripts.generate_case_html import generate_html
+from scripts.process_metadata import parse_decision_date
+
 
 
 class XMLRenderer(renderers.BaseRenderer):
@@ -56,7 +58,7 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
             'metadata': {
                 "name": data["name"],
                 "name_abbreviation": data["name_abbreviation"],
-                "decision_date": data["decision_date"],
+                "decision_date": parse_decision_date(data["decision_date"]),
                 "docket_number": data["docket_number"],
                 "first_page": data["first_page"],
                 "last_page": data["last_page"],

--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -39,14 +39,9 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
     def render(self, data, media_type=None, renderer_context=None):
         if 'detail' in data:
             if data['detail'] == "Not found.":
-                return generate_html_error("Case Not Found.",
-                                           "The case specified by the URL does not exist in our database.")
+                template = loader.get_template('case_404.html')
+                return template.render({}, renderer_context['request'])
             return generate_html_error("Authentication Error", data['detail'])
-
-        # if user requested format=html without requesting full casebody
-        if 'casebody' not in data:
-            return generate_html_error("Full Case Parameter Missing in Non-JSON Request",
-                                       "To retrieve the full case body, you must specify <span style='font-family: monospace; font-style: normal;'>full_case=true</span> in the URL. If you only want metadata you must specify <span style='font-family: monospace; font-style: normal;'>format=json</span> in the URL. We only serve standalone metadata in JSON format.")
 
         official_cit_entries = [citation['cite'] for citation in data['citations'] if citation['type'] == 'official']
         official_citation = official_cit_entries[0] if len(official_cit_entries[0]) > 0 else None
@@ -69,6 +64,11 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
                 "jurisdiction": data["jurisdiction"]},
             'citation_full': data["name_abbreviation"] + ", " + official_citation + " (" + data["decision_date"][                                                                                   0:4] + ")"
         }
+
+        # if user requested format=html without requesting full casebody
+        if 'casebody' not in data:
+            context['reason'] = "full_case_param_missing"
+            return template.render(context, renderer_context['request'])
 
         if data['casebody']['status'] != 'ok':
             if data['casebody']['status'] == 'error_auth_required':

--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -37,29 +37,47 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
     def render(self, data, media_type=None, renderer_context=None):
         if 'detail' in data:
             if data['detail'] == "Not found.":
-                return generate_html_error("Case Not Found.", "The case specified by the URL does not exist in our database.")
+                return generate_html_error("Case Not Found.",
+                                           "The case specified by the URL does not exist in our database.")
             return generate_html_error("Authentication Error", data['detail'])
 
         # if user requested format=html without requesting full casebody
         if 'casebody' not in data:
-            return generate_html_error("Full Case Parameter Missing in Non-JSON Request", "To retrieve the full case body, you must specify <span style='font-family: monospace; font-style: normal;'>full_case=true</span> in the URL. If you only want metadata you must specify <span style='font-family: monospace; font-style: normal;'>format=json</span> in the URL. We only serve standalone metadata in JSON format.")
+            return generate_html_error("Full Case Parameter Missing in Non-JSON Request",
+                                       "To retrieve the full case body, you must specify <span style='font-family: monospace; font-style: normal;'>full_case=true</span> in the URL. If you only want metadata you must specify <span style='font-family: monospace; font-style: normal;'>format=json</span> in the URL. We only serve standalone metadata in JSON format.")
 
-        if data['casebody']['status'] != 'ok':
-            if data['casebody']['status'] == 'error_auth_required':
-                return generate_html_error("Not Authenticated <span style='font-family: monospace; font-style: normal;'>({})</span>".format(data['casebody']['status']), "You must be authenticated to view this case.")
-            return generate_html_error("Could Not Load Case Body", data['casebody']['status'], data['first_page'], data['last_page'], data['name'])
-
-        official_cit_entries = [ citation['cite'] for citation in data['citations'] if citation['type'] == 'official' ]
+        official_cit_entries = [citation['cite'] for citation in data['citations'] if citation['type'] == 'official']
         official_citation = official_cit_entries[0] if len(official_cit_entries[0]) > 0 else None
-
         template = loader.get_template('case.html')
         context = {
             'citation': official_citation,
-            'title': data['casebody']['title'],
-            'case_html': generate_html(data['casebody']['data']),
             'page_description': data['name'],
             'page_title': data['name_abbreviation'],
+            'metadata': {
+                "name": data["name"],
+                "name_abbreviation": data["name_abbreviation"],
+                "decision_date": data["decision_date"],
+                "docket_number": data["docket_number"],
+                "first_page": data["first_page"],
+                "last_page": data["last_page"],
+                "citations": data["citations"],
+                "volume": data["volume"],
+                "reporter": data["reporter"],
+                "court": data["court"],
+                "jurisdiction": data["jurisdiction"]},
+            'citation_full': data["name_abbreviation"] + ", " + official_citation + " (" + data["decision_date"][                                                                                   0:4] + ")"
         }
+
+        if data['casebody']['status'] != 'ok':
+            if data['casebody']['status'] == 'error_auth_required':
+                context['reason'] = data['casebody']['status']
+                return template.render(context, renderer_context['request'])
+            context['reason'] = 'other'
+            return template.render(context, renderer_context['request'])
+
+        context['case_html'] = generate_html(data['casebody']['data'])
+        context['title'] = data['casebody']['title']
+
         return template.render(context, renderer_context['request'])
 
 

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -4,8 +4,7 @@
 {% block extra_head %}
   {% stylesheet 'case' %}
 {% endblock %}
-
-{% block title %}{{ title }}{% endblock %}
+{% block title %}{{ citation_full }}{% endblock %}
 
 {% block content %}
   <div class="case-container header-margin">

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -9,17 +9,57 @@
 
 {% block content %}
   <div class="case-container header-margin">
-    <div id="citation_container" class="text-center">
-      <input title="official citation" readonly="readonly" class="center" type="input" id="citation_for_copy" name="citation" value="{{ citation }}">
-        <button data-toggle="tooltip" title="Copy Citation to Clipboard" id="citation_copy" onclick="copyCitation()">
-          <img src="{% static "img/copy_icon.png" %}" alt="Copy Citation to Clipboard">
-        </button>
-    </div>
-    <div class="case-title-container">
-      <h6 class="case-title">{{ title }}</h6>
-    </div>
-    {{ case_html|safe }}
+    <div class="metadata">
+      <div class="reporter-and-volume-container">
+        <p class="reporter-and-volume">
+          <a href="{{ metadata.reporter.url }}">
+            {{ metadata.reporter.full_name }}</a>,
+          No.<a href="{{ metadata.volume.url }}">
+          {{ metadata.volume.volume_number }}.</a>
+          <span class="pages">p.{{ metadata.first_page }}&ndash;{{ metadata.last_page }}.</span>
+        </p>
+      </div>
+
+      <div class="text-center">
+        <p class="">
+          <a href="{{ metadata.court.url }}">{{ metadata.court.name }}</a>
+          {% if metadata.docket_number %}
+            {{ metadata.docket_number }}{% endif %}
+        </p>
+        <p>
+          {{ metadata.decision_date }}
+        </p>
+      </div>
+      <div id="citation_container" class="text-center">
+        <p title="official citation" class="center" id="citation_for_copy"
+           name="citation">{{ citation_full }}
+          <!--<button data-toggle="tooltip" title="Copy Citation to Clipboard" id="citation_copy"
+              onclick="CopyToClipboard('citation_for_copy')">
+        <img src="{% static "img/copy_icon.png" %}" alt="Copy Citation to Clipboard">
+      </button>-->
+        </p>
   </div>
+
+      </div>
+      {% if reason == 'error_auth_required' %}
+        <section class="name">
+          <h4 class="text-center">{{ metadata.name }}</h4>
+          <br/>
+          <div class="alert-warning text-center">
+            <h6 class="case-viewing-error">
+              You must be signed in to see the full
+              case.</h6>
+          </div>
+        </section>
+      {% elif reason == 'other' %}
+        <div class="alert-warning text-center">
+          <h6 class="case-viewing-error">
+            Could not load case body</h6>
+        </div>
+        </div>
+      {% else %}
+        {{ case_html|safe }}
+      {% endif %}
 
   <script>
     /*

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -57,6 +57,23 @@
             case.</h6>
         </div>
       </section>
+    {% elif reason == 'full_case_param_missing' %}
+      <section class="name text-center">
+        <h4>{{ metadata.name }}</h4>
+        <br/>
+        <div class="alert-warning text-center">
+          <h6 class="case-viewing-error">
+            Full case parameter is missing in HTML request.</h6>
+        </div>
+        <p>
+          To retrieve the full case body, you must specify <span style='font-family: monospace; font-style: normal;'>full_case=true</span>
+          in the URL.
+        </p>
+        <p>If you only want metadata you must specify
+          <span style='font-family: monospace; font-style: normal;'>format=json</span>
+          in the URL.</p>
+        <p>We only serve standalone metadata in JSON format.")</p>
+      </section>
     {% elif reason == 'other' %}
       <div class="alert-warning text-center">
         <h6 class="case-viewing-error">

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -10,26 +10,6 @@
 {% block content %}
   <div class="case-container header-margin">
     <div class="metadata">
-      <div class="reporter-and-volume-container">
-        <p class="reporter-and-volume">
-          <a href="{{ metadata.reporter.url }}">
-            {{ metadata.reporter.full_name }}</a>,
-          No.<a href="{{ metadata.volume.url }}">
-          {{ metadata.volume.volume_number }}.</a>
-          <span class="pages">p.{{ metadata.first_page }}&ndash;{{ metadata.last_page }}.</span>
-        </p>
-      </div>
-
-      <div class="text-center">
-        <p class="">
-          <a href="{{ metadata.court.url }}">{{ metadata.court.name }}</a>
-          {% if metadata.docket_number %}
-            {{ metadata.docket_number }}{% endif %}
-        </p>
-        <p>
-          {{ metadata.decision_date }}
-        </p>
-      </div>
       <div id="citation_container" class="text-center">
         <p title="official citation" class="center" id="citation_for_copy"
            name="citation">{{ citation_full }}
@@ -38,28 +18,55 @@
         <img src="{% static "img/copy_icon.png" %}" alt="Copy Citation to Clipboard">
       </button>-->
         </p>
-  </div>
-
       </div>
-      {% if reason == 'error_auth_required' %}
-        <section class="name">
-          <h4 class="text-center">{{ metadata.name }}</h4>
-          <br/>
-          <div class="alert-warning text-center">
-            <h6 class="case-viewing-error">
-              You must be signed in to see the full
-              case.</h6>
-          </div>
-        </section>
-      {% elif reason == 'other' %}
+      <div class="text-center court">
+        <p class="">
+          <!--<a href="{{ metadata.court.url }}">{{ metadata.court.name }}</a>-->
+          {{ metadata.court.name }}
+        </p>
+        <p>
+          {{ metadata.decision_date }}
+        </p>
+      </div>
+
+      <div class="text-center reporter">
+        <p>
+          <!--<a href="{{ metadata.reporter.url }}">
+            {{ metadata.reporter.full_name }}</a>,
+          No.<a href="{{ metadata.volume.url }}">
+          {{ metadata.volume.volume_number }}.</a>-->
+          {{ metadata.reporter.full_name }}, No. {{ metadata.volume.volume_number }}.
+          <span class="pages">p.{{ metadata.first_page }}&ndash;{{ metadata.last_page }}.</span>
+        </p>
+      </div>
+
+      {% if metadata.docket_number %}
+        <div class="text-center docket">
+          {{ metadata.docket_number }}
+        </div>
+      {% endif %}
+
+
+    </div>
+    {% if reason == 'error_auth_required' %}
+      <section class="name">
+        <h4 class="text-center">{{ metadata.name }}</h4>
+        <br/>
         <div class="alert-warning text-center">
           <h6 class="case-viewing-error">
-            Could not load case body</h6>
+            You must be signed in to see the full
+            case.</h6>
         </div>
-        </div>
-      {% else %}
-        {{ case_html|safe }}
-      {% endif %}
+      </section>
+    {% elif reason == 'other' %}
+      <div class="alert-warning text-center">
+        <h6 class="case-viewing-error">
+          Could not load case body</h6>
+      </div>
+      </div>
+    {% else %}
+      {{ case_html|safe }}
+    {% endif %}
 
   <script>
     /*

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -53,8 +53,8 @@
         <br/>
         <div class="alert-warning text-center">
           <h6 class="case-viewing-error">
-            You must be signed in to see the full
-            case.</h6>
+            You must be signed in to see the full case.
+          </h6>
         </div>
       </section>
     {% elif reason == 'full_case_param_missing' %}

--- a/capstone/capapi/templates/case_404.html
+++ b/capstone/capapi/templates/case_404.html
@@ -1,0 +1,3 @@
+{% with type="404 - Not Found" title="Not Found" middle="The case specified by the URL does not exist in our database." action="If you got here through our site or an article we host, please <a href='https://caselaw.freshdesk.com/support/tickets/new'>let us know</a>, so we can fix it." %}
+  {% include "error_page.html" %}
+{% endwith %}

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -131,7 +131,7 @@ def test_unauthenticated_full_case(case, jurisdiction, client):
     check_response(response, content_type="application/xml", content_includes='error_auth_required')
 
     response = client.get(case_url, {"full_case": "true", "format": "html"})
-    check_response(response, content_type="text/html", content_includes='<h1>Error: Not Authenticated')
+    check_response(response, content_type="text/html", content_includes='You must be signed in to see the full case')
 
 
 @pytest.mark.django_db

--- a/capstone/static/css/scss/case.scss
+++ b/capstone/static/css/scss/case.scss
@@ -1,15 +1,49 @@
 @import "base.scss";
+section, article {
+  @include make-col(11);
+  @extend .col-centered;
+  @include media-breakpoint-up(lg) {
+    @include make-col(10);
+  }
+  padding-top: 1em;
 
-.case-title-container {
-  border-bottom: 1px solid $color-tan;
 }
 
-.case-title {
-  padding-bottom: 20px;
+p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.metadata {
   font-family: $font-serif;
+  font-size: 16px;
   text-align: center;
+  padding-bottom: 20px;
+  border-bottom: 1px solid $color-tan;
+  a {
+    border-bottom: 0;
+  }
+}
+
+.case-container {
+  padding-bottom: 100px !important;
+}
+
+p.small-text {
+  font-size: 14px;
+  font-weight: $font-weight-semibold;
+}
+
+.reporter-and-volume {
+  font-family: $font-serif;
   color: $color-violet-gray-dark;
   letter-spacing: 0.03em;
+}
+
+.case-viewing-error {
+  @extend .reporter-and-volume;
+  padding-bottom: 10px;
+  padding-top: 10px;
 }
 
 h4 {
@@ -18,14 +52,16 @@ h4 {
 }
 
 #citation_container {
-  @include make-col(6);
+  //@include make-col(6);
   @extend .col-centered;
 }
 
 #citation_for_copy {
+  font-weight: normal;
+  text-align: center;
   padding-left: 8px;
-  color: $color-violet;
-  border: 1px solid $color-violet;
+  border: 0;
+  outline: none;
 }
 
 #citation_copy {
@@ -33,6 +69,7 @@ h4 {
   border: 1px solid $color-violet;
   position: relative;
   top: -2px;
+  margin-bottom: 0;
 }
 
 #citation_copy > img {
@@ -41,19 +78,6 @@ h4 {
   margin-top: -7px;
   margin-left: -2px;
   cursor: pointer;
-}
-
-.citation_copied:after {
-  display: block;
-  color: $color-violet;
-  content: "Citation Copied!";
-  font-size: .75em;
-  margin-bottom: 1em;
-  margin-top: -10px;
-}
-
-section {
-  padding-top: 1em;
 }
 
 section.head-matter {
@@ -105,6 +129,7 @@ section.head-matter {
 
 .parties {
   text-align: center;
+  padding-bottom: 20px;
 }
 
 .decisiondate, .attorneys, .judges {
@@ -149,7 +174,6 @@ section.head-matter {
 
 .opinion {
   padding-top: 2em;
-
   &:before {
     content: "Opinion";
     font-weight: bold;

--- a/capstone/static/css/scss/case.scss
+++ b/capstone/static/css/scss/case.scss
@@ -37,11 +37,12 @@ p.small-text {
 .reporter-and-volume {
   font-family: $font-serif;
   color: $color-violet-gray-dark;
-  letter-spacing: 0.03em;
+
 }
 
 .case-viewing-error {
-  @extend .reporter-and-volume;
+  font-family: $font-serif;
+  color: $color-violet-gray-dark;
   padding-bottom: 10px;
   padding-top: 10px;
 }

--- a/capstone/static/css/scss/case.scss
+++ b/capstone/static/css/scss/case.scss
@@ -34,6 +34,10 @@ p.small-text {
   font-weight: $font-weight-semibold;
 }
 
+.docket {
+  color: $color-violet-gray;
+}
+
 .reporter-and-volume {
   font-family: $font-serif;
   color: $color-violet-gray-dark;


### PR DESCRIPTION
Without the links (which are currently commented out), things look a little drab. But that should be fixed soon.

<img width="1440" alt="screen shot 2019-02-19 at 5 57 29 pm" src="https://user-images.githubusercontent.com/1494102/53053622-ea64ce80-346f-11e9-8d06-9bdee2f02af9.png">

<img width="1440" alt="screen shot 2019-02-19 at 5 57 43 pm" src="https://user-images.githubusercontent.com/1494102/53053630-ed5fbf00-346f-11e9-8045-60e104794252.png">
