### PR TITLE
Pagebreaks in styled XML

### DIFF
--- a/capstone/scripts/generate_case_html.py
+++ b/capstone/scripts/generate_case_html.py
@@ -10,7 +10,7 @@ tag_map = {"author": "p", "opinion": "article", "casebody": "section",
            "parties": "h4", "seealso": "aside", "summary": "p",
            "syllabus": "p", "footnote": "aside", "attorneys": "p",
            "judges": "p", "bracketnum": "a", "footnotemark": "a",
-           "pagebreak": "br"}
+           "page-number": "a"}
 
 # these will pull out the headnotes number and corresponding bracketnum
 bracketnum_number = re.compile(r'\d')
@@ -47,13 +47,15 @@ def generate_html(casebody, tag_map=tag_map):
 
         element_text_copy = element.text
 
-        if element_text_copy is None and tag != 'pagebreak':
+        if element_text_copy is None and tag != 'page-number':
             element_text_copy = element.getchildren()[0].text
 
         # for every attribute except id, turn it into an accepted data-* attribute
         # use list(element.attrib) so we can safely mutate dictionary during iteration
         for attribute in list(element.attrib):
-            if attribute == 'id' or attribute.startswith('data-'):
+            if attribute == 'id' \
+                or attribute == 'href' \
+                or attribute.startswith('data-'):
                 continue
             element.attrib['data-' + attribute] = element.attrib[attribute]
             element.attrib.pop(attribute)
@@ -103,7 +105,7 @@ def generate_html(casebody, tag_map=tag_map):
             else:
                 element.tag = "span"
 
-        elif tag == "pagebreak":
+        elif tag == "page-number":
             # point to the anchor in the headnote
             element.attrib['style'] = "page-break-before: always"
 

--- a/capstone/scripts/merge_alto_style.py
+++ b/capstone/scripts/merge_alto_style.py
@@ -118,7 +118,7 @@ def generate_styled_case_xml(case_xml, strict=True):
         current_final_page = casebody_element.attrib['pgmap'].split(' ')[-1].split('(')[0]
         if previous_page != current_final_page and ' ' not in casebody_element.attrib['pgmap']:
             first_text_element = True
-            previous_page = current_final_page
+        previous_page = current_final_page
 
         if casebody_element.text.isspace():
             continue
@@ -206,6 +206,12 @@ def generate_styled_case_xml(case_xml, strict=True):
             if previous_tags and (not current_tags or current_tags['close'] != previous_tags['close']):
                 insertions[cursor].insert(0, previous_tags['close'])
 
+            # check if this element needs a page break
+            if first_text_element:
+                first_text_element = False
+                page_marker = page_number_html(alto_element, parsed_case)
+                insertions[cursor].append(page_marker)
+
             if current_tags:
                 # If tag changes, new style tag needs to be opened:
                 if not previous_tags or (current_tags['open'] != previous_tags['open']):
@@ -215,12 +221,6 @@ def generate_styled_case_xml(case_xml, strict=True):
                 elif cursor in insertions and not ''.join(insertions[cursor]).isspace():
                     insertions[cursor].append(current_tags['open'])
                     insertions[cursor].insert(0, current_tags['close'])
-
-            # check if this element needs a page break
-            if first_text_element:
-                first_text_element = False
-                page_marker = page_number_html(alto_element, parsed_case)
-                insertions[cursor].append(page_marker)
 
             # check if this element needs an inline page break
             if len(page_breaks) > 0 and alto_element in page_breaks:


### PR DESCRIPTION
Ok, so this is an update to the code which pulls in the styling information from ALTO— it now indicates exactly where page breaks occur. This is going to have to be run in batch and stored, which is a task for another P.R. This doesn't implement any sort of cite index logic because right now I think we only have pagination for one citation, and I presume that the official citation will always be number 1.