### PR TITLE
Fix more token stream edge cases

### DIFF
--- a/capstone/scripts/render_case.py
+++ b/capstone/scripts/render_case.py
@@ -218,7 +218,7 @@ class VolumeRenderer:
         if metadata['spine_start_date']:
             spinedate_el = etree.SubElement(volume_el, 'spinedate')
             etree.SubElement(spinedate_el, 'start').text = metadata['spine_start_date']
-            if metadata['end_date']:
+            if metadata['spine_end_date']:
                 etree.SubElement(spinedate_el, 'end').text = metadata['spine_end_date']
         etree.SubElement(volume_el, 'publicationdate').text = metadata['publication_date']
         publisher = metadata['publisher']


### PR DESCRIPTION
Notably:

- Fix spine end date rendering
- Match redacted blocks based on rect instead of ID (though this really should only come up with redacted volumes we don't want to validate in the first place, because they were generated at a different time than the unredacted vol)
- Add ability to skip validating entire redacted vols