### PR TITLE
New template tag only urlizes urls, implemented in api.html

### DIFF
--- a/capstone/capapi/templates/rest_framework/api.html
+++ b/capstone/capapi/templates/rest_framework/api.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load i18n %}
 {% load rest_framework %}
+{% load urlize_url_fields_only %}
 
 {% block extra_head %}
   {% stylesheet 'api' %}
@@ -127,7 +128,7 @@
         <pre class="prettyprint"><span class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}{% for key, val in response_headers|items %}
   <b>{{ key }}:</b> <span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
 
-  </span>{{ content|urlize_quoted_links }}</pre>{% endautoescape %}
+  </span>{{ content|urlize_url_fields_only }}</pre>{% endautoescape %}
       </div>
     </div>
 

--- a/capstone/capapi/templatetags/urlize_url_fields_only.py
+++ b/capstone/capapi/templatetags/urlize_url_fields_only.py
@@ -1,0 +1,14 @@
+from re import findall
+
+from django import template
+
+from rest_framework.templatetags.rest_framework import urlize_quoted_links
+
+register = template.Library()
+
+@register.filter()
+def urlize_url_fields_only(text):
+    ret = text.decode()
+    for url in findall('"url": "(http[^"]+)"', text.decode()):
+        ret = ret.replace(url, urlize_quoted_links(url))
+    return ret


### PR DESCRIPTION
This stops DRF from making urls clickable in the browsable API, unless they're actually in url fields.

 Changes to be committed:
	modified:   capapi/templates/rest_framework/api.html
	new file:   capapi/templatetags/urlize_url_fields_only.py