### PR TITLE
Reorder head matter in API views

### DIFF
--- a/capstone/scripts/count_chars.py
+++ b/capstone/scripts/count_chars.py
@@ -4,7 +4,7 @@ from celery import shared_task
 from capdb.models import CaseXML
 import json
 from os import mkdir
-from scripts.helpers import extract_casebody
+
 
 def count_chars_in_all_cases(path):
     """
@@ -37,7 +37,7 @@ def count_case_chars(case_xml_id, path, write_to_disk=False):
     reporter = case_metadata.reporter
     volume = case_metadata.volume
     charlist = list(case_xml.orig_xml)
-    case_body_char_list = list(extract_casebody(case_xml.orig_xml).text())
+    case_body_char_list = list(case_xml.extract_casebody().text())
 
     output = {}
     output['metadata_db_id'] = case_metadata.pk

--- a/capstone/scripts/generate_case_html.py
+++ b/capstone/scripts/generate_case_html.py
@@ -1,7 +1,7 @@
 from lxml import etree
 import re
 
-from .helpers import parse_xml, left_strip_text
+from .helpers import left_strip_text
 
 tag_map = {"author": "p", "opinion": "article", "casebody": "section",
            "citation": "p", "correction": "aside", "court": "p",
@@ -17,18 +17,10 @@ bracketnum_number = re.compile(r'\d')
 headnotes_number = re.compile(r'^(\d+).*')
 
 
-def generate_html(case_xml, tag_map=tag_map):
+def generate_html(casebody, tag_map=tag_map):
     """
-    converts case xml to html
+        Converts case xml to html. casebody should be a pyquery element extracted from case XML.
     """
-    parsed_xml = parse_xml(case_xml)
-
-    # give a descriptive error for duplicative cases
-    if parsed_xml('duplicative|casebody'):
-        return "<h1 class='error'>This case is duplicative and was not fully \
-        processed. It should be available in the original, non-regional \
-        reporter.</h1>"
-    casebody = parsed_xml("casebody|casebody")
     casebody_tree = casebody[0]
 
     # all elements before the first opinion go into a <section class="head-matter"> container

--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -269,14 +269,6 @@ def ordered_query_iterator(queryset, chunk_size=1000):
         if i < chunk_size:
             break
         filter = get_filter(order_by, obj)
-            
-def extract_casebody(case_xml):
-    # strip soft hyphens from line endings
-    text = case_xml.replace(u'\xad', '')
-    case = parse_xml(text)
-
-    return case('casebody|casebody')
-
 
 def element_text_iter(el, with_tail=False):
     """


### PR DESCRIPTION
Here's a first pass at addressing the issue we talked about in Slack today. As @ChefAndy suggested, we can use the `<structMap TYPE="xref">` part of casemets to re-order headmatter blocks by the order they appear in the ALTO, which should map to reading order.

To keep things simple, I just changed extract_casebody() to do the reordering, and made sure we were calling that for all of our API views. So this only changes the appearance of cases when we display them, rather than permanently storing the reordering anywhere. If we like, we can do something more efficient/permanent later.

On the tiny number of cases I've looked at, this seems to be a definite improvement.

**Example one:**

Old way:

![image](https://user-images.githubusercontent.com/376272/53926050-14adb300-4050-11e9-8c27-e343ec51822f.png)

New way:

![image](https://user-images.githubusercontent.com/376272/53926005-f47df400-404f-11e9-9524-01ff238d7177.png)

In this example the old version is totally misleading -- the text paragraphs at the end are the arguments of the parties, and only make sense with the attorney paragraphs in the right locations.

**Example two:**

Old way:

![image](https://user-images.githubusercontent.com/376272/53926240-b7663180-4050-11e9-80d4-891cda390ea9.png)

New way:

![image](https://user-images.githubusercontent.com/376272/53926244-baf9b880-4050-11e9-9ca9-677d5b764749.png)
 
Here the old way had a weird thing where it looked like the case name was in brackets for some reason, when actually the case just had "[No. 33971-8-III. Division Three. July 11, 2017.]" printed at the top.

**To do later:**

* Spot check more examples on beta.
* Tweak styles based on text appearing in a less predictable order.
* Remove the extra linebreaks that are slipping in because single paragraphs are split into two. I think maybe we can just turn `id="A..."` head matter elements into spans in the HTML generator.