### PR TITLE
Expose ngram api endpoint

### DIFF
--- a/capstone/capapi/pagination.py
+++ b/capstone/capapi/pagination.py
@@ -145,3 +145,8 @@ class CapPagination(FTSPagination):
             return queryset.count()
         except (AttributeError, TypeError):
             return len(queryset)
+
+
+class SmallCapPagination(CapPagination):
+    page_size = 10
+    max_page_size = 10

--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -125,6 +125,14 @@ class BrowsableAPIRenderer(renderers.BrowsableAPIRenderer):
             context['page_description'] = "CAPAPI: The Caselaw Access Project API"
         return context
 
+
+class NgramBrowsableAPIRenderer(BrowsableAPIRenderer):
+    def get_filter_form(self, data, view, request):
+        # Passing in an empty list here makes the filter options show even though this endpoint returns a dictionary
+        # instead of a list.
+        return super().get_filter_form([], view, request)
+
+
 class PassthroughRenderer(renderers.JSONRenderer):
     """
         Return data as-is. View should supply a Response.

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -304,14 +304,6 @@ class CourtSerializer(serializers.ModelSerializer):
         )
 
 
-class NgramSerializer(serializers.Serializer):
-    year = serializers.IntegerField()
-    count = serializers.IntegerField()
-
-    class Meta:
-        fields = ('year', 'count')
-
-
 ### BULK SERIALIZERS ###
 
 class CaseExportSerializer(serializers.ModelSerializer):

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1300,6 +1300,37 @@ class NgramWord(models.Model):
         return self.word
 
 
+class NgramQuerySet(models.QuerySet):
+    def from_string(self, s):
+        """
+            Search for ngrams by string.
+            Given "foo bar baz box", search for (w1="foo", w2="bar", w3="baz")
+            Given "foo", search for (w1="foo", w2=None, w3=None)
+            Given "foo *", search for (w1="foo", w3=None)
+        """
+        # split s into parts
+        parts = s.split()[:3]
+
+        # apply wildcard placeholder
+        any_word = object()
+        if len(parts) > 1 and parts[-1] == '*':
+            parts[-1] = any_word
+
+        # pad with None
+        parts += [None] * (3-len(parts))
+
+        # apply filter
+        query = Q()
+        for i, part in enumerate(parts, 1):
+            if part == any_word:
+                query &= ~Q(**{"w%s" % i: None})
+            elif part:
+                query &= Q(**{"w%s__word" % i: part})
+            else:
+                query &= Q(**{"w%s" % i: None})
+        return self.filter(query)
+
+
 class Ngram(models.Model):
     """
         A record for a 1-gram, 2-gram, or 3-gram.
@@ -1308,6 +1339,8 @@ class Ngram(models.Model):
     w1 = models.ForeignKey(NgramWord, on_delete=models.CASCADE, related_name='w1')
     w2 = models.ForeignKey(NgramWord, on_delete=models.CASCADE, related_name='w2', null=True)
     w3 = models.ForeignKey(NgramWord, on_delete=models.CASCADE, related_name='w3', null=True)
+
+    objects = NgramQuerySet.as_manager()
 
     class Meta:
         indexes = [
@@ -1320,16 +1353,7 @@ class Ngram(models.Model):
 
 class NgramObservationQuerySet(models.QuerySet):
     def from_string(self, s):
-        """ Search for ngrams by string. """
-        parts = s.split()
-        parts += [None] * (3-len(parts))
-        query = Q()
-        for i, part in enumerate(parts):
-            if part:
-                query &= Q(**{"ngram__w%s__word" % (i+1): part})
-            else:
-                query &= Q(**{"ngram__w%s" % (i+1): None})
-        return self.filter(query)
+        return self.filter(ngram__in=Ngram.objects.from_string(s))
 
 
 class NgramObservation(models.Model):


### PR DESCRIPTION
Add /v1/ngrams/ API endpoint to search for a given ngram ("hold these truths" or prefix "hold these *"). By default, get results totaled across jurisdictions. Can also filter for a given jurisdiction or year, or multiple jurisdictions, or request all jurisdictions separately. Results are paginated with 10 grams per page, to allow for large prefix searches ("and so *").

This is still behind a feature flag, so won't show on prod until we want it to. 