### PR TITLE
Fix numerical sorting of alto IDs for head matter reordering

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1184,13 +1184,16 @@ class CaseXML(BaseXMLModel):
         #         <fptr><area BEGIN="b15-4" .../></fptr>
         #         <fptr><seq><area BEGIN="BL_15.2" .../></seq></fptr>
         #     </div>
-        # Build a dictionary of ID to ALTO order for sorting, e.g. {'b15-4': ('BL_15.2',)}
+        # Build a dictionary of ID to ALTO order for sorting, e.g. {'b15-4': (15, 2),)}
+        # ALTO blocks have IDs like "BL_<page number>.<block number>", so extract the two numbers to sort numerically.
         id_to_alto_order = {}
         for xref_el in parsed_xml('mets|div[TYPE="blocks"] > mets|div[TYPE="element"]').items():
             par_el, blocks_el = xref_el('mets|fptr').items()
-            id_to_alto_order[par_el('mets|area').attr.BEGIN] = tuple(block_el.attr.BEGIN for block_el in blocks_el('mets|area').items())
+            alto_id = blocks_el('mets|area').attr.BEGIN
+            parts = alto_id.split('_')[1].split('.')
+            id_to_alto_order[par_el('mets|area').attr.BEGIN] = (int(parts[0]), int(parts[1]))
 
-        # Split our remove_els into head_els and opinion_els, based on whether or not they come before the first
+        # Split remove_els into head_els and opinion_els, based on whether or not they come before the first
         # element in the first opinion:
         removed_els.sort(key=lambda el: id_to_alto_order[el.attr.id])
         first_opinion_el_id = parsed_xml('casebody|opinion:eq(0) > :eq(0)').attr.id

--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -409,11 +409,12 @@ def test_reorder_head_matter(case_xml):
 
     # specify new element order
     element_order = "b a d c1 e c2 f c3"
+    alto_ids = "BL_9.9 BL_9.10 BL_9.11 BL_9.12 BL_10.9 BL_10.10 BL_10.11 BL_10.12"
     xml = xml.replace("REPLACE_BLOCKS", "".join("""
         <div TYPE="element">
             <fptr><area BEGIN="%s" BETYPE="IDREF" FILEID="casebody_0001"/></fptr>
-            <fptr><seq><area BEGIN="foo.%s" BETYPE="IDREF" FILEID="alto_00009_0"/></seq></fptr>
-        </div>""" % (case_id, alto_id) for alto_id, case_id in enumerate(element_order.split())))
+            <fptr><seq><area BEGIN="%s" BETYPE="IDREF" FILEID="alto_00009_0"/></seq></fptr>
+        </div>""" % (case_id, alto_id) for case_id, alto_id in zip(element_order.split(), alto_ids.split())))
 
     # reorder xml
     parsed = parse_xml(xml)


### PR DESCRIPTION
Whoops, I messed up the reorder_head_matter function so it was sorting alphabetically on ALTO IDs, which would cause some elements to be out of order. This augments the test to catch that, and switches to numerically sorting on `"BL_<page number>.<block number>"`.