### PR TITLE
More token stream edge cases

### DIFF
--- a/capstone/scripts/render_case.py
+++ b/capstone/scripts/render_case.py
@@ -158,7 +158,8 @@ class VolumeRenderer:
                     elif token[0] == 'font':
                         current_font = fonts_lookup[token[1]['id']]
                     elif token[0] == 'edit':
-                        string_el.attrib['CONTENT'] += token[1]['was']
+                        if string_el is not None:
+                            string_el.attrib['CONTENT'] += token[1]['was']
                         ignore_strings = True
                     elif token[0] == '/edit':
                         ignore_strings = False


### PR DESCRIPTION
Notably, this involves a rewrite of the case/page diffing algorithm to ensure that footnotemark and bracketnum tags in alto line up with the ones in the case, which helps us more often do the correct thing when edits overlap with redactions.