### PR TITLE
Better url handling in browsable API

### DIFF
--- a/capstone/capapi/templatetags/urlize_url_fields_only.py
+++ b/capstone/capapi/templatetags/urlize_url_fields_only.py
@@ -2,6 +2,8 @@ from re import findall
 
 from django import template
 from django.utils.html import escape
+import re
+
 
 from rest_framework.templatetags.rest_framework import urlize_quoted_links
 
@@ -9,7 +11,8 @@ register = template.Library()
 
 @register.filter()
 def urlize_url_fields_only(text):
-    ret = escape(text.decode())
-    for url in findall('"url": "(http[^"]+)"', text.decode()):
-        ret = ret.replace(url, urlize_quoted_links(url))
+    ret = re.sub(
+        '&quot;(http:.*)?(&quot;)',
+        lambda url_match: urlize_quoted_links(url_match.group(1)),
+        escape(text.decode()))
     return ret

--- a/capstone/capapi/templatetags/urlize_url_fields_only.py
+++ b/capstone/capapi/templatetags/urlize_url_fields_only.py
@@ -11,7 +11,7 @@ register = template.Library()
 @register.filter()
 def urlize_url_fields_only(text):
     ret = sub(
-        '&quot;(http:.*)?(&quot;)',
+        '&quot;(http:.*)+(&quot;)',
         lambda url_match: urlize_quoted_links(url_match.group(1)),
         escape(text.decode()))
     return ret

--- a/capstone/capapi/templatetags/urlize_url_fields_only.py
+++ b/capstone/capapi/templatetags/urlize_url_fields_only.py
@@ -1,8 +1,7 @@
-from re import findall
+from re import sub
 
 from django import template
 from django.utils.html import escape
-import re
 
 
 from rest_framework.templatetags.rest_framework import urlize_quoted_links
@@ -11,7 +10,7 @@ register = template.Library()
 
 @register.filter()
 def urlize_url_fields_only(text):
-    ret = re.sub(
+    ret = sub(
         '&quot;(http:.*)?(&quot;)',
         lambda url_match: urlize_quoted_links(url_match.group(1)),
         escape(text.decode()))


### PR DESCRIPTION
This temporary fix to restore functionality opens up the whitelist to include all URLs in quotes that start with http. I'm looking to avoid parsing the json and then doing something more involved, but I will if this doesn't work.