### PR TITLE
Css padding fixes

### DIFF
--- a/capstone/capapi/templates/bulk.html
+++ b/capstone/capapi/templates/bulk.html
@@ -37,32 +37,28 @@
 {% block main_content %}
   {# ==============> PUBLIC DATA <============== #}
   {% if exports.public %}
-    <div class="page-section">
-      <h2 class="subtitle" id="public">Public Bulk Data</h2>
-      {% include "includes/download_list.html" with zips=exports.public %}
-    </div>
+    <h2 class="subtitle" id="public">Public Bulk Data</h2>
+    {% include "includes/download_list.html" with zips=exports.public %}
   {% endif %}
   {# ==============> RESEARCHER DOWNLOADS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="researcher">Researcher downloads</h2>
-    {% if exports.private %}
-      <p>
-        The following jurisdictions are available for download under your scholarly research agreement.
-        Click a link to download.
-      </p>
-      {% include "includes/download_list.html" with zips=exports.private %}
-    {% elif request.user.harvard_access and not request.user.harvard_ip %}
-      <p>You will have access to bulk data when accessing this page from a Harvard IP address.</p>
-    {% else %}
-      <p>
-        Bulk downloads of the remaining jurisdictions are freely available to research scholars.
-        To request access, please log in, visit your <a href="{% url "user-details" %}">account page</a>,
-        and click "Request unlimited research access."
-      </p>
-      <p>
-        For more information about our access limits, or details on requesting bulk data for commercial use, see the
-        <a href="{% url "api" %}">Access Limits section of our API documentation</a>.
-      </p>
-    {% endif %}
-  </div>
+  <h2 class="subtitle" id="researcher">Researcher downloads</h2>
+  {% if exports.private %}
+    <p>
+      The following jurisdictions are available for download under your scholarly research agreement.
+      Click a link to download.
+    </p>
+    {% include "includes/download_list.html" with zips=exports.private %}
+  {% elif request.user.harvard_access and not request.user.harvard_ip %}
+    <p>You will have access to bulk data when accessing this page from a Harvard IP address.</p>
+  {% else %}
+    <p>
+      Bulk downloads of the remaining jurisdictions are freely available to research scholars.
+      To request access, please log in, visit your <a href="{% url "user-details" %}">account page</a>,
+      and click "Request unlimited research access."
+    </p>
+    <p>
+      For more information about our access limits, or details on requesting bulk data for commercial use, see the
+      <a href="{% url "api" %}">Access Limits section of our API documentation</a>.
+    </p>
+  {% endif %}
 {% endblock %}

--- a/capstone/capapi/templates/research_request/index.html
+++ b/capstone/capapi/templates/research_request/index.html
@@ -6,44 +6,40 @@
   Project{% endblock %}
 
 {% block main_content %}
-  <div class="page-section">
+  <p>
+    If you are a research scholar and your work requires access to the full text of more than 500 cases per day,
+    you may apply for unmetered access to the full text of all cases made available by the Caselaw Access Project.
+  </p>
+  <p>
+    To be eligible, you must demonstrate that you are a research scholar and you must enter into a special bulk access
+    agreement with LexisNexis, which prohibits you from (1) using the cases for non-research or commercial purposes
+    and
+    (2) sharing bulk caselaw with others.
+  </p>
+  <p>
+    We offer several ways to obtain unmetered access:
+  </p>
+
+  {% if HARVARD_RESEARCHER_FEATURE %}
+    <h2 class="simple-subtitle">Harvard community members</h2>
     <p>
-      If you are a research scholar and your work requires access to the full text of more than 500 cases per day,
-      you may apply for unmetered access to the full text of all cases made available by the Caselaw Access Project.
+      If you are a member of the Harvard community with a Harvard email address, you can
+      <a href="{% url "harvard-research-request-intro" %}">sign the Harvard bulk access agreement</a>
+      and you will immediately have full access from Harvard IP addresses.
     </p>
-    <p>
-      To be eligible, you must demonstrate that you are a research scholar and you must enter into a special bulk access
-      agreement with LexisNexis, which prohibits you from (1) using the cases for non-research or commercial purposes
-      and
-      (2) sharing bulk caselaw with others.
-    </p>
-    <p>
-      We offer several ways to obtain unmetered access:
-    </p>
-  </div>
-  <div class="page-section">
-    {% if HARVARD_RESEARCHER_FEATURE %}
-      <h2 class="simple-subtitle">Harvard community members</h2>
-      <p>
-        If you are a member of the Harvard community with a Harvard email address, you can
-        <a href="{% url "harvard-research-request-intro" %}">sign the Harvard bulk access agreement</a>
-        and you will immediately have full access from Harvard IP addresses.
-      </p>
-    {% endif %}
-  </div>
-  <div class="page-section">
-    <h2 class="simple-subtitle">Educational or non-profit affiliates</h2>
-    <p>
-      If you are officially affiliated with an educational or non-profit research institution,
-      <a href="{% url "affiliated-research-request" %}">sign this application to request access</a> and your application
-      will be reviewed shortly.
-    </p>
-    <h2 class="simple-subtitle">Other researchers</h2>
-    <p>
-      If you do not otherwise qualify for unmetered access, <a href="{% url "unaffiliated-research-request" %}">fill out
-      this form</a> to explain your standing as an independent research scholar and we will do our best to work with you
-      or refer you to an appropriate organization.
-    </p>
-    <p>Please <a href="{% url "contact" %}">contact us</a> with any questions.</p>
-  </div>
+  {% endif %}
+
+  <h2 class="simple-subtitle">Educational or non-profit affiliates</h2>
+  <p>
+    If you are officially affiliated with an educational or non-profit research institution,
+    <a href="{% url "affiliated-research-request" %}">sign this application to request access</a> and your application
+    will be reviewed shortly.
+  </p>
+  <h2 class="simple-subtitle">Other researchers</h2>
+  <p>
+    If you do not otherwise qualify for unmetered access, <a href="{% url "unaffiliated-research-request" %}">fill out
+    this form</a> to explain your standing as an independent research scholar and we will do our best to work with you
+    or refer you to an appropriate organization.
+  </p>
+  <p>Please <a href="{% url "contact" %}">contact us</a> with any questions.</p>
 {% endblock %}

--- a/capstone/capweb/templates/about.html
+++ b/capstone/capweb/templates/about.html
@@ -77,280 +77,259 @@
 
 {% block main_content %}
   {# ==============> DATA <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="data">What data do we have?</h2>
-    <p>
-      CAP includes all official, book-published United States case law — every volume designated as an official
-      report of decisions by a court within the United States.
-    </p>
-    <p>
-      Our scope includes all state courts, federal courts, and territorial courts for American
-      Samoa, Dakota Territory, Guam, Native American Courts, Navajo Nation, and the Northern Mariana
-      Islands. Our earliest case is from 1658, and our most recent cases are from 2018.
-    </p>
-    <p>
-      Each volume has been converted into structured, case-level data broken out by majority and dissenting
-      opinion, with human-checked metadata for party names, docket number, citation, and date.
-    </p>
-    <p>
-      We also plan to share (but have not yet published) page images and page-level OCR data for all volumes.
-    </p>
-  </div>
+  <h2 class="subtitle" id="data">What data do we have?</h2>
+  <p>
+    CAP includes all official, book-published United States case law — every volume designated as an official
+    report of decisions by a court within the United States.
+  </p>
+  <p>
+    Our scope includes all state courts, federal courts, and territorial courts for American
+    Samoa, Dakota Territory, Guam, Native American Courts, Navajo Nation, and the Northern Mariana
+    Islands. Our earliest case is from 1658, and our most recent cases are from 2018.
+  </p>
+  <p>
+    Each volume has been converted into structured, case-level data broken out by majority and dissenting
+    opinion, with human-checked metadata for party names, docket number, citation, and date.
+  </p>
+  <p>
+    We also plan to share (but have not yet published) page images and page-level OCR data for all volumes.
+  </p>
 
   {# ==============> LIMITS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="limits">Scope limits</h2>
-    <p>CAP does not include:</p>
-    <ul class="spacious-list bullets">
-      <li>
-        New cases as they are published. We currently include volumes published through
-        June, 2018, and may or may not include additional volumes in the future.
-      </li>
-      <li>
-        Cases not designated as officially published, such as most lower court decisions.
-      </li>
-      <li>
-        Non-published trial documents such as party filings, orders, and exhibits.
-      </li>
-      <li>
-        Parallel versions of cases from regional reporters, unless those cases were
-        designated by a court as official.
-      </li>
-      <li>
-        Cases officially published in digital form, such as recent cases from Illinois and Arkansas.
-      </li>
-    </ul>
-    <p>
-      Cases published after 1922 do not include headnotes.
-    </p>
-  </div>
+  <h2 class="subtitle" id="limits">Scope limits</h2>
+  <p>CAP does not include:</p>
+  <ul class="spacious-list bullets">
+    <li>
+      New cases as they are published. We currently include volumes published through
+      June, 2018, and may or may not include additional volumes in the future.
+    </li>
+    <li>
+      Cases not designated as officially published, such as most lower court decisions.
+    </li>
+    <li>
+      Non-published trial documents such as party filings, orders, and exhibits.
+    </li>
+    <li>
+      Parallel versions of cases from regional reporters, unless those cases were
+      designated by a court as official.
+    </li>
+    <li>
+      Cases officially published in digital form, such as recent cases from Illinois and Arkansas.
+    </li>
+  </ul>
+  <p>
+    Cases published after 1922 do not include headnotes.
+  </p>
 
   {# ==============> NUMBERS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="numbers">By the numbers</h2>
-    <p>
-      Here are some tsv-formatted spreadsheets with specific counts from our collection, and links to view
-      those cases in the API:
-    </p>
-    <ul class="spacious-list">
-      <li>
-        <a href="{% static "downloads/cases_by_reporter.tsv" %}">Case Count by Reporter Series</a>
-      </li>
-      <li>
-        <a href="{% static "downloads/cases_by_jurisdiction.tsv" %}">Case Count by Jurisdiction</a>
-      </li>
-      <li>
-        <a href="{% static "downloads/cases_by_decision_date.tsv" %}">Case Count by Decision Date</a>
-      </li>
-    </ul>
-  </div>
+  <h2 class="subtitle" id="numbers">By the numbers</h2>
+  <p>
+    Here are some tsv-formatted spreadsheets with specific counts from our collection, and links to view
+    those cases in the API:
+  </p>
+  <ul class="spacious-list">
+    <li>
+      <a href="{% static "downloads/cases_by_reporter.tsv" %}">Case Count by Reporter Series</a>
+    </li>
+    <li>
+      <a href="{% static "downloads/cases_by_jurisdiction.tsv" %}">Case Count by Jurisdiction</a>
+    </li>
+    <li>
+      <a href="{% static "downloads/cases_by_decision_date.tsv" %}">Case Count by Decision Date</a>
+    </li>
+  </ul>
+
   {# ==============> DIGITIZATION PROCESS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="digitization">Digitization Process</h2>
-    <p>
-      We created this data by digitizing roughly 40 million pages of court decisions contained in roughly 40,000 bound
-      volumes owned by the Harvard Law School Library.
-    </p>
-    <p>
-      Members of our team created metadata for each volume, including a unique barcode, reporter name, title,
-      jurisdiction, publication date and other volume-level information. We then used a high-speed scanner to produce
-      JP2 and TIF images of every page. A vendor then used OCR to extract the text of every case, creating case-level
-      XML files. Key metadata fields, like case name, citation, court and decision date, were corrected for accuracy,
-      while the text of each case was left as raw OCR output. In addition, for cases from volumes not yet in the public
-      domain, our vendor redacted any headnotes.
-    </p>
-  </div>
+  <h2 class="subtitle" id="digitization">Digitization Process</h2>
+  <p>
+    We created this data by digitizing roughly 40 million pages of court decisions contained in roughly 40,000 bound
+    volumes owned by the Harvard Law School Library.
+  </p>
+  <p>
+    Members of our team created metadata for each volume, including a unique barcode, reporter name, title,
+    jurisdiction, publication date and other volume-level information. We then used a high-speed scanner to produce
+    JP2 and TIF images of every page. A vendor then used OCR to extract the text of every case, creating case-level
+    XML files. Key metadata fields, like case name, citation, court and decision date, were corrected for accuracy,
+    while the text of each case was left as raw OCR output. In addition, for cases from volumes not yet in the public
+    domain, our vendor redacted any headnotes.
+  </p>
+
   {# ==============> DATA QUALITY <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="data-quality">Data quality</h2>
-    <p>
-      Our data inevitably includes countless errors as part of the digitization process.
-      <span class="highlighted">The public launch of this project is only the start of discovering
-        errors, and we hope you will help us in finding and fixing them.</span>
-    </p>
-    <p>
-      Some parts of our data are higher quality than others. Case metadata, such as the party names, docket
-      number, citation, and date, has received human review. Case text and general head matter has been
-      generated by machine OCR and has not received human review.</p>
-    <p>
-      You can report errors of all kinds at
-      <a href="https://github.com/harvard-lil/capstone/labels/Data">our Github issue tracker</a>, where you
-      can also see currently known issues. We particularly welcome metadata corrections, feature requests,
-      and suggestions for large-scale algorithmic changes. We are not currently able to process individual
-      OCR corrections, but welcome general suggestions on the OCR correction process.
-    </p>
-  </div>
+  <h2 class="subtitle" id="data-quality">Data quality</h2>
+  <p>
+    Our data inevitably includes countless errors as part of the digitization process.
+    <span class="highlighted">The public launch of this project is only the start of discovering
+      errors, and we hope you will help us in finding and fixing them.</span>
+  </p>
+  <p>
+    Some parts of our data are higher quality than others. Case metadata, such as the party names, docket
+    number, citation, and date, has received human review. Case text and general head matter has been
+    generated by machine OCR and has not received human review.</p>
+  <p>
+    You can report errors of all kinds at
+    <a href="https://github.com/harvard-lil/capstone/labels/Data">our Github issue tracker</a>, where you
+    can also see currently known issues. We particularly welcome metadata corrections, feature requests,
+    and suggestions for large-scale algorithmic changes. We are not currently able to process individual
+    OCR corrections, but welcome general suggestions on the OCR correction process.
+  </p>
 
   {# ==============> DATA CITATION <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="data-citation">Data citation</h2>
-    <p>
-      Data made available through the Caselaw Access Project API and bulk download service is citable.
-      View our suggested citation in these standard formats:
-    </p>
-    <p>
-      <span class="highlighted">APA</span>
-      <br/>
-      <span class="font-italic">Caselaw Access Project.</span> (2018). Retrieved [date], from [url].
-    </p>
-    <p>
-      <span class="highlighted">MLA</span>
-      <br/>
-      The President and Fellows of Harvard University. "Caselaw Access Project." 2018, [url].
-    </p>
-    <p>
-      <span class="highlighted">Chicago / Turabian</span>
-      <br/>
-      Caselaw Access Project. "Caselaw Access Project." Last modified [date], [url].
-    </p>
-    <p>
-      Have you used Caselaw Access Project data in your research?
-      <a class="contact_email" href="mailto:{{ email }}">Tell us about it.</a>
-    </p>
-  </div>
+  <h2 class="subtitle" id="data-citation">Data citation</h2>
+  <p>
+    Data made available through the Caselaw Access Project API and bulk download service is citable.
+    View our suggested citation in these standard formats:
+  </p>
+  <p>
+    <span class="highlighted">APA</span>
+    <br/>
+    <span class="font-italic">Caselaw Access Project.</span> (2018). Retrieved [date], from [url].
+  </p>
+  <p>
+    <span class="highlighted">MLA</span>
+    <br/>
+    The President and Fellows of Harvard University. "Caselaw Access Project." 2018, [url].
+  </p>
+  <p>
+    <span class="highlighted">Chicago / Turabian</span>
+    <br/>
+    Caselaw Access Project. "Caselaw Access Project." Last modified [date], [url].
+  </p>
+  <p>
+    Have you used Caselaw Access Project data in your research?
+    <a class="contact_email" href="mailto:{{ email }}">Tell us about it.</a>
+  </p>
 
   {# ==============> USAGE <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="usage">Usage &amp; access</h2>
-    <p>
-      <span class="highlighted">The CAP data is free for the public to use and access.</span>
-    </p>
-    <p>
-      Case metadata, such as the case name, citation, court, date, etc.,
-      is freely and openly accessible without limitation.
-      Full case text can be freely viewed or downloaded but
-      you must register for an account to do so, and currently you may
-      view or download no more than 500 cases per day. In addition,
-      research scholars can qualify for bulk data access by agreeing to certain use and redistribution restrictions.
-      You can request a bulk access agreement by <a href="{% url "register" %}">creating an account</a>
-      and then <a href="{% url "user-details" %}">visiting your account page</a>.
-    </p>
-    <p>
-      Access limitations on full text and bulk data are a component of Harvard’s
-      collaboration agreement with Ravel Law, Inc. (now part of Lexis-Nexis).
-      These limitations will end, at the latest, in March of 2024.
-      In addition, these limitations apply only to cases from
-      jurisdictions that continue to publish their official case law in print form.
-      Once a jurisdiction transitions from print-first publishing to digital-first publishing,
-      these limitations cease. Thus far, Illinois and Arkansas have made this important and positive
-      shift and, as a result, all historical cases from these jurisdictions are freely available to the public
-      without restriction. We hope many other jurisdictions will follow their example soon.
-    </p>
-  </div>
+  <h2 class="subtitle" id="usage">Usage &amp; access</h2>
+  <p>
+    <span class="highlighted">The CAP data is free for the public to use and access.</span>
+  </p>
+  <p>
+    Case metadata, such as the case name, citation, court, date, etc.,
+    is freely and openly accessible without limitation.
+    Full case text can be freely viewed or downloaded but
+    you must register for an account to do so, and currently you may
+    view or download no more than 500 cases per day. In addition,
+    research scholars can qualify for bulk data access by agreeing to certain use and redistribution restrictions.
+    You can request a bulk access agreement by <a href="{% url "register" %}">creating an account</a>
+    and then <a href="{% url "user-details" %}">visiting your account page</a>.
+  </p>
+  <p>
+    Access limitations on full text and bulk data are a component of Harvard’s
+    collaboration agreement with Ravel Law, Inc. (now part of Lexis-Nexis).
+    These limitations will end, at the latest, in March of 2024.
+    In addition, these limitations apply only to cases from
+    jurisdictions that continue to publish their official case law in print form.
+    Once a jurisdiction transitions from print-first publishing to digital-first publishing,
+    these limitations cease. Thus far, Illinois and Arkansas have made this important and positive
+    shift and, as a result, all historical cases from these jurisdictions are freely available to the public
+    without restriction. We hope many other jurisdictions will follow their example soon.
+  </p>
 
   {# ==============> PRESS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="press">Press</h2>
-    <ul>
-      {% for news_item in news %}
-        <li class="item-set">
-          <p class="item-title">
-            <a href="{{ news_item.url }}">{{ news_item.title }}</a>
-          </p>
-          <span class="item-origin">
-              {{ news_item.publication }}
-            </span>
-          <span class="item-date">
-              {{ news_item.date }}
-            </span>
-        </li>
-      {% endfor %}
-    </ul>
-  </div>
+  <h2 class="subtitle" id="press">Press</h2>
+  <ul>
+    {% for news_item in news %}
+      <li class="item-set">
+        <p class="item-title">
+          <a href="{{ news_item.url }}">{{ news_item.title }}</a>
+        </p>
+        <span class="item-origin">
+            {{ news_item.publication }}
+          </span>
+        <span class="item-date">
+            {{ news_item.date }}
+          </span>
+      </li>
+    {% endfor %}
+  </ul>
 
   {# ==============> Friends & Partners <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="partners">Friends & Partners</h2>
+  <h2 class="subtitle" id="partners">Friends & Partners</h2>
 
-    <ul>
-      <li class="item-set">
-        The Caselaw Access Project is a <a class="item-name" href="https://lil.law.harvard.edu/">Harvard Law School
-        Library Innovation Lab</a> Project.
-      </li>
-      <li class="item-set">
-        LIL is part of the <a class="item-name" href="https://law.harvard.edu/library">
-        Harvard Law School Library.
-      </a>
-      </li>
+  <ul>
+    <li class="item-set">
+      The Caselaw Access Project is a <a class="item-name" href="https://lil.law.harvard.edu/">Harvard Law School
+      Library Innovation Lab</a> Project.
+    </li>
+    <li class="item-set">
+      LIL is part of the <a class="item-name" href="https://law.harvard.edu/library">
+      Harvard Law School Library.
+    </a>
+    </li>
 
-      <li class="item-set">
-        <a class="item-name" href="https://cyber.law.harvard.edu">
-          Berkman-Klein Center
-        </a> cooperated with LIL on the Caselaw Access Project.
-      </li>
+    <li class="item-set">
+      <a class="item-name" href="https://cyber.law.harvard.edu">
+        Berkman-Klein Center
+      </a> cooperated with LIL on the Caselaw Access Project.
+    </li>
 
-      <li class="item-set">
-        <a class="item-name" href="https://www.ravellaw.com/">
-          Ravel Law
-        </a> has partnered with the Harvard Law Library and LIL since the beginning of the Caselaw Access Project.
-        Ravel funded the digitization effort and now offers free public access to the entire corpus through their
-        <a href="https://home.ravellaw.com">search interface</a> and their
-        <a href="https://home.ravellaw.com/api">non-commercial API</a>.
-      </li>
+    <li class="item-set">
+      <a class="item-name" href="https://www.ravellaw.com/">
+        Ravel Law
+      </a> has partnered with the Harvard Law Library and LIL since the beginning of the Caselaw Access Project.
+      Ravel funded the digitization effort and now offers free public access to the entire corpus through their
+      <a href="https://home.ravellaw.com">search interface</a> and their
+      <a href="https://home.ravellaw.com/api">non-commercial API</a>.
+    </li>
 
-      <li class="item-set">
-        Carl Jaeckel of <a class="item-name" href="https://www.classaction.org/">ClassAction.org</a> graciously donated
-        the case.law domain name.
-      </li>
+    <li class="item-set">
+      Carl Jaeckel of <a class="item-name" href="https://www.classaction.org/">ClassAction.org</a> graciously donated
+      the case.law domain name.
+    </li>
 
-      <li class="item-set">
-        <a class="item-name" href="https://www.cloudflare.com/">Cloudflare</a> has generously provided LIL with network
-        services for case.law.
-      </li>
-    </ul>
-  </div>
+    <li class="item-set">
+      <a class="item-name" href="https://www.cloudflare.com/">Cloudflare</a> has generously provided LIL with network
+      services for case.law.
+    </li>
+  </ul>
 
   {# ==============> CONTRIBUTORS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="contributors">Contributors</h2>
+  <h2 class="subtitle" id="contributors">Contributors</h2>
 
-    <ul>
-      {% for key,contributor in contributors.items %}
-        {% if contributor.name %}
-          <li class="item-set">
-                <span class="item-name">
-                  {% if contributor.hash %}
-                    <a href="https://lil.law.harvard.edu/about/#{{ contributor.hash }}">
-                      {{ contributor.name }}
-                    </a>
-                  {% else %}
+  <ul>
+    {% for key,contributor in contributors.items %}
+      {% if contributor.name %}
+        <li class="item-set">
+              <span class="item-name">
+                {% if contributor.hash %}
+                  <a href="https://lil.law.harvard.edu/about/#{{ contributor.hash }}">
                     {{ contributor.name }}
-                  {% endif %}
-                </span>
-            <span class="color-red">
-                  &rarr;
-                </span>
-            <span>
-                  {{ contributor.role }}
-                </span>
-          </li>
-        {% endif %}
-      {% endfor %}
-    </ul>
-  </div>
-
+                  </a>
+                {% else %}
+                  {{ contributor.name }}
+                {% endif %}
+              </span>
+          <span class="color-red">
+                &rarr;
+              </span>
+          <span>
+                {{ contributor.role }}
+              </span>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
 
   {# ==============> GETTING LEGAL HELP <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="legal-help">Getting Legal Help</h2>
-    <p>
-      The Caselaw Access Project team cannot help with personal legal research problems or legal representation.
-      Our data is valuable for scholarship, but it is a work in progress and is not kept up to date. Please do not rely
-      on our data set to solve personal legal problems.
-    </p>
-    <p>
-      <strong>Finding a lawyer:</strong> see the list of links on the Harvard Law School Library's page
-      "<a href="https://asklib.law.harvard.edu/faq/115265">Where can I get legal advice?</a>"
-    </p>
-    <p>
-      <strong>Alternate databases:</strong> if you need to conduct up-to-date research for use in a legal proceeding,
-      consider <a href="https://guides.library.harvard.edu/alternatelegaldatabases">one of these alternate databases</a>.
-    </p>
-    <p>
-      <strong>Learning to conduct legal research:</strong> If you have access to a
-      <a href="http://www.washlaw.edu/statecourtcounty/">public law library</a>, its librarians should
-      be able to help you learn legal research skills. The Harvard Law School Library Reference Desk may also be able
-      to offer assistance through their <a href="https://asklib.law.harvard.edu/">Ask a Librarian</a> service.
-    </p>
-  </div>
+  <h2 class="subtitle" id="legal-help">Getting Legal Help</h2>
+  <p>
+    The Caselaw Access Project team cannot help with personal legal research problems or legal representation.
+    Our data is valuable for scholarship, but it is a work in progress and is not kept up to date. Please do not rely
+    on our data set to solve personal legal problems.
+  </p>
+  <p>
+    <strong>Finding a lawyer:</strong> see the list of links on the Harvard Law School Library's page
+    "<a href="https://asklib.law.harvard.edu/faq/115265">Where can I get legal advice?</a>"
+  </p>
+  <p>
+    <strong>Alternate databases:</strong> if you need to conduct up-to-date research for use in a legal proceeding,
+    consider <a href="https://guides.library.harvard.edu/alternatelegaldatabases">one of these alternate databases</a>.
+  </p>
+  <p>
+    <strong>Learning to conduct legal research:</strong> If you have access to a
+    <a href="http://www.washlaw.edu/statecourtcounty/">public law library</a>, its librarians should
+    be able to help you learn legal research skills. The Harvard Law School Library Reference Desk may also be able
+    to offer assistance through their <a href="https://asklib.law.harvard.edu/">Ask a Librarian</a> service.
+  </p>
 {% endblock %}

--- a/capstone/capweb/templates/api.html
+++ b/capstone/capweb/templates/api.html
@@ -81,51 +81,46 @@
 
 {% block main_content %}
   {# ==============> GETTING STARTED <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="getting-started">Getting Started</h2>
-    <p><a class="btn-primary" href="{% api_url "api-root" %}">API</a></p>
-    <p>
-      CAPAPI includes an in-browser API viewer, but is primarily intended for software developers to access
-      caselaw programmatically, whether to run your own analysis or build tools for other users. API results are in JSON
-      format with case text available as structured XML, presentation HTML, or plain text.
-    </p>
-    <p>
-      To get started with the API, you can <a href="{% api_url "api-root" %}">explore it in your browser,</a>
-      or reach it from the command line. For example, here is a curl command to request a single case from Illinois:</p>
-    <pre class="code-block">curl "{% api_url "casemetadata-list" %}?jurisdiction=ill&page_size=1"</pre>
-    <p>
-      If you haven't used APIs before, you might want to check out our <a href="{% url "search" %}">search tool</a>,
-      or jump down to our <a href="#beginners">Beginner's Introduction to APIs</a>.
-    </p>
-  </div>
+  <h2 class="subtitle" id="getting-started">Getting Started</h2>
+  <p><a class="btn-primary" href="{% api_url "api-root" %}">API</a></p>
+  <p>
+    CAPAPI includes an in-browser API viewer, but is primarily intended for software developers to access
+    caselaw programmatically, whether to run your own analysis or build tools for other users. API results are in JSON
+    format with case text available as structured XML, presentation HTML, or plain text.
+  </p>
+  <p>
+    To get started with the API, you can <a href="{% api_url "api-root" %}">explore it in your browser,</a>
+    or reach it from the command line. For example, here is a curl command to request a single case from Illinois:</p>
+  <pre class="code-block">curl "{% api_url "casemetadata-list" %}?jurisdiction=ill&page_size=1"</pre>
+  <p>
+    If you haven't used APIs before, you might want to check out our <a href="{% url "search" %}">search tool</a>,
+    or jump down to our <a href="#beginners">Beginner's Introduction to APIs</a>.
+  </p>
 
   {# ==============> REGISTER  <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="registration">Registration</h2>
-      <p>
-        <span class="highlighted"> Most API queries don't require registration: check our
-        <a href="#limits">access limits</a> section for more details.
-        </span>
-      </p>
+  <h2 class="subtitle" id="registration">Registration</h2>
     <p>
-      <a href="{% url "register" %}">Click here to register for an API key</a> if you need to access case text
-      from non-<a href="#def-whitelisted">whitelisted</a> jurisdictions.
+      <span class="highlighted"> Most API queries don't require registration: check our
+      <a href="#limits">access limits</a> section for more details.
+      </span>
     </p>
-  </div>
+  <p>
+    <a href="{% url "register" %}">Click here to register for an API key</a> if you need to access case text
+    from non-<a href="#def-whitelisted">whitelisted</a> jurisdictions.
+  </p>
 
   {# ==============> AUTHENTICATION <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="authentication">Authentication</h2>
-    <p>
-        <span class="highlighted"> Most API queries don't require registration: check our
-          <a href="#limits">access limits</a> section for more details.
-        </span>
-    </p>
-    <p>
-      Most API requests do not need to be authenticated. However, if requests are not authenticated, you may see
-      this response in results from the case endpoint with <code>full_case=true</code>:
-    </p>
-    <pre class="code-block">
+  <h2 class="subtitle" id="authentication">Authentication</h2>
+  <p>
+      <span class="highlighted"> Most API queries don't require registration: check our
+        <a href="#limits">access limits</a> section for more details.
+      </span>
+  </p>
+  <p>
+    Most API requests do not need to be authenticated. However, if requests are not authenticated, you may see
+    this response in results from the case endpoint with <code>full_case=true</code>:
+  </p>
+  <pre class="code-block">
 {
   "results": [
     {
@@ -142,58 +137,57 @@
     },
   ]
 }</pre>
-    <p>
-      In this example the response included a case from a non-whitelisted jurisdiction, and
-      <code>casebody.data</code> for the case is therefore blank, while <code>casebody.status</code> is
-      "error_auth_required".
-    </p>
-    <p>
-      To authenticate the request from code or the command line, you can provide an <code>Authorization</code>
-      header:
-    </p>
+  <p>
+    In this example the response included a case from a non-whitelisted jurisdiction, and
+    <code>casebody.data</code> for the case is therefore blank, while <code>casebody.status</code> is
+    "error_auth_required".
+  </p>
+  <p>
+    To authenticate the request from code or the command line, you can provide an <code>Authorization</code>
+    header:
+  </p>
 
-    <pre class="code-block">curl -H "Authorization: Token abcd12345" "{% api_url "casemetadata-list" %}?full_case=true"</pre>
-    <p>
-      While you are <a href="{% url "login" %}">logged into this website</a>, all requests through the API
-      browser will be authenticated automatically.
-    </p>
-  </div>
+  <pre class="code-block">curl -H "Authorization: Token abcd12345" "{% api_url "casemetadata-list" %}?full_case=true"</pre>
+  <p>
+    While you are <a href="{% url "login" %}">logged into this website</a>, all requests through the API
+    browser will be authenticated automatically.
+  </p>
+
   {# ==============> DATA FORMATS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="dataformats">Case Text Formats</h2>
-    <p>
-      <span class="highlighted">Both of these parameters must be used in conjunction with the
-      <code>full_case=true</code>parameter.</span>
-    </p>
-    <p>
-      CAPAPI returns case text in three formats: text (default), XML, or HTML. The choice of format is either
-      controlled by the <code>body_format</code>, which will return the body and metadata in a JSON container,
-      or the <code>format</code> parameter which will return the case by itself. Only one of these parameters
-      should be specified at a time.
-    </p>
-    <p>
-      The non-default behavior, and simpler of the two is the <code>format</code> parameter, which accepts a
-      value of either <code>html</code> or <code>xml</code>. If you specify <code>html</code>, CAPAPI returns a
-      lightly styled, standalone HTML page. If you specify <code>xml</code> CAPAPI returns the entire original
-      XML document with intact METS, PREMIS and structural metadata.
-    </p>
+  <h2 class="subtitle" id="dataformats">Case Text Formats</h2>
+  <p>
+    <span class="highlighted">Both of these parameters must be used in conjunction with the
+    <code>full_case=true</code>parameter.</span>
+  </p>
+  <p>
+    CAPAPI returns case text in three formats: text (default), XML, or HTML. The choice of format is either
+    controlled by the <code>body_format</code>, which will return the body and metadata in a JSON container,
+    or the <code>format</code> parameter which will return the case by itself. Only one of these parameters
+    should be specified at a time.
+  </p>
+  <p>
+    The non-default behavior, and simpler of the two is the <code>format</code> parameter, which accepts a
+    value of either <code>html</code> or <code>xml</code>. If you specify <code>html</code>, CAPAPI returns a
+    lightly styled, standalone HTML page. If you specify <code>xml</code> CAPAPI returns the entire original
+    XML document with intact METS, PREMIS and structural metadata.
+  </p>
 
-    <p>
-    This is what you can expect from different format specifications using the <code>body_format</code>
-    parameter.
-    </p>
-    <dl>
-      <dt>Text Format (default)</dt>
-      <dd class="example-link">
-        <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true">
-        {% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true
-        </a>
-      </dd>
-      <dd>
-        <p>
-          The default text format is best for natural language processing. Example response data:
-        </p>
-        <pre class="code-block">
+  <p>
+  This is what you can expect from different format specifications using the <code>body_format</code>
+  parameter.
+  </p>
+  <dl>
+    <dt>Text Format (default)</dt>
+    <dd class="example-link">
+      <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true">
+      {% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true
+      </a>
+    </dd>
+    <dd>
+      <p>
+        The default text format is best for natural language processing. Example response data:
+      </p>
+      <pre class="code-block">
 "data": {
       "head_matter": "Fifth District\n(No. 70-17;\nThe People of the State of Illinois ...",
       "opinions": [
@@ -213,1145 +207,1128 @@
       ]
   }
 }</pre>
-        <p>
-          In this example, <code>"head_matter"</code> is a string representing all text printed in the volume before
-          the text prepared by judges. <code>"opinions"</code> is an array containing a dictionary for each opinion
-          in the case. <code>"judges"</code>, <code>"parties"</code>, and <code>"attorneys"</code> are
-          particular substrings from <code>"head_matter"</code> that we believe to refer to entities involved with the case.
-        </p>
-      </dd>
+      <p>
+        In this example, <code>"head_matter"</code> is a string representing all text printed in the volume before
+        the text prepared by judges. <code>"opinions"</code> is an array containing a dictionary for each opinion
+        in the case. <code>"judges"</code>, <code>"parties"</code>, and <code>"attorneys"</code> are
+        particular substrings from <code>"head_matter"</code> that we believe to refer to entities involved with the case.
+      </p>
+    </dd>
 
-      <dt>XML Format</dt>
-        <dd class="example-link">
-          <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=xml" %}">
-          {% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=xml"
-        </a>
-      </dd>
-      <dd>
-        <p>
-          The XML format is best if your analysis requires more information about pagination, formatting, or
-          page layout. It contains a superset of the information available from body_format=text, but requires
-          parsing XML data. Example response data:
-        </p>
-        <pre class="code-block">{% filter force_escape %}
-"data": "<?xml version='1.0' encoding='utf-8'?>\n<casebody ..."{% endfilter %}</pre>
-      </dd>
-
-      <dt>HTML Format</dt>
+    <dt>XML Format</dt>
       <dd class="example-link">
-        <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html">
-        {% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html"
-        </a></dd>
-      <dd>
-        <p>
-          The HTML format is best if you want to show readable, formatted caselaw to humans. It represents a
-          best-effort attempt to transform our XML-formatted data to semantic HTML ready for CSS formatting of your
-          choice. Example response data:
-        </p>
-        <pre class="code-block">{% filter force_escape %}
+        <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=xml" %}">
+        {% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=xml"
+      </a>
+    </dd>
+    <dd>
+      <p>
+        The XML format is best if your analysis requires more information about pagination, formatting, or
+        page layout. It contains a superset of the information available from body_format=text, but requires
+        parsing XML data. Example response data:
+      </p>
+      <pre class="code-block">{% filter force_escape %}
+"data": "<?xml version='1.0' encoding='utf-8'?>\n<casebody ..."{% endfilter %}</pre>
+    </dd>
+
+    <dt>HTML Format</dt>
+    <dd class="example-link">
+      <a href="{% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html">
+      {% api_url "casemetadata-list" %}?jurisdiction=ill&full_case=true&body_format=html"
+      </a></dd>
+    <dd>
+      <p>
+        The HTML format is best if you want to show readable, formatted caselaw to humans. It represents a
+        best-effort attempt to transform our XML-formatted data to semantic HTML ready for CSS formatting of your
+        choice. Example response data:
+      </p>
+      <pre class="code-block">{% filter force_escape %}
 "data": "<section class=\"casebody\" data-firstpage=\"538\" data-lastpage=\"543\"> ..."{% endfilter %}</pre>
-      </dd>
-    </dl>
-  </div>
+    </dd>
+  </dl>
 
   {# ====> PAGINATION <==== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="pagination">Pagination and Counts</h2>
-    <p>
-      Queries by default return 100 results per page, but you may request a smaller number using the
-      <code>page_size</code> parameter:
-    </p>
-    <pre class="code-block">curl "{% api_url "casemetadata-list" %}?jurisdiction=ill&page_size=1"</pre>
-    <p>
-      We use <a href="#def-cursor">cursor</a>-based pagination, meaning we keep track of where you are in the
-      results set on the server, and you can access each page of results by using the link in the
-      <code>"previous"</code> and <code>"next"</code> keys of the response:
-    </p>
-    <pre class="code-block">{% filter force_escape %}
+  <h2 class="subtitle" id="pagination">Pagination and Counts</h2>
+  <p>
+    Queries by default return 100 results per page, but you may request a smaller number using the
+    <code>page_size</code> parameter:
+  </p>
+  <pre class="code-block">curl "{% api_url "casemetadata-list" %}?jurisdiction=ill&page_size=1"</pre>
+  <p>
+    We use <a href="#def-cursor">cursor</a>-based pagination, meaning we keep track of where you are in the
+    results set on the server, and you can access each page of results by using the link in the
+    <code>"previous"</code> and <code>"next"</code> keys of the response:
+  </p>
+  <pre class="code-block">{% filter force_escape %}
 {
   "count": 183149,
   "next": "{% api_url "casemetadata-list" %}?cursor=cD0xODMyLTEyLTAx",
   "previous": "{% api_url "casemetadata-list" %}?cursor=bz0xMCZyPTEmcD0xODI4LTEyLTAx"
   ...
 }{% endfilter %}</pre>
-    <p>
-      Responses also include a <code>"count"</code> key. Occasionally this may show <code>"count": null</code>,
-      indicating that the total count for a particular query has not yet been calculated.
-    </p>
-  </div>
+  <p>
+    Responses also include a <code>"count"</code> key. Occasionally this may show <code>"count": null</code>,
+    indicating that the total count for a particular query has not yet been calculated.
+  </p>
 
   {# ==============> ACCESS LIMITS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="limits">Access Limits</h2>
-    <p>
-      The agreement with our project partner, <a href="http://ravellaw.com">Ravel</a>, requires us to limit
-      access to the full text of cases to no more than 500 cases per person, per day. This limitation does not
-      apply to <a href="#def-researchers">researchers</a> who agree to certain restrictions on use and redistribution.
-      Nor does this restriction apply to cases issued in <a href="#def-jurisdiction">jurisdictions</a> that make
-      their newly issued cases freely available online in an authoritative, citable, machine-readable format. We call
-      these <a href="#def-whitelisted">whitelisted</a> jurisdictions. Currently, Illinois and Arkansas are the
-      only whitelisted jurisdictions.
-    </p>
-    <p>
-      We would love to whitelist more jurisdictions! If you are involved in US case publishing at the state or federal
-      level, we'd love to talk to you about making the transition to digital-first publishing. Please
-      <a href="{% url "contact" %}">contact us</a> and introduce yourself!
-    </p>
-    <p>
-      If you qualify for unlimited access as a research scholar, you can request a research agreement by
-      <a href="{% url "register" %}">creating an account</a>
-      and then <a href="{% url "user-details" %}">visiting your account page</a>.
-    </p>
-    <p>
-      In addition, under our agreement with Ravel (now owned by Lexis-Nexis), Ravel must negotiate in good faith
-      to provide bulk access to anyone seeking to make commercial use of this data.
-      <a href="http://info.ravellaw.com/contact-us-form">Click here to contact Ravel for more information</a>,
-      or <a href="{% url "contact" %}">contact us</a> and we will put you in touch with Ravel.
-    </p>
-    <dl>
-      <dt>
-        <a id="def-unregistered-user"></a>
-        Unregistered Users
-      </dt>
-      <dd>
-        <ul>
-          <li class="list-group-item">Access all metadata</li>
-          <li class="list-group-item">Unlimited API access to all cases from
-            <a href="#def-whitelisted">whitelisted</a> jurisdictions
-          </li>
-          <li class="list-group-item">Bulk Download all cases from
-            <a href="#def-whitelisted">whitelisted</a> jurisdictions
-          </li>
-        </ul>
-      </dd>
+  <h2 class="subtitle" id="limits">Access Limits</h2>
+  <p>
+    The agreement with our project partner, <a href="http://ravellaw.com">Ravel</a>, requires us to limit
+    access to the full text of cases to no more than 500 cases per person, per day. This limitation does not
+    apply to <a href="#def-researchers">researchers</a> who agree to certain restrictions on use and redistribution.
+    Nor does this restriction apply to cases issued in <a href="#def-jurisdiction">jurisdictions</a> that make
+    their newly issued cases freely available online in an authoritative, citable, machine-readable format. We call
+    these <a href="#def-whitelisted">whitelisted</a> jurisdictions. Currently, Illinois and Arkansas are the
+    only whitelisted jurisdictions.
+  </p>
+  <p>
+    We would love to whitelist more jurisdictions! If you are involved in US case publishing at the state or federal
+    level, we'd love to talk to you about making the transition to digital-first publishing. Please
+    <a href="{% url "contact" %}">contact us</a> and introduce yourself!
+  </p>
+  <p>
+    If you qualify for unlimited access as a research scholar, you can request a research agreement by
+    <a href="{% url "register" %}">creating an account</a>
+    and then <a href="{% url "user-details" %}">visiting your account page</a>.
+  </p>
+  <p>
+    In addition, under our agreement with Ravel (now owned by Lexis-Nexis), Ravel must negotiate in good faith
+    to provide bulk access to anyone seeking to make commercial use of this data.
+    <a href="http://info.ravellaw.com/contact-us-form">Click here to contact Ravel for more information</a>,
+    or <a href="{% url "contact" %}">contact us</a> and we will put you in touch with Ravel.
+  </p>
+  <dl>
+    <dt>
+      <a id="def-unregistered-user"></a>
+      Unregistered Users
+    </dt>
+    <dd>
+      <ul>
+        <li class="list-group-item">Access all metadata</li>
+        <li class="list-group-item">Unlimited API access to all cases from
+          <a href="#def-whitelisted">whitelisted</a> jurisdictions
+        </li>
+        <li class="list-group-item">Bulk Download all cases from
+          <a href="#def-whitelisted">whitelisted</a> jurisdictions
+        </li>
+      </ul>
+    </dd>
 
-      <dt>
-        <a id="def-registered-user"></a>
-        Registered Users
-      </dt>
-      <dd>
-        <ul>
-          <li class="list-group-item">Access all metadata</li>
-          <li class="list-group-item">Unlimited API access to all cases from
-            <a href="#def-whitelisted">whitelisted</a> jurisdictions
-          </li>
-          <li class="list-group-item">Access to 500 cases per day from non-<a
-              href="#def-whitelisted">whitelisted</a> jurisdictions
-          </li>
-          <li class="list-group-item">Bulk Download all cases from
-            <a href="#def-whitelisted">whitelisted</a> jurisdictions
-          </li>
-        </ul>
-      </dd>
+    <dt>
+      <a id="def-registered-user"></a>
+      Registered Users
+    </dt>
+    <dd>
+      <ul>
+        <li class="list-group-item">Access all metadata</li>
+        <li class="list-group-item">Unlimited API access to all cases from
+          <a href="#def-whitelisted">whitelisted</a> jurisdictions
+        </li>
+        <li class="list-group-item">Access to 500 cases per day from non-<a
+            href="#def-whitelisted">whitelisted</a> jurisdictions
+        </li>
+        <li class="list-group-item">Bulk Download all cases from
+          <a href="#def-whitelisted">whitelisted</a> jurisdictions
+        </li>
+      </ul>
+    </dd>
 
-      <dt>
-        <a id="def-researchers"></a>
-        Researchers
-      </dt>
-      <dd>
-        <ul>
-          <li class="list-group-item">Access all metadata</li>
-          <li class="list-group-item">Unlimited API access to all cases</li>
-          <li class="list-group-item">Bulk Downloads from all jurisdictions</li>
-        </ul>
-      </dd>
+    <dt>
+      <a id="def-researchers"></a>
+      Researchers
+    </dt>
+    <dd>
+      <ul>
+        <li class="list-group-item">Access all metadata</li>
+        <li class="list-group-item">Unlimited API access to all cases</li>
+        <li class="list-group-item">Bulk Downloads from all jurisdictions</li>
+      </ul>
+    </dd>
 
-      <dt>
-        <a id="def-commerical-user"></a>
-        Commercial Users
-      </dt>
-      <dd>
-        <a href="http://info.ravellaw.com/contact-us-form">Click here to contact Ravel for more
-          information.</a>
-      </dd>
-    </dl>
-  </div>
+    <dt>
+      <a id="def-commerical-user"></a>
+      Commercial Users
+    </dt>
+    <dd>
+      <a href="http://info.ravellaw.com/contact-us-form">Click here to contact Ravel for more
+        information.</a>
+    </dd>
+  </dl>
 
   {# ==============> EXAMPLES <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="examples">
-      Usage Examples
-    </h2>
-    <p>
-      This is a non-exhaustive set of examples intended to orient new users. The
-      <a href="#endpoints">endpoints</a> section contains more comprehensive documentation about the URLs and
-      their parameters.
-    </p>
-    <dl>
-      {# ====> single case <==== #}
-      <dt>
-        Retrieve a single case by ID
-      </dt>
-      <dd class="example-link">
-        <a href="{% api_url "casemetadata-detail" case_id %}">
-          {% api_url "casemetadata-detail" case_id %}</a>
-      </dd>
-      <dd>
-        <p>
-          This example uses the <a href="#endpoint-case">single case</a> endpoint, and will retrieve the
-          metadata for a single case.
-        </p>
-        <h5 class="list-header">Modification with Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header">Standalone HTML-formatted Case</h5>
-            <ul>
-              <li class="example-mod-url"><a href="{% api_url "casemetadata-detail" case_id %}?full_case=true&format=html">
-                {% api_url "casemetadata-detail" case_id %}?full_case=true&format=html</a>
-              </li>
-              <li class="example-mod-description">This will return a lightly styled, standalone HTML
-                representation of the case with no accompanying metadata.
-              </li>
-            </ul>
-          </li>
-        </ul>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header">Plain Text Case in JSON container with metadata</h5>
-            <ul>
-              <li class="example-mod-url"><a href="{% api_url "casemetadata-detail" case_id %}">
-                {% api_url "casemetadata-detail" case_id %}</a>
-              </li>
-              <li class="example-mod-description">This will return a lightly styled, standalone HTML
-                representation of the case with no accompanying metadata.
-              </li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header">Raw original XML document, with METS data</h5>
-            <ul>
-              <li class="example-mod-url">
-                <a href="{% api_url "casemetadata-detail" case_id %}?full_case=true&body_format=xml">
-                  {% api_url "casemetadata-detail" case_id %}?full_case=true&format=xml
-                </a>
-              </li>
-              <li class="example-mod-description">To get the document by itself, without the JSON enclosure and
-                metadata, use the <code>format</code> parameter. Set it to HTML and get a display-ready,
-                standalone HTML document.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
-      {# ====> filter cases <==== #}
+  <h2 class="subtitle" id="examples">
+    Usage Examples
+  </h2>
+  <p>
+    This is a non-exhaustive set of examples intended to orient new users. The
+    <a href="#endpoints">endpoints</a> section contains more comprehensive documentation about the URLs and
+    their parameters.
+  </p>
+  <dl>
+    {# ====> single case <==== #}
+    <dt>
+      Retrieve a single case by ID
+    </dt>
+    <dd class="example-link">
+      <a href="{% api_url "casemetadata-detail" case_id %}">
+        {% api_url "casemetadata-detail" case_id %}</a>
+    </dd>
+    <dd>
+      <p>
+        This example uses the <a href="#endpoint-case">single case</a> endpoint, and will retrieve the
+        metadata for a single case.
+      </p>
+      <h5 class="list-header">Modification with Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header">Standalone HTML-formatted Case</h5>
+          <ul>
+            <li class="example-mod-url"><a href="{% api_url "casemetadata-detail" case_id %}?full_case=true&format=html">
+              {% api_url "casemetadata-detail" case_id %}?full_case=true&format=html</a>
+            </li>
+            <li class="example-mod-description">This will return a lightly styled, standalone HTML
+              representation of the case with no accompanying metadata.
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header">Plain Text Case in JSON container with metadata</h5>
+          <ul>
+            <li class="example-mod-url"><a href="{% api_url "casemetadata-detail" case_id %}">
+              {% api_url "casemetadata-detail" case_id %}</a>
+            </li>
+            <li class="example-mod-description">This will return a lightly styled, standalone HTML
+              representation of the case with no accompanying metadata.
+            </li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header">Raw original XML document, with METS data</h5>
+          <ul>
+            <li class="example-mod-url">
+              <a href="{% api_url "casemetadata-detail" case_id %}?full_case=true&body_format=xml">
+                {% api_url "casemetadata-detail" case_id %}?full_case=true&format=xml
+              </a>
+            </li>
+            <li class="example-mod-description">To get the document by itself, without the JSON enclosure and
+              metadata, use the <code>format</code> parameter. Set it to HTML and get a display-ready,
+              standalone HTML document.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
+    {# ====> filter cases <==== #}
 
-      <dt>
-        Retrieve a list of cases using a metadata filter
-      </dt>
-      <dd class="example-link">
-        <a href="{% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}">
-          {% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}
-        </a>
-      </dd>
-      <dd>
-        <p>
-          This example uses the <a href="#endpoint-cases">cases</a> endpoint, and will retrieve every case with
-          the citation {{ case_metadata.citations.0.cite }}.
-        </p>
-        <p>
-          There are many parameters with which you can filter the cases result. Check the
-          <a href="#endpoint-cases">cases</a> endpoint documentation for a complete list of the parameters, and
-          what values they accept.
-        </p>
-        <h5 class="list-header">Modification with Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header">Add a date range filter</h5>
-            <ul>
-              <li class="example-mod-url">
-                <a href="{% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-12-30">
-                  {% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-06-15
-                </a>
-              </li>
-              <li class="example-mod-description">You can combine any of these parameters to refine your search.
-                Here, we have the same search as in the first example, but will only receive results from within
-                the specified dates.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
-    </dl>
-    <dl>
-      {# ====> filter cases <==== #}
-      <dt>
-        Simple Full-Text Search
-      </dt>
-      <dd class="example-link">
-        <a href="{% api_url "casemetadata-list" %}?search=insurance">
-          {% api_url "casemetadata-list" %}?search=insurance
-        </a>
-      </dd>
-      <dd>
-        <p>
-          This example performs a simple full-text case search which finds all cases containing the word
-          "insurance."
-        </p>
-        <p>
-          There are many parameters with which you can filter the cases result. Check the
-          <a href="#endpoint-cases">cases</a> endpoint documentation for a complete list of the parameters, and
-          what values they accept.
-        </p>
-        <h5 class="list-header">Modification with Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header">Add Search Term</h5>
-            <ul>
-              <li class="example-mod-url">
-                <a href="{% api_url "casemetadata-list" %}?search=insurance Peoria">
-                  {% api_url "casemetadata-list" %}?search=insurance Peoria
-                </a>
-              </li>
-              <li class="example-mod-description">You can narrow your search results by adding terms, separated
-                by spaces. This search will only include cases that contain both "insurance" and Peoria.
-              </li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header">Filter Search With Metadata</h5>
-            <ul>
-              <li class="example-mod-url">
-                <a href="{% api_url "casemetadata-list" %}?search=insurance Peoria&jurisdiction=ill">
-                  {% api_url "casemetadata-list" %}?search=insurance Peoria&jurisdiction=ill
-                </a>
-              </li>
-              <li class="example-mod-description">These queries can be filtered using other metadata fields.
-                This query will perform the prior search while limiting the query to the Illinois jurisdiction.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
-    </dl>
+    <dt>
+      Retrieve a list of cases using a metadata filter
+    </dt>
+    <dd class="example-link">
+      <a href="{% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}">
+        {% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}
+      </a>
+    </dd>
+    <dd>
+      <p>
+        This example uses the <a href="#endpoint-cases">cases</a> endpoint, and will retrieve every case with
+        the citation {{ case_metadata.citations.0.cite }}.
+      </p>
+      <p>
+        There are many parameters with which you can filter the cases result. Check the
+        <a href="#endpoint-cases">cases</a> endpoint documentation for a complete list of the parameters, and
+        what values they accept.
+      </p>
+      <h5 class="list-header">Modification with Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header">Add a date range filter</h5>
+          <ul>
+            <li class="example-mod-url">
+              <a href="{% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-12-30">
+                {% api_url "casemetadata-list" %}?cite={{ case_metadata.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-06-15
+              </a>
+            </li>
+            <li class="example-mod-description">You can combine any of these parameters to refine your search.
+              Here, we have the same search as in the first example, but will only receive results from within
+              the specified dates.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
+  </dl>
+  <dl>
+    {# ====> filter cases <==== #}
+    <dt>
+      Simple Full-Text Search
+    </dt>
+    <dd class="example-link">
+      <a href="{% api_url "casemetadata-list" %}?search=insurance">
+        {% api_url "casemetadata-list" %}?search=insurance
+      </a>
+    </dd>
+    <dd>
+      <p>
+        This example performs a simple full-text case search which finds all cases containing the word
+        "insurance."
+      </p>
+      <p>
+        There are many parameters with which you can filter the cases result. Check the
+        <a href="#endpoint-cases">cases</a> endpoint documentation for a complete list of the parameters, and
+        what values they accept.
+      </p>
+      <h5 class="list-header">Modification with Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header">Add Search Term</h5>
+          <ul>
+            <li class="example-mod-url">
+              <a href="{% api_url "casemetadata-list" %}?search=insurance Peoria">
+                {% api_url "casemetadata-list" %}?search=insurance Peoria
+              </a>
+            </li>
+            <li class="example-mod-description">You can narrow your search results by adding terms, separated
+              by spaces. This search will only include cases that contain both "insurance" and Peoria.
+            </li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header">Filter Search With Metadata</h5>
+          <ul>
+            <li class="example-mod-url">
+              <a href="{% api_url "casemetadata-list" %}?search=insurance Peoria&jurisdiction=ill">
+                {% api_url "casemetadata-list" %}?search=insurance Peoria&jurisdiction=ill
+              </a>
+            </li>
+            <li class="example-mod-description">These queries can be filtered using other metadata fields.
+              This query will perform the prior search while limiting the query to the Illinois jurisdiction.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
+  </dl>
 
 
-    {# ====> get reporters for a jurisdiction <==== #}
-    <dl>
-      <dt>
-        Get all reporters in a jurisdiction
-      </dt>
-      <dd class="example-link">
-        <a href="{% api_url "reporter-list" %}?jurisdictions=ark">
-          {% api_url "reporter-list" %}?jurisdictions=ark
-        </a>
-      </dd>
-      <dd>
-        <p>
-          This example uses the <a href="#endpoint-reporters">reporter</a> endpoint, and will retrieve all
-          reporters in Arkansas.
-        </p>
-      </dd>
-    </dl>
-  </div>
+  {# ====> get reporters for a jurisdiction <==== #}
+  <dl>
+    <dt>
+      Get all reporters in a jurisdiction
+    </dt>
+    <dd class="example-link">
+      <a href="{% api_url "reporter-list" %}?jurisdictions=ark">
+        {% api_url "reporter-list" %}?jurisdictions=ark
+      </a>
+    </dd>
+    <dd>
+      <p>
+        This example uses the <a href="#endpoint-reporters">reporter</a> endpoint, and will retrieve all
+        reporters in Arkansas.
+      </p>
+    </dd>
+  </dl>
 
   {# ==============> ENDPOINTS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="endpoints">
-      Endpoints
-    </h2>
-    <dl>
+  <h2 class="subtitle" id="endpoints">
+    Endpoints
+  </h2>
+  <dl>
 
-      {# ==============> BASE <============== #}
-      <a id="endpoint-base"></a>
-      <dt>
-        API Base
-      </dt>
-      <dd class="endpoint-link">
-        <a class="endpoint-link" href="{% api_url "api-root" %}">{% api_url "api-root" %}v1/</a>
-      </dd>
-      <dd>
-        <p class="endpoint-description">
-          This is the base <a href="#def-endpoint">endpoint</a> of CAPAPI. It just lists all of the available
-          <a href="#def-endpoint">endpoints</a>.
-        </p>
-      </dd>
-
-      {# ==============> CASES <============== #}
-      <dt>
-        <a id="endpoint-cases"></a>
-        Case Browse/Search Endpoint
-      </dt>
-      <dd class="endpoint-link">
-        <a href="{% api_url "casemetadata-list" %}">{% api_url "casemetadata-list" %}</a>
-      </dd>
-      <dd>
-        <p class="endpoint-description">
-          This is the primary endpoint; you use it to browse, search for, and retrieve cases. If you know the
-          numeric ID of your case in our system, you can append it to the <a href="#def-path">path</a> to
-          retrieve a <a href="#endpoint-case">single case</a>.
-        </p>
-        <h5 class="list-header">Endpoint Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">name_abbreviation</code></h5>
-            <ul>
-              <li class="param-data-type"> An arbitrary <a href="#def-string">string</a></li>
-              <li class="param-description"> e.g. <code>People v. Smith</code></li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">decision_date_min</code></h5>
-            <ul>
-              <li class="param-data-type"><code>YYYY-MM-DD</code></li>
-              <li class="param-description"></li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">decision_date_max</code></h5>
-            <ul>
-              <li class="param-data-type"><code>YYYY-MM-DD</code></li>
-              <li class="param-description"></li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">docket_number</code></h5>
-            <ul>
-              <li class="param-data-type"> An arbitrary <a href="#def-string">string</a></li>
-              <li class="param-description"></li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">citation</code></h5>
-            <ul>
-              <li class="param-data-type"> e.g. <code>1 Ill. 21</code></li>
-              <li class="param-description"></li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">reporter</code></h5>
-            <ul>
-              <li class="param-data-type"> integer</li>
-              <li class="param-description"> a <a href="#endpoint-reporters">reporter</a> id</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">court</code></h5>
-            <ul>
-              <li class="param-data-type"><a href="#def-slug">slug</a></li>
-              <li class="param-description"> a <a href="#endpoint-courts">court</a> <a href="#def-slug">slug</a>
-              </li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">court_id</code></h5>
-            <ul>
-              <li class="param-data-type">integer</li>
-              <li class="param-description"> a <a href="#endpoint-courts">court</a> id</li>
-              </li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">jurisdiction</code></h5>
-            <ul>
-              <li class="param-data-type"><a href="#def-slug">slug</a></li>
-              <li class="param-description"> a <a href="#endpoint-jurisdictions">jurisdiction</a> <a
-                  href="#def-slug">slug</a></li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">search</code></h5>
-            <ul>
-              <li class="param-data-type"> An arbitrary <a href="#def-string">string</a></li>
-              <li class="param-description"> A full-text search query</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 id="def-cursor" class="list-header"><code class="parameter-name">cursor</code></h5>
-            <ul>
-              <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
-              <li class="param-description">
-                This field contains a value that we generate which will bring you to a specific page of results.
-              </li>
-            </ul>
-          </li>
-        </ul>
-
-
-      </dd>
-
-      {# ==============> CASE <============== #}
-      <dt>
-        <a id="endpoint-case"></a>
-        Single Case Endpoint
-      </dt>
-      <dd class="endpoint-link">
-        <a href="{% api_url "casemetadata-detail" case_id %}">{% api_url "casemetadata-detail" case_id %}</a>
-      </dd>
-      <dd>
-        <p class="endpoint-description">
-          This is the way to retrieve a single case.
-        </p>
-        <h5 class="list-header">Endpoint Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">full_case</code></h5>
-            <ul>
-              <li class="param-data-type"><code>true</code> or <code>false</code></li>
-              <li class="param-description">
-                When set to <code>true</code>, this parameter loads the case body.
-                It is required for setting both <code>body_format</code> and <code>format</code>.
-              </li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">body_format</code></h5>
-            <ul>
-              <li class="param-data-type"><code>html</code> or <code>xml</code></li>
-              <li class="param-description">
-                This will return a JSON enclosure with metadata, and a field containing the case in XML or HTML.
-              </li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">format</code></h5>
-            <ul>
-              <li class="param-data-type"><code>html</code> or <code>xml</code></li>
-              <li class="param-description">
-                This will return the case in HTML or its original XML with no JSON enclosure or metadata.
-              </li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
-            <ul>
-              <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
-              <li class="param-description">
-                This field contains a value that we generate which will bring you to a specific page of results.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
-      <p>
-        Here's what you can expect when you request a single case. Everything under
-        <code><span class="code-example-casebody-section">casebody</span></code> is only returned if
-        <code>full_case=true</code> is set. In the <a href="#endpoint-cases">cases</a> endpoint, you'd get a
-        list of these in a JSON object which also included pagination information and result counts.
+    {# ==============> BASE <============== #}
+    <a id="endpoint-base"></a>
+    <dt>
+      API Base
+    </dt>
+    <dd class="endpoint-link">
+      <a class="endpoint-link" href="{% api_url "api-root" %}">{% api_url "api-root" %}v1/</a>
+    </dd>
+    <dd>
+      <p class="endpoint-description">
+        This is the base <a href="#def-endpoint">endpoint</a> of CAPAPI. It just lists all of the available
+        <a href="#def-endpoint">endpoints</a>.
       </p>
-      <pre class="code-block">{
-    "id": <span class="json-data-type">integer</span>
-    "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
-    "name": <span class="json-data-type"><a href="#def-string">string</a></span>,
-    "name_abbreviation": <span class="json-data-type"><a href="#def-string">string</a></span>,
-    "decision_date": <span class="json-data-type">YYYY-MM-DD</span>,
-    "docket_number": <span class="json-data-type"><a href="#def-string">string</a></span>,
-    "first_page": <span class="json-data-type"><a href="#def-string">string</a> (generally a number)</span>,
-    "last_page": <span class="json-data-type"><a href="#def-string">string</a> (generally a number)</span>,
-    "citations": [
-        {
-            "type": <span class="json-data-type">"official" or "parallel"</span>,
-            "cite": <span class="json-data-type"><a href="#def-string">string</a></span>
-        }
-    ],
-    "volume": {
-        "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
-        "volume_number": <span class="json-data-type"><a href="#def-string">string</a> (generally a number)</span>
-    },
-    "reporter": {
-        "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
-        "full_name": <span class="json-data-type"><a href="#def-string">string</a></span>
-    },
-    "court": {
-        "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
-        "id": <span class="json-data-type">integer</span>,
-        "slug": <span class="json-data-type"><a href="#def-slug">slug</a></span>,
-        "name": <span class="json-data-type"><a href="#def-string">string</a></span>,
-        "name_abbreviation": <span class="json-data-type"><a href="#def-string">string</a></span>
-    },
-    "jurisdiction": {
-        "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
-        "id": <span class="json-data-type">integer</span>,
-        "slug": <span class="json-data-type"><a href="#def-slug">slug</a></span>,
-        "name": <span class="json-data-type"><a href="#def-string">string</a></span>,
-        "name_long": <span class="json-data-type"><a href="#def-string">string</a></span>,
-        "whitelisted": <span class="json-data-type">"true" or "false"</span>
-    },
-    <span class="code-example-casebody-section">
-    "casebody": {
-        "data": {
-            "judges": [],
-            "head_matter": <span class="json-data-type"><a href="#def-string">string</a></span>
-            "attorneys": [
+    </dd>
+
+    {# ==============> CASES <============== #}
+    <dt>
+      <a id="endpoint-cases"></a>
+      Case Browse/Search Endpoint
+    </dt>
+    <dd class="endpoint-link">
+      <a href="{% api_url "casemetadata-list" %}">{% api_url "casemetadata-list" %}</a>
+    </dd>
+    <dd>
+      <p class="endpoint-description">
+        This is the primary endpoint; you use it to browse, search for, and retrieve cases. If you know the
+        numeric ID of your case in our system, you can append it to the <a href="#def-path">path</a> to
+        retrieve a <a href="#endpoint-case">single case</a>.
+      </p>
+      <h5 class="list-header">Endpoint Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">name_abbreviation</code></h5>
+          <ul>
+            <li class="param-data-type"> An arbitrary <a href="#def-string">string</a></li>
+            <li class="param-description"> e.g. <code>People v. Smith</code></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">decision_date_min</code></h5>
+          <ul>
+            <li class="param-data-type"><code>YYYY-MM-DD</code></li>
+            <li class="param-description"></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">decision_date_max</code></h5>
+          <ul>
+            <li class="param-data-type"><code>YYYY-MM-DD</code></li>
+            <li class="param-description"></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">docket_number</code></h5>
+          <ul>
+            <li class="param-data-type"> An arbitrary <a href="#def-string">string</a></li>
+            <li class="param-description"></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">citation</code></h5>
+          <ul>
+            <li class="param-data-type"> e.g. <code>1 Ill. 21</code></li>
+            <li class="param-description"></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">reporter</code></h5>
+          <ul>
+            <li class="param-data-type"> integer</li>
+            <li class="param-description"> a <a href="#endpoint-reporters">reporter</a> id</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">court</code></h5>
+          <ul>
+            <li class="param-data-type"><a href="#def-slug">slug</a></li>
+            <li class="param-description"> a <a href="#endpoint-courts">court</a> <a href="#def-slug">slug</a>
+            </li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">court_id</code></h5>
+          <ul>
+            <li class="param-data-type">integer</li>
+            <li class="param-description"> a <a href="#endpoint-courts">court</a> id</li>
+            </li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">jurisdiction</code></h5>
+          <ul>
+            <li class="param-data-type"><a href="#def-slug">slug</a></li>
+            <li class="param-description"> a <a href="#endpoint-jurisdictions">jurisdiction</a> <a
+                href="#def-slug">slug</a></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">search</code></h5>
+          <ul>
+            <li class="param-data-type"> An arbitrary <a href="#def-string">string</a></li>
+            <li class="param-description"> A full-text search query</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 id="def-cursor" class="list-header"><code class="parameter-name">cursor</code></h5>
+          <ul>
+            <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
+            <li class="param-description">
+              This field contains a value that we generate which will bring you to a specific page of results.
+            </li>
+          </ul>
+        </li>
+      </ul>
+
+
+    </dd>
+
+    {# ==============> CASE <============== #}
+    <dt>
+      <a id="endpoint-case"></a>
+      Single Case Endpoint
+    </dt>
+    <dd class="endpoint-link">
+      <a href="{% api_url "casemetadata-detail" case_id %}">{% api_url "casemetadata-detail" case_id %}</a>
+    </dd>
+    <dd>
+      <p class="endpoint-description">
+        This is the way to retrieve a single case.
+      </p>
+      <h5 class="list-header">Endpoint Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">full_case</code></h5>
+          <ul>
+            <li class="param-data-type"><code>true</code> or <code>false</code></li>
+            <li class="param-description">
+              When set to <code>true</code>, this parameter loads the case body.
+              It is required for setting both <code>body_format</code> and <code>format</code>.
+            </li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">body_format</code></h5>
+          <ul>
+            <li class="param-data-type"><code>html</code> or <code>xml</code></li>
+            <li class="param-description">
+              This will return a JSON enclosure with metadata, and a field containing the case in XML or HTML.
+            </li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">format</code></h5>
+          <ul>
+            <li class="param-data-type"><code>html</code> or <code>xml</code></li>
+            <li class="param-description">
+              This will return the case in HTML or its original XML with no JSON enclosure or metadata.
+            </li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
+          <ul>
+            <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
+            <li class="param-description">
+              This field contains a value that we generate which will bring you to a specific page of results.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
+    <p>
+      Here's what you can expect when you request a single case. Everything under
+      <code><span class="code-example-casebody-section">casebody</span></code> is only returned if
+      <code>full_case=true</code> is set. In the <a href="#endpoint-cases">cases</a> endpoint, you'd get a
+      list of these in a JSON object which also included pagination information and result counts.
+    </p>
+    <pre class="code-block">{
+  "id": <span class="json-data-type">integer</span>
+  "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
+  "name": <span class="json-data-type"><a href="#def-string">string</a></span>,
+  "name_abbreviation": <span class="json-data-type"><a href="#def-string">string</a></span>,
+  "decision_date": <span class="json-data-type">YYYY-MM-DD</span>,
+  "docket_number": <span class="json-data-type"><a href="#def-string">string</a></span>,
+  "first_page": <span class="json-data-type"><a href="#def-string">string</a> (generally a number)</span>,
+  "last_page": <span class="json-data-type"><a href="#def-string">string</a> (generally a number)</span>,
+  "citations": [
+      {
+          "type": <span class="json-data-type">"official" or "parallel"</span>,
+          "cite": <span class="json-data-type"><a href="#def-string">string</a></span>
+      }
+  ],
+  "volume": {
+      "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
+      "volume_number": <span class="json-data-type"><a href="#def-string">string</a> (generally a number)</span>
+  },
+  "reporter": {
+      "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
+      "full_name": <span class="json-data-type"><a href="#def-string">string</a></span>
+  },
+  "court": {
+      "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
+      "id": <span class="json-data-type">integer</span>,
+      "slug": <span class="json-data-type"><a href="#def-slug">slug</a></span>,
+      "name": <span class="json-data-type"><a href="#def-string">string</a></span>,
+      "name_abbreviation": <span class="json-data-type"><a href="#def-string">string</a></span>
+  },
+  "jurisdiction": {
+      "url": <span class="json-data-type"><a href="#def-url">url</a></span>,
+      "id": <span class="json-data-type">integer</span>,
+      "slug": <span class="json-data-type"><a href="#def-slug">slug</a></span>,
+      "name": <span class="json-data-type"><a href="#def-string">string</a></span>,
+      "name_long": <span class="json-data-type"><a href="#def-string">string</a></span>,
+      "whitelisted": <span class="json-data-type">"true" or "false"</span>
+  },
+  <span class="code-example-casebody-section">
+  "casebody": {
+      "data": {
+          "judges": [],
+          "head_matter": <span class="json-data-type"><a href="#def-string">string</a></span>
+          "attorneys": [
+            <span class="json-data-type"><a href="#def-string">string</a></span>
+          ],
+          "opinions": [
+              {
+                  "type": <span class="json-data-type"><a href="#def-string">string</a></span>,
+                  "author": <span class="json-data-type"><a href="#def-string">string</a></span>,
+                  "text": <span class="json-data-type"><a href="#def-string">string</a></span>
+              }
+          ],
+          "parties": [
               <span class="json-data-type"><a href="#def-string">string</a></span>
-            ],
-            "opinions": [
-                {
-                    "type": <span class="json-data-type"><a href="#def-string">string</a></span>,
-                    "author": <span class="json-data-type"><a href="#def-string">string</a></span>,
-                    "text": <span class="json-data-type"><a href="#def-string">string</a></span>
-                }
-            ],
-            "parties": [
-                <span class="json-data-type"><a href="#def-string">string</a></span>
-            ]
-        },
-        "status": <span class="json-data-type">should be "ok"</span>
-    }
-    </span>
+          ]
+      },
+      "status": <span class="json-data-type">should be "ok"</span>
+  }
+  </span>
 }</pre>
-      {# ==============> reporters <============== #}
-      <dt>
-        <a id="endpoint-reporters"></a>
-        Reporters
-      </dt>
-      <dd>
-        <a class="endpoint-link" href="{% api_url "reporter-list" %}">{% api_url "reporter-list" %}</a>
-        <p class="endpoint-description">
-          This will return a list of reporter series.
-        </p>
-        <h5 class="list-header">Endpoint Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">full_name</code></h5>
-            <ul>
-              <li class="param-data-type"> e.g. Illinois Appellate Court Reports</li>
-              <li class="param-description"> the full reporter name</li>
-            </ul>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">short_name</code></h5>
-            <ul>
-              <li class="param-data-type"> e.g. Ill. App.</li>
-              <li class="param-description"> the abbreviated name for the reporter</li>
-            </ul>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">start_year</code></h5>
-            <ul>
-              <li class="param-data-type"> YYYY</li>
-              <li class="param-description"> the earliest year reported on in the series</li>
-            </ul>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">end_year</code></h5>
-            <ul>
-              <li class="param-data-type"> YYYY</li>
-              <li class="param-description"> the latest year reported on in the series</li>
-            </ul>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">volume_count</code></h5>
-            <ul>
-              <li class="param-data-type"> integer</li>
-              <li class="param-description"> filter on the number of volumes in a reporter
-                series
-              </li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
-            <ul>
-              <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
-              <li class="param-description">
-                This field contains a value that we generate which will bring you to a specific page of results.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
+    {# ==============> reporters <============== #}
+    <dt>
+      <a id="endpoint-reporters"></a>
+      Reporters
+    </dt>
+    <dd>
+      <a class="endpoint-link" href="{% api_url "reporter-list" %}">{% api_url "reporter-list" %}</a>
+      <p class="endpoint-description">
+        This will return a list of reporter series.
+      </p>
+      <h5 class="list-header">Endpoint Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">full_name</code></h5>
+          <ul>
+            <li class="param-data-type"> e.g. Illinois Appellate Court Reports</li>
+            <li class="param-description"> the full reporter name</li>
+          </ul>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">short_name</code></h5>
+          <ul>
+            <li class="param-data-type"> e.g. Ill. App.</li>
+            <li class="param-description"> the abbreviated name for the reporter</li>
+          </ul>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">start_year</code></h5>
+          <ul>
+            <li class="param-data-type"> YYYY</li>
+            <li class="param-description"> the earliest year reported on in the series</li>
+          </ul>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">end_year</code></h5>
+          <ul>
+            <li class="param-data-type"> YYYY</li>
+            <li class="param-description"> the latest year reported on in the series</li>
+          </ul>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">volume_count</code></h5>
+          <ul>
+            <li class="param-data-type"> integer</li>
+            <li class="param-description"> filter on the number of volumes in a reporter
+              series
+            </li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
+          <ul>
+            <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
+            <li class="param-description">
+              This field contains a value that we generate which will bring you to a specific page of results.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
 
-      {# ==============> jurisdictions <============== #}
-      <dt>
-        <a id="endpoint-jurisdictions"></a>
-        Jurisdictions
-      </dt>
-      <dd>
-        <a class="endpoint-link" href="{% api_url "jurisdiction-list" %}">{% api_url "jurisdiction-list" %}</a>
-        <p class="endpoint-description">
-          This will return a list of jurisdictions.
-        </p>
-        <h5 class="list-header">Endpoint Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">id</code></h5>
-            <ul>
-              <li class="param-data-type"> integer</li>
-              <li class="param-description"> get jurisdiction by ID</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">name</code></h5>
-            <ul>
-              <li class="param-data-type"> e.g. <code>Ill.</code></li>
-              <li class="param-description"> abbreviated jurisdiction name</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">name_long</code></h5>
-            <ul>
-              <li class="param-data-type"> e.g. <code>Illinois</code></li>
-              <li class="param-description"> full jurisdiction name</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">whitelisted</code></h5>
-            <ul>
-              <li class="param-data-type"><code>true</code> or <code>false</code></li>
-              <li class="param-description"> filter for <a href="#def-whitelisted">whitelisted</a> cases</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">slug</code></h5>
-            <ul>
-              <li class="param-data-type"> a <a href="#def-slug">slug</a></li>
-              <li class="param-description"> filter on the jurisdiction <a href="#def-slug">slug</a></li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
-            <ul>
-              <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
-              <li class="param-description">
-                This field contains a value that we generate which will bring you to a specific page of results.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
+    {# ==============> jurisdictions <============== #}
+    <dt>
+      <a id="endpoint-jurisdictions"></a>
+      Jurisdictions
+    </dt>
+    <dd>
+      <a class="endpoint-link" href="{% api_url "jurisdiction-list" %}">{% api_url "jurisdiction-list" %}</a>
+      <p class="endpoint-description">
+        This will return a list of jurisdictions.
+      </p>
+      <h5 class="list-header">Endpoint Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">id</code></h5>
+          <ul>
+            <li class="param-data-type"> integer</li>
+            <li class="param-description"> get jurisdiction by ID</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">name</code></h5>
+          <ul>
+            <li class="param-data-type"> e.g. <code>Ill.</code></li>
+            <li class="param-description"> abbreviated jurisdiction name</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">name_long</code></h5>
+          <ul>
+            <li class="param-data-type"> e.g. <code>Illinois</code></li>
+            <li class="param-description"> full jurisdiction name</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">whitelisted</code></h5>
+          <ul>
+            <li class="param-data-type"><code>true</code> or <code>false</code></li>
+            <li class="param-description"> filter for <a href="#def-whitelisted">whitelisted</a> cases</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">slug</code></h5>
+          <ul>
+            <li class="param-data-type"> a <a href="#def-slug">slug</a></li>
+            <li class="param-description"> filter on the jurisdiction <a href="#def-slug">slug</a></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
+          <ul>
+            <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
+            <li class="param-description">
+              This field contains a value that we generate which will bring you to a specific page of results.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
 
-      {# ==============> courts <============== #}
-      <dt>
-        <a id="endpoint-courts"></a>
-        Courts
-      </dt>
-      <dd>
-        <a class="endpoint-link" href="{% api_url "court-list" %}">{% api_url "court-list" %}</a>
-        <p class="endpoint-description">
-          This will return a list of courts.
-        </p>
-        <h5 class="list-header">Endpoint Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">id</code></h5>
-            <ul>
-              <li class="param-data-type"> integer</li>
-              <li class="param-description"> get courts by ID</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">slug</code></h5>
-            <ul>
-              <li class="param-data-type"> a <a href="#def-slug">slug</a></li>
-              <li class="param-description"> filter on the court <a href="#def-slug">slug</a></li>
-            </ul> 
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">name</code></h5>
-            <ul>
-              <li class="param-data-type"> e.g. <code>Illinois Appellate Court</code></li>
-              <li class="param-description"> full court name</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">name_abbreviation</code></h5>
-            <ul>
-              <li class="param-data-type">e.g. <code>Ill. App. Ct.</code></li>
-              <li class="param-description"> abbreviated court name</li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">jurisdiction</code></h5>
-            <ul>
-              <li class="param-data-type"><a href="#def-slug">slug</a></li>
-              <li class="param-description"><a href="#endpoint-jurisdictions">jurisdiction</a> <a
-                  href="#def-slug">slug</a></li>
-            </ul>
-          </li>
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
-            <ul>
-              <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
-              <li class="param-description">
-                This field contains a value that we generate which will bring you to a specific page of results.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
+    {# ==============> courts <============== #}
+    <dt>
+      <a id="endpoint-courts"></a>
+      Courts
+    </dt>
+    <dd>
+      <a class="endpoint-link" href="{% api_url "court-list" %}">{% api_url "court-list" %}</a>
+      <p class="endpoint-description">
+        This will return a list of courts.
+      </p>
+      <h5 class="list-header">Endpoint Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">id</code></h5>
+          <ul>
+            <li class="param-data-type"> integer</li>
+            <li class="param-description"> get courts by ID</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">slug</code></h5>
+          <ul>
+            <li class="param-data-type"> a <a href="#def-slug">slug</a></li>
+            <li class="param-description"> filter on the court <a href="#def-slug">slug</a></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">name</code></h5>
+          <ul>
+            <li class="param-data-type"> e.g. <code>Illinois Appellate Court</code></li>
+            <li class="param-description"> full court name</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">name_abbreviation</code></h5>
+          <ul>
+            <li class="param-data-type">e.g. <code>Ill. App. Ct.</code></li>
+            <li class="param-description"> abbreviated court name</li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">jurisdiction</code></h5>
+          <ul>
+            <li class="param-data-type"><a href="#def-slug">slug</a></li>
+            <li class="param-description"><a href="#endpoint-jurisdictions">jurisdiction</a> <a
+                href="#def-slug">slug</a></li>
+          </ul>
+        </li>
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
+          <ul>
+            <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
+            <li class="param-description">
+              This field contains a value that we generate which will bring you to a specific page of results.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
 
-      {# ==============> volumes <============== #}
-      <dt>
-        <a id="endpoint-volumes"></a>
-        Volumes
-      </dt>
-      <dd>
-        <a class="endpoint-link" href="{% api_url "volumemetadata-list" %}">{% api_url "volumemetadata-list" %}</a>
-        <p class="endpoint-description">
-          This will return a complete list of volumes.
-        </p>
-        <h5 class="list-header">Endpoint Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
-            <ul>
-              <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
-              <li class="param-description">
-                This field contains a value that we generate which will bring you to a specific page of results.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
+    {# ==============> volumes <============== #}
+    <dt>
+      <a id="endpoint-volumes"></a>
+      Volumes
+    </dt>
+    <dd>
+      <a class="endpoint-link" href="{% api_url "volumemetadata-list" %}">{% api_url "volumemetadata-list" %}</a>
+      <p class="endpoint-description">
+        This will return a complete list of volumes.
+      </p>
+      <h5 class="list-header">Endpoint Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
+          <ul>
+            <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
+            <li class="param-description">
+              This field contains a value that we generate which will bring you to a specific page of results.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
 
-      <dt>
-        <a id="endpoint-volumes"></a>
-        Citations
-      </dt>
-      <dd>
-        <a class="endpoint-link" href="{% api_url "citation-list" %}">{% api_url "citation-list" %}</a>
-        <p class="endpoint-description">
-          This will return a list of citations.
-        </p>
-        <h5 class="list-header">Endpoint Parameters:</h5>
-        <ul class="parameter-list">
-          <li class="list-group-item">
-            <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
-            <ul>
-              <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
-              <li class="param-description">
-                This field contains a value that we generate which will bring you to a specific page of results.
-              </li>
-            </ul>
-          </li>
-        </ul>
-      </dd>
-    </dl>
-  </div>
+    <dt>
+      <a id="endpoint-volumes"></a>
+      Citations
+    </dt>
+    <dd>
+      <a class="endpoint-link" href="{% api_url "citation-list" %}">{% api_url "citation-list" %}</a>
+      <p class="endpoint-description">
+        This will return a list of citations.
+      </p>
+      <h5 class="list-header">Endpoint Parameters:</h5>
+      <ul class="parameter-list">
+        <li class="list-group-item">
+          <h5 class="list-header"><code class="parameter-name">cursor</code></h5>
+          <ul>
+            <li class="param-data-type"> An randomly generated <a href="#def-string">string</a></li>
+            <li class="param-description">
+              This field contains a value that we generate which will bring you to a specific page of results.
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </dd>
+  </dl>
 
   {# ==============> BEGINNERS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="beginners">
-      Beginner's Introduction to APIs
-    </h2>
-    <p>
-      Are you a little lost in all the technical jargon, but still want to give the API a shot? This is a good place to
-      start! This is by no means a complete introduction to using <a href="#def-api">APIs</a>, but it might be just
-      enough to help situate a technically inclined person who's a bit outside of their comfort zone. If you've had
-      enough and would prefer to just access the cases using a human-centric interface, please check out our
-      <a href="{% url 'search' %}">search tool</a>.
-    </p>
-    <p>
-      Fundamentally, an API is no different from a regular website: A program on your computer, such as a web
-      browser or <a href="#def-curl">curl</a> sends a bit of data to a <a href="#def-server">server</a>, the
-      server processes that data, and then sends a response. If you know how to read a
-      <a href="#def-url">URL</a>, you can interact with web-based services in ways that aren't limited to
-      clicking on the links and buttons on the screen.
-    </p>
-    <p>
-      Consider the following <a href="#def-url">URL</a>, which will
-      <a href="https://www.google.com/search?q=CAP">perform a google search for the word "CAP."</a>
-    </p>
-    <pre><code>https://www.google.com/search?q=CAP</code></pre>
-    <p>
-      Let's break it down into its individual parts:
-    </p>
-    <pre><code>https://</code></pre>
-    <p>
-      This first part tells your web browser which protocol to use: this isn't very
-      important for our purposes, so we'll ignore it.
-    </p>
-    <pre><code>www.google.com</code></pre>
-    <p>
-      The next part is a list of words, separated by periods, between the initial double-slash, and before the
-      subsequent single slash. Many people generically refer to this as the domain, which is only partly true,
-      but the reason why that's not entirely true isn't really important for our purposes; the important
-      consideration here is that it points to a specific <a href="#def-server">server</a>, which is just another
-      computer on the internet.
-    </p>
-    <pre><code>/search</code></pre>
-    <p>
-      The next section, which is comprised of everything between the slash after the server name and the
-      question mark, is called the <a href="#def-path">path</a>. It's called a path because, in the earlier days
-      of the web, it was a 'path' through folders/directories to find a specific file on the web server. These
-      days, it's more likely that the path will point to a specific <a href="#def-endpoint">endpoint</a>.
-    </p>
-    <p>
-      You can think of an endpoint as a distinct part of a program, which could require specific inputs,
-      and/or provide different results. For example, the "login" endpoint on a website might accept a
-      valid username and a password for input, and return a message that you've successfully logged in. A
-      "register" endpoint might accept various bits of identifying information, and return a screen that
-      says your account was successfully registered.
-    </p>
-    <p>
-      Though there is only one part of this particular path, <code>search</code>, developers usually
-      organize paths into hierarchical lists separated by slashes. Hypothetically, if the developers at
-      Google decided that one generalized search endpoint wasn't sufficiently serving people who wanted to
-      search for books or locations, they could implement more specific endpoints such as
-      <code>/search/books</code> and <code>/search/locations</code>.
-    </p>
-    <pre><code>?q=CAP</code></pre>
-    <p>
-      The final section of the URL is where you'll find the <a href="#def-parameter">parameters</a>, and is
-      comprised of everything after the question mark. Parameters are a way of passing individual, labelled
-      pieces of information to the endpoint to help it perform its job. In this case, the parameter tells the
-      <code>/search</code> endpoint what to search for. Without this parameter, the response wouldn't be
-      particularly useful.
-    </p>
-    <p>
-      A URL can contain many parameters, separated by ampersands, but in this instance, there is only one
-      parameter: the rather cryptically named "q," which is short for "query," which has a value of "CAP."
-      Parameter names are arbitrary— Google's developers could just as easily have set the parameter name
-      to <code>?query=CAP</code>, but decided that "q" would sufficiently communicate its purpose.
-    </p>
-    <p>
-      The Google developers designed their web search endpoint to accept other parameters, too. For
-      example, there is an even more cryptically named parameter, 'tbs' which will limit the age of the
-      documents returned in the search results. The parameters <code>?q=CAP&tbs=qdr:y</code> will perform
-      a web search for "CAP" and limit the results to documents less than a year old.
-    </p>
-    <p>
-      So when you're working with CAPAPI, the same principles apply. Rather than http://www.google.com, you'll
-      be using {% api_url "api-root" %}. Rather than using the /search?q= endpoint and parameter, you'll
-      be using one of our <a href="#endpoints">endpoints and the parameters we've defined</a>. One important
-      difference is the purpose of the structured data we're returning, vs. the visual, browser-oriented data
-      that google is returning with their search engine.
-    </p>
-    <p>
-      When you perform a query in a web browser using our API, there are some links and buttons, but the data
-      itself is in a text-based format with lots of brackets and commas. This format is called JSON, or
-      JavaScript Object Notation. We use this format because software developers can easily utilize data in that
-      format in their own programs. We do intend to have a more user-friendly case browser at some point soon,
-      but we're not quite there yet.
-    </p>
-    <p>
-      OK! That about does it for our beginner's introduction to web-based APIs. Please check out our
-      <a href="#examples">usage examples</a> section to see some of the ways you can put these principles to
-      work in CAPAPI. If you have any suggestions for making this documentation better, we'd appreciate your
-      taking the time to let us know in an issue report
-      <a href="https://github.com/harvard-lil/capstone/issues">in our code repository on github.com</a>.
-    </p>
-    <p>
-      Thanks, and good luck!
-    </p>
-  </div>
+  <h2 class="subtitle" id="beginners">
+    Beginner's Introduction to APIs
+  </h2>
+  <p>
+    Are you a little lost in all the technical jargon, but still want to give the API a shot? This is a good place to
+    start! This is by no means a complete introduction to using <a href="#def-api">APIs</a>, but it might be just
+    enough to help situate a technically inclined person who's a bit outside of their comfort zone. If you've had
+    enough and would prefer to just access the cases using a human-centric interface, please check out our
+    <a href="{% url 'search' %}">search tool</a>.
+  </p>
+  <p>
+    Fundamentally, an API is no different from a regular website: A program on your computer, such as a web
+    browser or <a href="#def-curl">curl</a> sends a bit of data to a <a href="#def-server">server</a>, the
+    server processes that data, and then sends a response. If you know how to read a
+    <a href="#def-url">URL</a>, you can interact with web-based services in ways that aren't limited to
+    clicking on the links and buttons on the screen.
+  </p>
+  <p>
+    Consider the following <a href="#def-url">URL</a>, which will
+    <a href="https://www.google.com/search?q=CAP">perform a google search for the word "CAP."</a>
+  </p>
+  <pre><code>https://www.google.com/search?q=CAP</code></pre>
+  <p>
+    Let's break it down into its individual parts:
+  </p>
+  <pre><code>https://</code></pre>
+  <p>
+    This first part tells your web browser which protocol to use: this isn't very
+    important for our purposes, so we'll ignore it.
+  </p>
+  <pre><code>www.google.com</code></pre>
+  <p>
+    The next part is a list of words, separated by periods, between the initial double-slash, and before the
+    subsequent single slash. Many people generically refer to this as the domain, which is only partly true,
+    but the reason why that's not entirely true isn't really important for our purposes; the important
+    consideration here is that it points to a specific <a href="#def-server">server</a>, which is just another
+    computer on the internet.
+  </p>
+  <pre><code>/search</code></pre>
+  <p>
+    The next section, which is comprised of everything between the slash after the server name and the
+    question mark, is called the <a href="#def-path">path</a>. It's called a path because, in the earlier days
+    of the web, it was a 'path' through folders/directories to find a specific file on the web server. These
+    days, it's more likely that the path will point to a specific <a href="#def-endpoint">endpoint</a>.
+  </p>
+  <p>
+    You can think of an endpoint as a distinct part of a program, which could require specific inputs,
+    and/or provide different results. For example, the "login" endpoint on a website might accept a
+    valid username and a password for input, and return a message that you've successfully logged in. A
+    "register" endpoint might accept various bits of identifying information, and return a screen that
+    says your account was successfully registered.
+  </p>
+  <p>
+    Though there is only one part of this particular path, <code>search</code>, developers usually
+    organize paths into hierarchical lists separated by slashes. Hypothetically, if the developers at
+    Google decided that one generalized search endpoint wasn't sufficiently serving people who wanted to
+    search for books or locations, they could implement more specific endpoints such as
+    <code>/search/books</code> and <code>/search/locations</code>.
+  </p>
+  <pre><code>?q=CAP</code></pre>
+  <p>
+    The final section of the URL is where you'll find the <a href="#def-parameter">parameters</a>, and is
+    comprised of everything after the question mark. Parameters are a way of passing individual, labelled
+    pieces of information to the endpoint to help it perform its job. In this case, the parameter tells the
+    <code>/search</code> endpoint what to search for. Without this parameter, the response wouldn't be
+    particularly useful.
+  </p>
+  <p>
+    A URL can contain many parameters, separated by ampersands, but in this instance, there is only one
+    parameter: the rather cryptically named "q," which is short for "query," which has a value of "CAP."
+    Parameter names are arbitrary— Google's developers could just as easily have set the parameter name
+    to <code>?query=CAP</code>, but decided that "q" would sufficiently communicate its purpose.
+  </p>
+  <p>
+    The Google developers designed their web search endpoint to accept other parameters, too. For
+    example, there is an even more cryptically named parameter, 'tbs' which will limit the age of the
+    documents returned in the search results. The parameters <code>?q=CAP&tbs=qdr:y</code> will perform
+    a web search for "CAP" and limit the results to documents less than a year old.
+  </p>
+  <p>
+    So when you're working with CAPAPI, the same principles apply. Rather than http://www.google.com, you'll
+    be using {% api_url "api-root" %}. Rather than using the /search?q= endpoint and parameter, you'll
+    be using one of our <a href="#endpoints">endpoints and the parameters we've defined</a>. One important
+    difference is the purpose of the structured data we're returning, vs. the visual, browser-oriented data
+    that google is returning with their search engine.
+  </p>
+  <p>
+    When you perform a query in a web browser using our API, there are some links and buttons, but the data
+    itself is in a text-based format with lots of brackets and commas. This format is called JSON, or
+    JavaScript Object Notation. We use this format because software developers can easily utilize data in that
+    format in their own programs. We do intend to have a more user-friendly case browser at some point soon,
+    but we're not quite there yet.
+  </p>
+  <p>
+    OK! That about does it for our beginner's introduction to web-based APIs. Please check out our
+    <a href="#examples">usage examples</a> section to see some of the ways you can put these principles to
+    work in CAPAPI. If you have any suggestions for making this documentation better, we'd appreciate your
+    taking the time to let us know in an issue report
+    <a href="https://github.com/harvard-lil/capstone/issues">in our code repository on github.com</a>.
+  </p>
+  <p>
+    Thanks, and good luck!
+  </p>
 
   {# ==============> PROBLEMS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="problems">
-      Reporting Problems and Enhancement Requests
-    </h2>
-    <p>
-      We are serving an imperfect, living dataset through an API that will forever be a work-in-progress. We
-      work hard to hunt down and fix problems in both the API and the data, but a robust user base will uncover
-      problems more quickly than our small team could ever hope to. Here's the best way to report common types
-      of errors.
-    </p>
-    <dl>
-      <ul>
-        <li><a href="https://github.com/harvard-lil/capstone#errata">Our data errata</a></li>
-        <li><a href="https://github.com/harvard-lil/capstone/issues">Our issue tracker</a></li>
-        <li><a href="https://github.com/harvard-lil/capstone">Our Github repository</a></li>
-      </ul>
-      <dt>
-        Jumbled or Misspelled Words in Case Text
-      </dt>
-      <dd>
-        For now, we're not accepting bug reports for <a href="#def-ocr">OCR</a> problems. While our data is
-        good quality for OCR'd text, we fully expect these errors in every case.  We're working on the best way
-        to tackle this.
-      </dd>
-      <dt>
-        Typos or Broken Links in Documentation or Website, API Error Messages or Performance Problems, and
-        Missing Features
-      </dt>
-      <dd>
-        First, please check our existing <a href="https://github.com/harvard-lil/capstone/issues">issues</a> to
-        see if someone has already reported the problem. If so, please feel free to comment on the issue to add
-        information. We'll update the issue when there's more information about the issue, so if you'd like
-        notifications, click on the "Subscribe" button on the right-hand side of the screen. If no issue exists,
-        create a new issue, and we'll get back to you as soon as we can.
-      </dd>
+  <h2 class="subtitle" id="problems">
+    Reporting Problems and Enhancement Requests
+  </h2>
+  <p>
+    We are serving an imperfect, living dataset through an API that will forever be a work-in-progress. We
+    work hard to hunt down and fix problems in both the API and the data, but a robust user base will uncover
+    problems more quickly than our small team could ever hope to. Here's the best way to report common types
+    of errors.
+  </p>
+  <dl>
+    <ul>
+      <li><a href="https://github.com/harvard-lil/capstone#errata">Our data errata</a></li>
+      <li><a href="https://github.com/harvard-lil/capstone/issues">Our issue tracker</a></li>
+      <li><a href="https://github.com/harvard-lil/capstone">Our Github repository</a></li>
+    </ul>
+    <dt>
+      Jumbled or Misspelled Words in Case Text
+    </dt>
+    <dd>
+      For now, we're not accepting bug reports for <a href="#def-ocr">OCR</a> problems. While our data is
+      good quality for OCR'd text, we fully expect these errors in every case.  We're working on the best way
+      to tackle this.
+    </dd>
+    <dt>
+      Typos or Broken Links in Documentation or Website, API Error Messages or Performance Problems, and
+      Missing Features
+    </dt>
+    <dd>
+      First, please check our existing <a href="https://github.com/harvard-lil/capstone/issues">issues</a> to
+      see if someone has already reported the problem. If so, please feel free to comment on the issue to add
+      information. We'll update the issue when there's more information about the issue, so if you'd like
+      notifications, click on the "Subscribe" button on the right-hand side of the screen. If no issue exists,
+      create a new issue, and we'll get back to you as soon as we can.
+    </dd>
 
-      <dt>Incorrect Metadata or Improperly Labelled data in XML</dt>
-      <dd>
-        First, check our <a href="https://github.com/harvard-lil/capstone#errata">errata</a> to see if this is
-        a known issue. Then, check our existing
-        <a href="https://github.com/harvard-lil/capstone/issues">issues</a> to see if someone has already
-        reported the problem. If so, please feel free to comment on the issue to add context or additional
-        instances that the issue owner didn't report. We'll update the issue when there's more information about
-        the issue, so if you'd like notifications, click on the "Subscribe" button on the right-hand side of the
-        screen. If no issue exists, create a new issue and we'll get back to you as soon as we can.
-      </dd>
-    </dl>
-  </div>
+    <dt>Incorrect Metadata or Improperly Labelled data in XML</dt>
+    <dd>
+      First, check our <a href="https://github.com/harvard-lil/capstone#errata">errata</a> to see if this is
+      a known issue. Then, check our existing
+      <a href="https://github.com/harvard-lil/capstone/issues">issues</a> to see if someone has already
+      reported the problem. If so, please feel free to comment on the issue to add context or additional
+      instances that the issue owner didn't report. We'll update the issue when there's more information about
+      the issue, so if you'd like notifications, click on the "Subscribe" button on the right-hand side of the
+      screen. If no issue exists, create a new issue and we'll get back to you as soon as we can.
+    </dd>
+  </dl>
 
   {# ==============> GLOSSARY <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="glossary">
-      Glossary
-    </h2>
-    <p>
-      This is a list of technical or project-specific terms we use in this documentation. These are stub
-      definitions to help you get unstuck, but they should not be considered authoritative or complete. A quick
-      Google search should provide more context for any of these terms.
-    </p>
-    <dl>
-      <dt>
-        <a id="def-api"></a>
-        API
-      </dt>
-      <dd>
-        API is an acronym for Application Programming Interface. Broadly, it is a way for one computer program
-        to transfer data to another computer program. CAPAPI is a <a href="#def-restful">RESTful</a> API
-        designed to distribute court case data.
-      </dd>
+  <h2 class="subtitle" id="glossary">
+    Glossary
+  </h2>
+  <p>
+    This is a list of technical or project-specific terms we use in this documentation. These are stub
+    definitions to help you get unstuck, but they should not be considered authoritative or complete. A quick
+    Google search should provide more context for any of these terms.
+  </p>
+  <dl>
+    <dt>
+      <a id="def-api"></a>
+      API
+    </dt>
+    <dd>
+      API is an acronym for Application Programming Interface. Broadly, it is a way for one computer program
+      to transfer data to another computer program. CAPAPI is a <a href="#def-restful">RESTful</a> API
+      designed to distribute court case data.
+    </dd>
 
 
-      <dt>
-        <a id="def-character"></a>
-        <a id="def-special-character"></a>
-        Character
-      </dt>
-      <dd>
-        A letter, number, space, or piece of punctuation. Multiple characters together make up a
-        <a href="#def-string">string</a>.
-      </dd>
-      <dd>
-        Special characters are characters that have programmatic significance to a program. The "specialness"
-        of any given character is determined by the context in which it's used. For example, you can't add a
-        bare question mark to your path because they indicate to the server that everything after them is a
-        <a href="#def-parameter">parameter</a>.
-      </dd>
+    <dt>
+      <a id="def-character"></a>
+      <a id="def-special-character"></a>
+      Character
+    </dt>
+    <dd>
+      A letter, number, space, or piece of punctuation. Multiple characters together make up a
+      <a href="#def-string">string</a>.
+    </dd>
+    <dd>
+      Special characters are characters that have programmatic significance to a program. The "specialness"
+      of any given character is determined by the context in which it's used. For example, you can't add a
+      bare question mark to your path because they indicate to the server that everything after them is a
+      <a href="#def-parameter">parameter</a>.
+    </dd>
 
-      <dt>
-        <a id="def-command-line"></a>
-        Command Line
-      </dt>
-      <dd>
-        This is the textual interface for interacting with a computer. Rather than interacting with the system
-        through windows and mouse clicks, commands are typed and output is rendered in its textual form. On mac,
-        the default Command Line program is Terminal. On Windows, the program is cmd.exe.
-      </dd>
+    <dt>
+      <a id="def-command-line"></a>
+      Command Line
+    </dt>
+    <dd>
+      This is the textual interface for interacting with a computer. Rather than interacting with the system
+      through windows and mouse clicks, commands are typed and output is rendered in its textual form. On mac,
+      the default Command Line program is Terminal. On Windows, the program is cmd.exe.
+    </dd>
 
-      <dt>
-        <a id="def-curl"></a>
-        curl
-      </dt>
-      <dd>
-        <a href="https://curl.haxx.se/">curl</a> is a simple <a href="#def-command-line">command line</a> tool
-        for retrieving data over the internet. It's similar to a web browser in that it will retrieve the
-        contents of a <a href="#def-url">url</a>, but it will dump the text contents to a terminal, rather than
-        show a rendered version in a graphical browser window.
-      </dd>
+    <dt>
+      <a id="def-curl"></a>
+      curl
+    </dt>
+    <dd>
+      <a href="https://curl.haxx.se/">curl</a> is a simple <a href="#def-command-line">command line</a> tool
+      for retrieving data over the internet. It's similar to a web browser in that it will retrieve the
+      contents of a <a href="#def-url">url</a>, but it will dump the text contents to a terminal, rather than
+      show a rendered version in a graphical browser window.
+    </dd>
 
-      <dt>
-        <a id="def-endpoint"></a>
-        Endpoint
-      </dt>
-      <dd>
-        You can think of an endpoint as a distinct part of a program, which could require specific inputs,
-        and/or provide different results. For example, the "login" endpoint on a website might accept a valid
-        username and a password for input, and return a message that you've successfully logged in. A "register"
-        endpoint might accept various bits of identifying information, and return a screen that says your
-        account was successfully registered.
-      </dd>
+    <dt>
+      <a id="def-endpoint"></a>
+      Endpoint
+    </dt>
+    <dd>
+      You can think of an endpoint as a distinct part of a program, which could require specific inputs,
+      and/or provide different results. For example, the "login" endpoint on a website might accept a valid
+      username and a password for input, and return a message that you've successfully logged in. A "register"
+      endpoint might accept various bits of identifying information, and return a screen that says your
+      account was successfully registered.
+    </dd>
 
-      <dt>
-        <a id="def-jurisdiction"></a>
-        Jurisdiction
-      </dt>
-      <dd>
-        The jurisdiction of a case or volume is the political division it belongs to, such as the United States, a state,
-        a territory, a tribe, or the District of Columbia. Volumes that collect cases from a region have the jurisdiction
-        "Regional." Cases from tribal courts (other than Navajo Nation) temporarily have the jurisdiction
-        "Tribal Jurisdictions" while we verify the correct jurisdiction for each tribal court.
-      </dd>
+    <dt>
+      <a id="def-jurisdiction"></a>
+      Jurisdiction
+    </dt>
+    <dd>
+      The jurisdiction of a case or volume is the political division it belongs to, such as the United States, a state,
+      a territory, a tribe, or the District of Columbia. Volumes that collect cases from a region have the jurisdiction
+      "Regional." Cases from tribal courts (other than Navajo Nation) temporarily have the jurisdiction
+      "Tribal Jurisdictions" while we verify the correct jurisdiction for each tribal court.
+    </dd>
 
-      <dt>
-        <a id="def-ocr"></a>
-        OCR
-      </dt>
-      <dd>
-        OCR is a process in which a computer attempts to create text from an image of text. The text in our
-        cases is OCR-derived using scanned case reporter pages as source images.
-      </dd>
+    <dt>
+      <a id="def-ocr"></a>
+      OCR
+    </dt>
+    <dd>
+      OCR is a process in which a computer attempts to create text from an image of text. The text in our
+      cases is OCR-derived using scanned case reporter pages as source images.
+    </dd>
 
-      <dt>
-        <a id="def-restful"></a>
-        RESTful
-      </dt>
-      <dd>
-        A RESTful <a href="#def-api">API</a> is based on
-        <a href="https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol">HTTP</a>, and makes use of its
-        built-in verbs(commands), such as GET and POST.
-      </dd>
-      <dt>
-        <a id="def-reporter"></a>
-        Reporter
-      </dt>
-      <dd>
-        In this project, we use the term 'reporter' to refer to a reporter series. We'd consider F2d. a
-        reporter.
-      </dd>
-      <dt>
-        <a id="def-server"></a>
-        Server
-      </dt>
-      <dd>
-        A server is just a computer on the internet that was configured to respond to requests from other
-        computers. A web server will respond to requests from a web browser. An email server will respond to
-        requests from email programs, and or other email servers which are sending it messages.
-      </dd>
-      <dt>
-        <a id="def-slug"></a>
-        Slug
-      </dt>
-      <dd>
-        A <a href="#def-string">string</a> with <a href="#def-special-character">special characters</a> removed
-        for ease of inclusion in a <a href="#def-url">URL</a>.
-      </dd>
-      <dt>
-        <a id="def-string"></a>
-        String
-      </dt>
-      <dd>
-        A string, as a type of data, just means an arbitrary list (or string) of
-        <a href="#def-character">characters</a>. A word is a string. This whole sentence is a string. "h3ll0.!"
-        is a string. This whole document is a string.
-      </dd>
+    <dt>
+      <a id="def-restful"></a>
+      RESTful
+    </dt>
+    <dd>
+      A RESTful <a href="#def-api">API</a> is based on
+      <a href="https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol">HTTP</a>, and makes use of its
+      built-in verbs(commands), such as GET and POST.
+    </dd>
+    <dt>
+      <a id="def-reporter"></a>
+      Reporter
+    </dt>
+    <dd>
+      In this project, we use the term 'reporter' to refer to a reporter series. We'd consider F2d. a
+      reporter.
+    </dd>
+    <dt>
+      <a id="def-server"></a>
+      Server
+    </dt>
+    <dd>
+      A server is just a computer on the internet that was configured to respond to requests from other
+      computers. A web server will respond to requests from a web browser. An email server will respond to
+      requests from email programs, and or other email servers which are sending it messages.
+    </dd>
+    <dt>
+      <a id="def-slug"></a>
+      Slug
+    </dt>
+    <dd>
+      A <a href="#def-string">string</a> with <a href="#def-special-character">special characters</a> removed
+      for ease of inclusion in a <a href="#def-url">URL</a>.
+    </dd>
+    <dt>
+      <a id="def-string"></a>
+      String
+    </dt>
+    <dd>
+      A string, as a type of data, just means an arbitrary list (or string) of
+      <a href="#def-character">characters</a>. A word is a string. This whole sentence is a string. "h3ll0.!"
+      is a string. This whole document is a string.
+    </dd>
 
-      <dt>
-        <a id="def-tld"></a>
-        Top-Level Domain
-      </dt>
-      <dd>
-        The suffix to a domain name, such as <code>.com</code>, <code>.edu</code> or <code>.co.uk</code>.
-      </dd>
+    <dt>
+      <a id="def-tld"></a>
+      Top-Level Domain
+    </dt>
+    <dd>
+      The suffix to a domain name, such as <code>.com</code>, <code>.edu</code> or <code>.co.uk</code>.
+    </dd>
 
-      <dt>
-        <a id="def-url"></a>
-        URL
-      </dt>
-      <dd>
-        A URL, or Uniform Resource Locator, is an internet address that generally contains a communication
-        protocol, a server name, a path to a file or endpoint, and possibly parameters to pass to the endpoint.
-      </dd>
-      <dt>
-        <a id="def-parameter"></a>
-        URL Parameter
-      </dt>
-      <dd>
-        For our purposes, a parameter is just a piece of data with a label that can be passed to an
-        <a href="#def-endpoint">endpoint</a> in a web request.
-      </dd>
-      <dt>
-        <a id="def-path"></a>
-        URL Path
-      </dt>
-      <dd>
-        The URL path begins with the slash after the <a href="#def-tld">top-level domain</a> and ends with the
-        question mark that signals the beginning of the <a href="#def-parameter">parameters</a>. It was
-        originally intended to point to a file on the server's hard drive, but these days it's just as likely to
-        point to an application <a href="#def-endpoint">endpoint</a>.
-      </dd>
-      <dt>
-        <a id="def-whitelisted"></a>
-        Whitelisted
-      </dt>
-      <dd>
-        While most cases in the database are subject to a 500 case per day access limit, jurisdictions that
-        publish their cases in a citable, machine-readable format are not subject to this limit.
-        <a href="#limits">Click here for more information on access limits, what type of users
-          aren't subject to them, and how you can eliminate them in your legal jurisdiction.</a>
-      </dd>
-
-
-    </dl>
-  </div>
+    <dt>
+      <a id="def-url"></a>
+      URL
+    </dt>
+    <dd>
+      A URL, or Uniform Resource Locator, is an internet address that generally contains a communication
+      protocol, a server name, a path to a file or endpoint, and possibly parameters to pass to the endpoint.
+    </dd>
+    <dt>
+      <a id="def-parameter"></a>
+      URL Parameter
+    </dt>
+    <dd>
+      For our purposes, a parameter is just a piece of data with a label that can be passed to an
+      <a href="#def-endpoint">endpoint</a> in a web request.
+    </dd>
+    <dt>
+      <a id="def-path"></a>
+      URL Path
+    </dt>
+    <dd>
+      The URL path begins with the slash after the <a href="#def-tld">top-level domain</a> and ends with the
+      question mark that signals the beginning of the <a href="#def-parameter">parameters</a>. It was
+      originally intended to point to a file on the server's hard drive, but these days it's just as likely to
+      point to an application <a href="#def-endpoint">endpoint</a>.
+    </dd>
+    <dt>
+      <a id="def-whitelisted"></a>
+      Whitelisted
+    </dt>
+    <dd>
+      While most cases in the database are subject to a 500 case per day access limit, jurisdictions that
+      publish their cases in a citable, machine-readable format are not subject to this limit.
+      <a href="#limits">Click here for more information on access limits, what type of users
+        aren't subject to them, and how you can eliminate them in your legal jurisdiction.</a>
+    </dd>
+  </dl>
 {% endblock %}

--- a/capstone/capweb/templates/bulk_docs.html
+++ b/capstone/capweb/templates/bulk_docs.html
@@ -56,130 +56,118 @@
 
 {% block main_content %}
   {# ==============> REQUESTING  <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="requesting-access">Requesting Access</h2>
-    <p>
-      Bulk data files for our whitelisted jurisdictions (currently Illinois and Arkansas) are
-      <a href="{% url "bulk-download" %}">available to everyone</a>
-      without a login.
-    </p>
-    <p>
-      Bulk data files for the remaining jurisdictions are available to research scholars who sign a research
-      agreement. You can request a research agreement by <a href="{% url "register" %}">creating an account</a>
-      and then <a href="{% url "user-details" %}">visiting your account page</a>.
-    </p>
-    <p>
-      See our  <a href="{% url "about" %}#usage">About page</a> for details on our data access restrictions.
-    </p>
-  </div>
+  <h2 class="subtitle" id="requesting-access">Requesting Access</h2>
+  <p>
+    Bulk data files for our whitelisted jurisdictions (currently Illinois and Arkansas) are
+    <a href="{% url "bulk-download" %}">available to everyone</a>
+    without a login.
+  </p>
+  <p>
+    Bulk data files for the remaining jurisdictions are available to research scholars who sign a research
+    agreement. You can request a research agreement by <a href="{% url "register" %}">creating an account</a>
+    and then <a href="{% url "user-details" %}">visiting your account page</a>.
+  </p>
+  <p>
+    See our  <a href="{% url "about" %}#usage">About page</a> for details on our data access restrictions.
+  </p>
 
   {# ==============> GETTING  <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="downloading">Downloading</h2>
-    <p>
-      You can download bulk data <a href="{% url "bulk-download" %}">manually from our website</a>, or
-      <a href="{% api_url "caseexport-list" %}">use the API</a> if you are fetching many files at once.
-    </p>
-    <p>
-      To download all cases via the API,
-      <a href="{% api_url "caseexport-list" %}?body_format=text&filter_type=jurisdiction">use the body_format and
-        filter_type parameters to the <code>/bulk/</code> endpoint</a> to select all cases, sorted by jurisdiction,
-      of your desired body_format.
-    </p>
-  </div>
+  <h2 class="subtitle" id="downloading">Downloading</h2>
+  <p>
+    You can download bulk data <a href="{% url "bulk-download" %}">manually from our website</a>, or
+    <a href="{% api_url "caseexport-list" %}">use the API</a> if you are fetching many files at once.
+  </p>
+  <p>
+    To download all cases via the API,
+    <a href="{% api_url "caseexport-list" %}?body_format=text&filter_type=jurisdiction">use the body_format and
+      filter_type parameters to the <code>/bulk/</code> endpoint</a> to select all cases, sorted by jurisdiction,
+    of your desired body_format.
+  </p>
 
   {# ==============> API EQUIVALENCE  <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="api-equivalence">API Equivalence</h2>
-    <p>
-      Each file that we offer for download is equivalent to a particular query to our API. For example, the file
-      "Illinois-20180829-text.zip" contains all cases that would be returned by
-      <a href="{% api_url "casemetadata-list" %}?full_case=true&jurisdiction=ill&body_format=text">an API query</a>
-      with <code>full_case=true&jurisdiction=ill&body_format=text</code>. We offer files for each possible
-      <code>jurisdiction</code> value and each possible <code>reporter</code> value, combined with
-      <code>body_format=text</code> and <code>body_format=xml</code>.
-    </p>
-    <p>
-      The JSON objects returned by the API and in bulk files differ only in that bulk JSON objects do not include
-      <code>"url"</code> fields, which can be reconstructed from object IDs.
-    </p>
-  </div>
+  <h2 class="subtitle" id="api-equivalence">API Equivalence</h2>
+  <p>
+    Each file that we offer for download is equivalent to a particular query to our API. For example, the file
+    "Illinois-20180829-text.zip" contains all cases that would be returned by
+    <a href="{% api_url "casemetadata-list" %}?full_case=true&jurisdiction=ill&body_format=text">an API query</a>
+    with <code>full_case=true&jurisdiction=ill&body_format=text</code>. We offer files for each possible
+    <code>jurisdiction</code> value and each possible <code>reporter</code> value, combined with
+    <code>body_format=text</code> and <code>body_format=xml</code>.
+  </p>
+  <p>
+    The JSON objects returned by the API and in bulk files differ only in that bulk JSON objects do not include
+    <code>"url"</code> fields, which can be reconstructed from object IDs.
+  </p>
 
   {# ==============> FORMAT  <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="data-format">Data Format</h2>
-    <p>
-      Bulk data files are provided as zipped directories. Each directory is in
-      <a href="https://en.wikipedia.org/wiki/BagIt">BagIt format</a>, with a layout like this:
-    </p>
-    <ul class="bullets">
-      <li>
-        Illinois-20180829-text/
-        <ul>
-          <li>bag-info.txt</li>
-          <li>bagit.txt</li>
-          <li>manifest-sha512.txt</li>
-          <li>
-            data/
-            <ul>
-              <li>data.jsonl.xz</li>
-            </ul>
-          </li>
-        </ul>
-      </li>
-    </ul>
-    <p>
-      Because the zip file provides no additional compression, we recommend uncompressing it for convenience and
-      keeping the uncompressed directory on disk.
-    </p>
-    <p>
-      Caselaw data is stored within the <code>data/data.jsonl.xz</code> file. The <code>.jsonl.xz</code> suffix
-      indicates that the file is compressed with xzip, and is a text file where each line represents a JSON object.
-    </p>
-  </div>
+  <h2 class="subtitle" id="data-format">Data Format</h2>
+  <p>
+    Bulk data files are provided as zipped directories. Each directory is in
+    <a href="https://en.wikipedia.org/wiki/BagIt">BagIt format</a>, with a layout like this:
+  </p>
+  <ul class="bullets">
+    <li>
+      Illinois-20180829-text/
+      <ul>
+        <li>bag-info.txt</li>
+        <li>bagit.txt</li>
+        <li>manifest-sha512.txt</li>
+        <li>
+          data/
+          <ul>
+            <li>data.jsonl.xz</li>
+          </ul>
+        </li>
+      </ul>
+    </li>
+  </ul>
+  <p>
+    Because the zip file provides no additional compression, we recommend uncompressing it for convenience and
+    keeping the uncompressed directory on disk.
+  </p>
+  <p>
+    Caselaw data is stored within the <code>data/data.jsonl.xz</code> file. The <code>.jsonl.xz</code> suffix
+    indicates that the file is compressed with xzip, and is a text file where each line represents a JSON object.
+  </p>
 
   {# ==============> USING DATA  <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="examples">Using Bulk Data</h2>
-    <p>
-      The <code>data.jsonl.xz</code> file can be unzipped using third-party GUI programs like
-      <a href="https://theunarchiver.com/">The Unarchiver</a> (Mac) or
-      <a href="https://www.7-zip.org/">7-zip</a> (Windows), or from the command line with a command like
-      <code>unxz -k data/data.jsonl.xz</code>.
-    </p>
-    <p>
-      However, this increases the disk space needed by about 500%, and in most cases is unnecessary. Instead
-      we recommend interacting directly with the compressed files.
-    </p>
-    <p>
-      To read the file from the command line, run:
-    </p>
-    <pre class="code-block">xzcat data/data.jsonl.xz | less</pre>
-    <p>
-      If you install <a href="https://stedolan.github.io/jq/download/">jq</a> you can get nicely formatted output ...
-    </p>
-    <pre class="code-block">xzcat data/data.jsonl.xz | jq | less</pre>
-    <p>
-      .. or run more sophisticated queries. For example, to extract the name of each case:
-    </p>
-    <pre class="code-block">xzcat data/data.jsonl.xz | jq .name | less</pre>
-    <p>
-      You can also interact directly with the compressed files from code. The following example prints
-      the name of each case using Python:
-    </p>
-    <pre class="code-block">
+  <h2 class="subtitle" id="examples">Using Bulk Data</h2>
+  <p>
+    The <code>data.jsonl.xz</code> file can be unzipped using third-party GUI programs like
+    <a href="https://theunarchiver.com/">The Unarchiver</a> (Mac) or
+    <a href="https://www.7-zip.org/">7-zip</a> (Windows), or from the command line with a command like
+    <code>unxz -k data/data.jsonl.xz</code>.
+  </p>
+  <p>
+    However, this increases the disk space needed by about 500%, and in most cases is unnecessary. Instead
+    we recommend interacting directly with the compressed files.
+  </p>
+  <p>
+    To read the file from the command line, run:
+  </p>
+  <pre class="code-block">xzcat data/data.jsonl.xz | less</pre>
+  <p>
+    If you install <a href="https://stedolan.github.io/jq/download/">jq</a> you can get nicely formatted output ...
+  </p>
+  <pre class="code-block">xzcat data/data.jsonl.xz | jq | less</pre>
+  <p>
+    .. or run more sophisticated queries. For example, to extract the name of each case:
+  </p>
+  <pre class="code-block">xzcat data/data.jsonl.xz | jq .name | less</pre>
+  <p>
+    You can also interact directly with the compressed files from code. The following example prints
+    the name of each case using Python:
+  </p>
+  <pre class="code-block">
 import lzma, json
 
 with lzma.open("data/data.jsonl.xz") as in_file:
 for line in in_file:
 case = json.loads(str(line, 'utf8'))
 print(case['name'])</pre>
-  </div>
 
   {# ==============> VISIT US  <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="visit-us">Visit Us</h2>    
-    <p>Explore our Illinois Public Bulk Data on <a href="https://dataverse.harvard.edu/dataverse/caselawaccess" target="_blank">Harvard Dataverse</a> and <a href="https://www.kaggle.com/harvardlil/caselaw-dataset-illinois" target="_blank">Kaggle</a>.
-    </p>
-  </div>
+  <h2 class="subtitle" id="visit-us">Visit Us</h2>
+  <p>Explore our Illinois Public Bulk Data on <a href="https://dataverse.harvard.edu/dataverse/caselawaccess" target="_blank">Harvard Dataverse</a> and <a href="https://www.kaggle.com/harvardlil/caselaw-dataset-illinois" target="_blank">Kaggle</a>.
+  </p>
 {% endblock %}

--- a/capstone/capweb/templates/gallery.html
+++ b/capstone/capweb/templates/gallery.html
@@ -61,255 +61,246 @@
 
 {% block main_content %}
   {# =============> H2O <============= #}
-  <div class="page-section">
-    <div class="row">
-      <div class="project-image">
-        <a href="https://opencasebook.org/"
-           aria-label="H2O homepage"
-           title="H2O homepage"
-           id="h2o"
-           target="_blank">
-          <img class="main-img rounded"
-               alt=""
-               src="{% static "img/h2o.png" %}">
+  <div class="row page-section">
+    <div class="project-image">
+      <a href="https://opencasebook.org/"
+         aria-label="H2O homepage"
+         title="H2O homepage"
+         id="h2o"
+         target="_blank">
+        <img class="main-img rounded"
+             alt=""
+             src="{% static "img/h2o.png" %}">
+      </a>
+    </div>
+    <div class="project-description">
+      <h3 class="subtitle simple-subtitle" id="h2o">
+        H2O
+      </h3>
+      <p>
+        H2O uses the
+        <a href="{% url "api" %}">
+          CAP API
         </a>
-      </div>
-      <div class="project-description">
-        <h3 class="subtitle simple-subtitle" id="h2o">
-          H2O
-        </h3>
-        <p>
-          H2O uses the
-          <a href="{% url "api" %}">
-            CAP API
-          </a>
-          to provide free caselaw textbooks for anyone.
-        </p>
-        <p class="social">
-          <span class="github">
-            <a href="https://github.com/harvard-lil/h2o" target="_blank"
-               title="H2O source code on Github"
-               aria-label="H2O source code on Github"></a>
-          </span>
+        to provide free caselaw textbooks for anyone.
+      </p>
+      <p class="social">
+        <span class="github">
+          <a href="https://github.com/harvard-lil/h2o" target="_blank"
+             title="H2O source code on Github"
+             aria-label="H2O source code on Github"></a>
+        </span>
 
-          <span class="website">
-            <a href="https://opencasebook.org/"
-               aria-label="H2O homepage"
-               title="H2O homepage"
-               target="_blank">
-            </a>
-          </span>
-        </p>
-      </div>
+        <span class="website">
+          <a href="https://opencasebook.org/"
+             aria-label="H2O homepage"
+             title="H2O homepage"
+             target="_blank">
+          </a>
+        </span>
+      </p>
     </div>
   </div>
 
   {# =============> WORDCLOUDS <============= #}
-  <div class="page-section">
-    <div class="row">
-      <div class="project-image">
-        <a href="{% url "wordclouds" %}"
-           title="Wordcloud homepage"
-           id="wordclouds"
-           aria-label="Wordcloud homepage">
-          <img class="main-img rounded"
-               alt=""
-               src="{% static "img/wordclouds-1933.png" %}">
-        </a>
-      </div>
-      <div class="project-description">
-        <h3 class="subtitle simple-subtitle" id="wordclouds">
-          Wordclouds
-        </h3>
-        <p>
-          Graphics showcasing the most-used words in California caselaw each year between 1852 and 2015.
-        </p>
-        <p class="social">
-          <span class="github">
-            <a href="https://github.com/harvard-lil/cap-examples-old/blob/master/make_wordclouds.py" target="_blank"
-               title="Wordcloud source code on Github"
-               aria-label="Wordcloud source code on Github"></a>
-          </span>
-          <span class="website">
-            <a href="{% url "wordclouds" %}"
-               title="Wordcloud homepage"
-               aria-label="Wordcloud homepage"></a>
-          </span>
-        </p>
-      </div>
+  <div class="row page-section">
+    <div class="project-image">
+      <a href="{% url "wordclouds" %}"
+         title="Wordcloud homepage"
+         id="wordclouds"
+         aria-label="Wordcloud homepage">
+        <img class="main-img rounded"
+             alt=""
+             src="{% static "img/wordclouds-1933.png" %}">
+      </a>
+    </div>
+    <div class="project-description">
+      <h3 class="subtitle simple-subtitle" id="wordclouds">
+        Wordclouds
+      </h3>
+      <p>
+        Graphics showcasing the most-used words in California caselaw each year between 1852 and 2015.
+      </p>
+      <p class="social">
+        <span class="github">
+          <a href="https://github.com/harvard-lil/cap-examples-old/blob/master/make_wordclouds.py" target="_blank"
+             title="Wordcloud source code on Github"
+             aria-label="Wordcloud source code on Github"></a>
+        </span>
+        <span class="website">
+          <a href="{% url "wordclouds" %}"
+             title="Wordcloud homepage"
+             aria-label="Wordcloud homepage"></a>
+        </span>
+      </p>
     </div>
   </div>
+
   {# =============> LIMERICKS <============= #}
-  <div class="page-section">
-    <div class="row">
-      <div class="project-image">
-        <a href="{% url "limericks" %}"
-           id="limericks"
-           aria-label="Limericks homepage">
-          <img class="main-img rounded"
-               alt=""
-               src="{% static "img/limerick.png" %}">
-        </a>
-      </div>
-      <div class="project-description">
-        <h3 class="subtitle simple-subtitle" id="limericks">
-          Limericks
-        </h3>
-        <p>
-          Generate rhymes using caselaw!
-        </p>
-        <p class="social">
-          <span class="github">
-            <a href="https://github.com/harvard-lil/cap-examples-old/blob/master/generate_limerick.py" target="_blank"
-               title="Limericks source code on Github"
-               aria-label="Limericks source code on Github"></a>
-          </span>
+  <div class="row page-section">
+    <div class="project-image">
+      <a href="{% url "limericks" %}"
+         id="limericks"
+         aria-label="Limericks homepage">
+        <img class="main-img rounded"
+             alt=""
+             src="{% static "img/limerick.png" %}">
+      </a>
+    </div>
+    <div class="project-description">
+      <h3 class="subtitle simple-subtitle" id="limericks">
+        Limericks
+      </h3>
+      <p>
+        Generate rhymes using caselaw!
+      </p>
+      <p class="social">
+        <span class="github">
+          <a href="https://github.com/harvard-lil/cap-examples-old/blob/master/generate_limerick.py" target="_blank"
+             title="Limericks source code on Github"
+             aria-label="Limericks source code on Github"></a>
+        </span>
 
-          <span class="website">
-            <a href="{% url "limericks" %}"
-               title="Limericks homepage"
-               aria-label="Limericks homepage"></a>
-          </span>
-        </p>
-      </div>
+        <span class="website">
+          <a href="{% url "limericks" %}"
+             title="Limericks homepage"
+             aria-label="Limericks homepage"></a>
+        </span>
+      </p>
     </div>
   </div>
+
   {# =============> WITCHCRAFT <============= #}
-  <div class="page-section">
-    <div class="row">
-      <div class="project-image">
-        <a href="{% url "witchcraft" %}"
-           id="witchcraft"
-           aria-label="Witchcraft homepage">
-          <img class="main-img"
-               alt=""
-               src="{% static "img/witchcraft.png" %}">
-        </a>
-      </div>
-      <div class="project-description">
-        <h3 class="subtitle simple-subtitle" id="witchcraft">
-          Witchcraft in Caselaw
-        </h3>
-        <p>
-          See all instances of "witchcraft" charted out on the U.S. map.
-        </p>
-        <p class="color-violet">Happy Halloween!</p>
-        <p class="social">
-          <span class="github">
-            <a href="https://github.com/harvard-lil/cap-examples/blob/master/api_wordsearch/wordsearch.py"
-               target="_blank"
-               title="Witchcraft source code on Github"
-               aria-label="Witchcraft source code on Github"></a>
-          </span>
+  <div class="row page-section">
+    <div class="project-image">
+      <a href="{% url "witchcraft" %}"
+         id="witchcraft"
+         aria-label="Witchcraft homepage">
+        <img class="main-img"
+             alt=""
+             src="{% static "img/witchcraft.png" %}">
+      </a>
+    </div>
+    <div class="project-description">
+      <h3 class="subtitle simple-subtitle" id="witchcraft">
+        Witchcraft in Caselaw
+      </h3>
+      <p>
+        See all instances of "witchcraft" charted out on the U.S. map.
+      </p>
+      <p class="color-violet">Happy Halloween!</p>
+      <p class="social">
+        <span class="github">
+          <a href="https://github.com/harvard-lil/cap-examples/blob/master/api_wordsearch/wordsearch.py"
+             target="_blank"
+             title="Witchcraft source code on Github"
+             aria-label="Witchcraft source code on Github"></a>
+        </span>
 
-          <span class="website">
-            <a href="{% url "witchcraft" %}"
-               title="Witchcraft homepage"
-               aria-label="Witchcraft homepage"></a>
-          </span>
-        </p>
-      </div>
+        <span class="website">
+          <a href="{% url "witchcraft" %}"
+             title="Witchcraft homepage"
+             aria-label="Witchcraft homepage"></a>
+        </span>
+      </p>
     </div>
   </div>
+
   {# =============> GAVELFURY <============= #}
-  <div class="page-section">
-    <div class="row">
-      <div class="project-image">
-        <a href="http://www.gavelfury.com/"
-           id="gavelfury"
-           target="_blank"
-           aria-label="GAVELFURY homepage">
-          <img class="main-img"
-               alt=""
-               src="{% static "img/fury.png" %}">
-        </a>
-      </div>
-      <div class="project-description">
-        <h3 class="subtitle simple-subtitle" id="gavelfury">
-          GAVELFURY
-        </h3>
-        <p>
-          See all instances of "!"
-        </p>
-        <p class="social">
-          <span class="website">
-            <a href="http://www.gavelfury.com/"
-               title="GAVELFURY homepage"
-               target="_blank"
-               aria-label="GAVELFURY homepage"></a>
-          </span>
-        </p>
-      </div>
+  <div class="row page-section">
+    <div class="project-image">
+      <a href="http://www.gavelfury.com/"
+         id="gavelfury"
+         target="_blank"
+         aria-label="GAVELFURY homepage">
+        <img class="main-img"
+             alt=""
+             src="{% static "img/fury.png" %}">
+      </a>
+    </div>
+    <div class="project-description">
+      <h3 class="subtitle simple-subtitle" id="gavelfury">
+        GAVELFURY
+      </h3>
+      <p>
+        See all instances of "!"
+      </p>
+      <p class="social">
+        <span class="website">
+          <a href="http://www.gavelfury.com/"
+             title="GAVELFURY homepage"
+             target="_blank"
+             aria-label="GAVELFURY homepage"></a>
+        </span>
+      </p>
     </div>
   </div>
-  {# =============> CODE EXAMPLES <============= #}
-  <div class="page-section">
-    <div class="row">
-      <div class="project-image">
-        <a href="https://github.com/harvard-lil/cap-examples"
-           id="examples"
-           aria-label="Limericks homepage">
-          <img class="main-img"
-               alt=""
-               src="{% static "img/examples.png" %}">
-        </a>
-      </div>
 
-      <div class="project-description">
-        <h3 class="subtitle simple-subtitle" id="examples">
-          Code examples
-        </h3>
-        <p>
-          See some ways of getting started with the data! Examples are written in Python.
-        </p>
-        <p class="social">
-          <span class="github">
-            <a href="https://github.com/harvard-lil/cap-examples"
-               target="_blank"
-               title="Examples source code on Github"
-               aria-label="Examples source code on Github"></a>
-          </span>
-        </p>
-      </div>
+  {# =============> CODE EXAMPLES <============= #}
+  <div class="row page-section">
+    <div class="project-image">
+      <a href="https://github.com/harvard-lil/cap-examples"
+         id="examples"
+         aria-label="Limericks homepage">
+        <img class="main-img"
+             alt=""
+             src="{% static "img/examples.png" %}">
+      </a>
+    </div>
+
+    <div class="project-description">
+      <h3 class="subtitle simple-subtitle" id="examples">
+        Code examples
+      </h3>
+      <p>
+        See some ways of getting started with the data! Examples are written in Python.
+      </p>
+      <p class="social">
+        <span class="github">
+          <a href="https://github.com/harvard-lil/cap-examples"
+             target="_blank"
+             title="Examples source code on Github"
+             aria-label="Examples source code on Github"></a>
+        </span>
+      </p>
     </div>
   </div>
+
   {# =============> CAP SEARCH <============= #}
-  <div class="page-section">
-    <div class="row">
-      <div class="project-image">
-        <a href="https://github.com/harvard-lil/capstone/tree/develop/capstone/capbrowse"
-           id="cap-search"
-           aria-label="CAP search code">
-          <img class="main-img"
-               alt=""
-               src="{% static "img/cap-search.png" %}">
-        </a>
-      </div>
-      <div class="project-description">
-        <h3 class="subtitle simple-subtitle" id="cap-search">
-            CAP Search
-        </h3>
-        <p>
-          Our own search utility is a CAPAPI consumer written in Vue
-          with a smattering of python on the back end. Most of the
-          relevant code can be found in the 'capbrowse' app in
-          Capstone, our larger codebase for case management.
-        </p>
-        <p class="social">
-          <span class="github">
-            <a href="https://github.com/harvard-lil/capstone/tree/develop/capstone/capbrowse"
-               target="_blank"
-               title="Capstone source code on Github"
-               aria-label="Capstone source code on Github"></a>
-          </span>
-          <span class="website">
-            <a href="{% url "search" %}"
-               title="CAP Search"
-               target="_blank"
-               aria-label="CAP Search"></a>
-          </span>
-        </p>
-      </div>
+  <div class="row page-section">
+    <div class="project-image">
+      <a href="https://github.com/harvard-lil/capstone/tree/develop/capstone/capbrowse"
+         id="cap-search"
+         aria-label="CAP search code">
+        <img class="main-img"
+             alt=""
+             src="{% static "img/cap-search.png" %}">
+      </a>
+    </div>
+    <div class="project-description">
+      <h3 class="subtitle simple-subtitle" id="cap-search">
+          CAP Search
+      </h3>
+      <p>
+        Our own search utility is a CAPAPI consumer written in Vue
+        with a smattering of python on the back end. Most of the
+        relevant code can be found in the 'capbrowse' app in
+        Capstone, our larger codebase for case management.
+      </p>
+      <p class="social">
+        <span class="github">
+          <a href="https://github.com/harvard-lil/capstone/tree/develop/capstone/capbrowse"
+             target="_blank"
+             title="Capstone source code on Github"
+             aria-label="Capstone source code on Github"></a>
+        </span>
+        <span class="website">
+          <a href="{% url "search" %}"
+             title="CAP Search"
+             target="_blank"
+             aria-label="CAP Search"></a>
+        </span>
+      </p>
     </div>
   </div>
 {% endblock %}

--- a/capstone/capweb/templates/index.html
+++ b/capstone/capweb/templates/index.html
@@ -5,8 +5,8 @@
 {% load format_number %}
 {% load render_bundle from webpack_loader %}
 
+{% block base_css %}{% stylesheet 'index' %}{% endblock %}
 {% block extra_head %}
-  {% stylesheet 'index' %}
   {% render_bundle 'map' %}
 {% endblock %}
 

--- a/capstone/capweb/templates/main_base.html
+++ b/capstone/capweb/templates/main_base.html
@@ -57,7 +57,8 @@
     <title>{% block title %}{% if title %}{{ title }}{% endif %}{% endblock title %}{% block title_suffix %} | Caselaw Access Project{% endblock title_suffix %}</title>
     <meta name="description" content="{% block meta_description %}{% if meta_description %}{{ meta_description }}{% else %}Explore American Caselaw{% endif %}{% endblock meta_description %}">
 
-    {% stylesheet "base" %}
+    {# if a stylesheet has to import base.scss, it should override this block instead of going in extra_head to avoid double import #}
+    {% block base_css %}{% stylesheet "base" %}{% endblock %}
     {% render_bundle 'chunk-vendors' %}
     {% render_bundle 'base' %}
     {% block extra_head %}{% endblock %}

--- a/capstone/capweb/templates/privacy-policy.html
+++ b/capstone/capweb/templates/privacy-policy.html
@@ -57,126 +57,106 @@
 
 {% block main_content %}
   {# ==============> INFORMATION <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="info-types">What types of information does CAP collect?</h2>
-    <ol class="num pl-0 mt-4">
-      <li class="h5 highlighted">Usage Data</li>
-      <p>As with most services, CAP may automatically collect certain information when you use the Services, even when
-        you
-        are not logged in. CAP collects this information when you access the Services, including when you set up an
-        account or browse, read, or download information from the Services. This type of information may include, but is
-        not limited to, your IP address, URL request, browser type, and the date and time of a request. CAP may use
-        cookies or other automated mechanisms to collect this information and may collect this information on an
-        aggregate
-        or individual basis. Cookies are small text files that the Services can send to your browser for storage on your
-        computer. They make use of the Website easier by saving your status and preferences and refreshing them every
-        time
-        you use the Website. For instance, to facilitate registration and login functions, CAP may use cookies to
-        recognize when you return to the Website so that you do not have to resubmit your logon credentials. In order to
-        clear this logon information, for example if using a public terminal, you should log out of your account. While
-        many browsers allow you to change your settings in order to refuse cookies or to be alerted when cookies are
-        being
-        sent, it is recommended that you leave cookies enabled, as disabling cookies may interfere with some
-        functionality
-        of the Services.</p>
-      <li class="h5 highlighted">Personal Information</li>
-      <p>In order to access certain parts of the Services, CAP may require you to provide personal information, such as
-        your
-        name and email address. CAP uses this information to manage your account, communicate with you, and provide the
-        Services to you. CAP will not collect any personal information from your use of the Services unless you choose
-        to
-        provide it by registering for an account or otherwise posting, sending, or uploading the information to the
-        Services.</p>
-    </ol>
-  </div>
+  <h2 class="subtitle" id="info-types">What types of information does CAP collect?</h2>
+  <ol class="num pl-0 mt-4">
+    <li class="h5 highlighted">Usage Data</li>
+    <p>As with most services, CAP may automatically collect certain information when you use the Services, even when
+      you
+      are not logged in. CAP collects this information when you access the Services, including when you set up an
+      account or browse, read, or download information from the Services. This type of information may include, but is
+      not limited to, your IP address, URL request, browser type, and the date and time of a request. CAP may use
+      cookies or other automated mechanisms to collect this information and may collect this information on an
+      aggregate
+      or individual basis. Cookies are small text files that the Services can send to your browser for storage on your
+      computer. They make use of the Website easier by saving your status and preferences and refreshing them every
+      time
+      you use the Website. For instance, to facilitate registration and login functions, CAP may use cookies to
+      recognize when you return to the Website so that you do not have to resubmit your logon credentials. In order to
+      clear this logon information, for example if using a public terminal, you should log out of your account. While
+      many browsers allow you to change your settings in order to refuse cookies or to be alerted when cookies are
+      being
+      sent, it is recommended that you leave cookies enabled, as disabling cookies may interfere with some
+      functionality
+      of the Services.</p>
+    <li class="h5 highlighted">Personal Information</li>
+    <p>In order to access certain parts of the Services, CAP may require you to provide personal information, such as
+      your
+      name and email address. CAP uses this information to manage your account, communicate with you, and provide the
+      Services to you. CAP will not collect any personal information from your use of the Services unless you choose
+      to
+      provide it by registering for an account or otherwise posting, sending, or uploading the information to the
+      Services.</p>
+  </ol>
 
   {# ==============> INFO USE <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="info-use">How does CAP use the information it collects?</h2>
-    <p>
-      CAP uses the information that it collects to deliver and improve the Services, administer mailing lists and online
-      communities, and other activities related to the provision of the Services. CAP may retain all data and content
-      collected through the Services for restorative, archival, or research purposes.
-    </p>
-  </div>
-
+  <h2 class="subtitle" id="info-use">How does CAP use the information it collects?</h2>
+  <p>
+    CAP uses the information that it collects to deliver and improve the Services, administer mailing lists and online
+    communities, and other activities related to the provision of the Services. CAP may retain all data and content
+    collected through the Services for restorative, archival, or research purposes.
+  </p>
 
   {# ==============> INFO DISCLOSE <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="info-disclose">When does CAP disclose information to third parties?</h2>
+  <h2 class="subtitle" id="info-disclose">When does CAP disclose information to third parties?</h2>
 
-    <p>CAP uses third party services providers, such as web analytics providers, infrastructure providers, and other
-      similar providers, to help deliver the Services. CAP may share the information it collects through the Services
-      with
-      these service providers as necessary to provide or improve the Services. CAP may also share certain information it
-      collects with its research partners. In addition, although CAP will not publicly share personal information unless
-      you choose to make that information public, CAP may publicly share aggregated data or statistics related to the
-      Services that may include anonymized user information or usage statistics. Finally, CAP may share information when
-      responding to a request from law enforcement, or to prevent malicious use of the Services. In the event that CAP
-      is
-      required by law to disclose any information related to your account, CAP will use reasonable efforts to provide
-      you
-      with notice of the request by email, unless CAP is prohibited by law or government order from doing so. CAP will
-      not
-      sell information it collects or stores through the Services to any third parties for monetary compensation.</p>
-  </div>
+  <p>CAP uses third party services providers, such as web analytics providers, infrastructure providers, and other
+    similar providers, to help deliver the Services. CAP may share the information it collects through the Services
+    with
+    these service providers as necessary to provide or improve the Services. CAP may also share certain information it
+    collects with its research partners. In addition, although CAP will not publicly share personal information unless
+    you choose to make that information public, CAP may publicly share aggregated data or statistics related to the
+    Services that may include anonymized user information or usage statistics. Finally, CAP may share information when
+    responding to a request from law enforcement, or to prevent malicious use of the Services. In the event that CAP
+    is
+    required by law to disclose any information related to your account, CAP will use reasonable efforts to provide
+    you
+    with notice of the request by email, unless CAP is prohibited by law or government order from doing so. CAP will
+    not
+    sell information it collects or stores through the Services to any third parties for monetary compensation.</p>
 
   {# ==============> THIRD PARTY ACCESS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="third-party-access">What if I access another website or third party service through the Services?</h2>
+  <h2 class="subtitle" id="third-party-access">What if I access another website or third party service through the Services?</h2>
 
-    <p>CAP may link you to or provide you access to services or websites offered by third parties, such as libraries,
-      museums, archives, Facebook, Twitter, Google, and other similar services. Please note that this privacy policy
-      does
-      not apply to the practices of those third parties, and CAP is not responsible for the privacy practices of those
-      third parties. Please make sure you are comfortable with the privacy practices of these third parties before using
-      their services.</p>
-  </div>
-
+  <p>CAP may link you to or provide you access to services or websites offered by third parties, such as libraries,
+    museums, archives, Facebook, Twitter, Google, and other similar services. Please note that this privacy policy
+    does
+    not apply to the practices of those third parties, and CAP is not responsible for the privacy practices of those
+    third parties. Please make sure you are comfortable with the privacy practices of these third parties before using
+    their services.</p>
 
   {# ==============> SECURITY <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="security">Security</h2>
-    <p>CAP has taken efforts to put security measures in place to protect information and data that is collected through
-      the Services. However, CAP cannot guarantee or warrant that any information collected through the Services will
-      remain confidential, and many functions of the Services are intended to make information and content publicly
-      available. You are responsible for setting and maintaining the security of your password. CAP may not keep a copy
-      of
-      your password, so please safeguard the password associated with your account and do not share your password with
-      third parties.</p>
-  </div>
-
+  <h2 class="subtitle" id="security">Security</h2>
+  <p>CAP has taken efforts to put security measures in place to protect information and data that is collected through
+    the Services. However, CAP cannot guarantee or warrant that any information collected through the Services will
+    remain confidential, and many functions of the Services are intended to make information and content publicly
+    available. You are responsible for setting and maintaining the security of your password. CAP may not keep a copy
+    of
+    your password, so please safeguard the password associated with your account and do not share your password with
+    third parties.</p>
 
   {# ==============> Transfer of Information <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="transfer">Transfer of Information</h2>
+  <h2 class="subtitle" id="transfer">Transfer of Information</h2>
 
-    <p>Your information may be transferred to and maintained on servers and databases located outside of your state,
-      province, country or other governmental jurisdiction where the privacy laws may not be as protective as your
-      jurisdiction. Please be advised that we may transfer your information to and from any state, province, country or
-      other governmental jurisdiction, and process it in the United States or elsewhere. By using the Services, you
-      consent to any such transfer of your information.</p>
-  </div>
+  <p>Your information may be transferred to and maintained on servers and databases located outside of your state,
+    province, country or other governmental jurisdiction where the privacy laws may not be as protective as your
+    jurisdiction. Please be advised that we may transfer your information to and from any state, province, country or
+    other governmental jurisdiction, and process it in the United States or elsewhere. By using the Services, you
+    consent to any such transfer of your information.</p>
 
   {# ==============> Changes <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="changes">Changes to this Privacy Policy
-    </h2>
+  <h2 class="subtitle" id="changes">Changes to this Privacy Policy
+  </h2>
 
-    <p>CAP reserves the right to modify this privacy policy at any time at its discretion. If CAP does make changes to
-      this privacy policy, CAP will update this page accordingly. Please check this page periodically for any changes.
-      Unless otherwise defined in this privacy policy, terms used in this privacy policy have the same meanings as in
-      the
-      Terms of Use.</p>
-  </div>
-
+  <p>CAP reserves the right to modify this privacy policy at any time at its discretion. If CAP does make changes to
+    this privacy policy, CAP will update this page accordingly. Please check this page periodically for any changes.
+    Unless otherwise defined in this privacy policy, terms used in this privacy policy have the same meanings as in
+    the
+    Terms of Use.</p>
 
   {# ==============> Questions <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="questions">Questions?</h2>
+  <h2 class="subtitle" id="questions">Questions?</h2>
 
-    <p>If you have questions about this privacy policy, please contact CAP.</p>
+  <p>If you have questions about this privacy policy, please contact CAP.</p>
 
-    <p>Last modified on October 2, 2018.</p>
-  </div>
+  <p>Last modified on October 2, 2018.</p>
 {% endblock %}

--- a/capstone/capweb/templates/search_docs.html
+++ b/capstone/capweb/templates/search_docs.html
@@ -50,130 +50,122 @@
 
 {% block main_content %}
   {# ==============> ABOUT <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="about">Overview</h2>
-    <p><a class="btn-primary" href="{% url "search" %}">Search CAP</a></p>
-    <p>
-       With this tool, we aim to provide a simple interface for locating and viewing the cases and metadata in the CAP
-      repository. Right now, this tool is fairly basic. You can use it to search through our cases and some of our
-      metadata tables, but there are no advanced tools. If you have any feature suggestions, we'd appreciate your taking
-      the time to let us know either in an issue report <a href="https://github.com/harvard-lil/capstone/issues">in our
-      code repository on github.com</a>, or through our <a href="{% url 'contact' %}">contact page</a>.
-    </p>
-    <p>
-      If you're a developer, you might be more interested in directly accessing our <a href="{% url "api" %}">API</a> or
-      <a href="{% url "bulk-docs" %}">Bulk Data</a>.
-    </p>
-  </div>
+  <h2 class="subtitle" id="about">Overview</h2>
+  <p><a class="btn-primary" href="{% url "search" %}">Search CAP</a></p>
+  <p>
+     With this tool, we aim to provide a simple interface for locating and viewing the cases and metadata in the CAP
+    repository. Right now, this tool is fairly basic. You can use it to search through our cases and some of our
+    metadata tables, but there are no advanced tools. If you have any feature suggestions, we'd appreciate your taking
+    the time to let us know either in an issue report <a href="https://github.com/harvard-lil/capstone/issues">in our
+    code repository on github.com</a>, or through our <a href="{% url 'contact' %}">contact page</a>.
+  </p>
+  <p>
+    If you're a developer, you might be more interested in directly accessing our <a href="{% url "api" %}">API</a> or
+    <a href="{% url "bulk-docs" %}">Bulk Data</a>.
+  </p>
+
   {# ==============> SCOPE <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="about">What's included?</h2>
-    <p>
-      The CAP search tool searches everything included in the <a href="{% url 'api' %}">CAP API</a>. See
-      <a href="{% url 'about' %}#data">our About page</a> for more details on the materials included.
-    </p>
-  </div>
+  <h2 class="subtitle" id="about">What's included?</h2>
+  <p>
+    The CAP search tool searches everything included in the <a href="{% url 'api' %}">CAP API</a>. See
+    <a href="{% url 'about' %}#data">our About page</a> for more details on the materials included.
+  </p>
+
   {# ==============> SEARCHING <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="searching">Searching in CAP is simple</h2>
-    <div>
-      <ul>
-        <li><strong>First:</strong> Choose What To Search</li>
-        <li><strong>Second:</strong> Select Your Search Criteria</li>
-        <li><strong>Third:</strong> Execute the Search</li>
-      </ul>
-    </div>
-    <div>
-      <dt>Choose What To Search</dt>
-      <dd>
-        The search tool allows you to search through several different tables of objects; right now, you may search
-        cases, courts, jurisdictions, and reporters. When you first arrive at the search page, it is set to search
-        cases. To search for something else, click on "Cases" and select something else from the dropdown menu. By
-        default, the search tool is set to search for Cases. To search for something else, click on "Cases" and select
-        something from the dropdown menu.
-      </dd>
-      <dd>
-        For example, you may want to search our jurisdiction list. At the top of the search form where it says "Search
-        for
-        <u>Cases</u>" (or whatever else it might be set to) you should click on the word "Cases" and select something
-        else
-        from the dropdown menu.
-      </dd>
-    </div>
-    <div>
-      <dt>Select Your Search Criteria</dt>
-      <dd>
-        Within each table of objects, there are several fields you can use to define your search. You could search for
-        cases by their citation or by full-text search, and you can search for reporters by their jurisdiction. You can
-        even precisely refine your search by using several fields at once. To add a field to your search, simply click
-        the
-        "Add Field" button, select the field you wish to add from the dropdown, add your search criteria, and press the
-        search button.
-      </dd>
-      <dd>
-        For example, if you were searching our Reporters, the default search field is Jurisdiction. Perhaps you'd like
-        to
-        search for reporters' names that start with a specific word: Press the "Add Field" button, and from the dropdown
-        box, and select "Full Name." There is no need to remove any field boxes you don't plan on entering search terms
-        into— they will not affect the search results— but it certainly might make complex searches easier to manage,
-        visually.
-      </dd>
-      <dt>Execute the Search</dt>
-      <dd>
-        Here's the easy part— just click on the Search button. The loading screen should pop up momentarily, and your
-        search results should appear below. If there was a problem contacting the search server, or the server returned
-        an error with one of your search fields, it appears on-screen.
-      </dd>
-    </div>
+  <h2 class="subtitle" id="searching">Searching in CAP is simple</h2>
+  <div>
+    <ul>
+      <li><strong>First:</strong> Choose What To Search</li>
+      <li><strong>Second:</strong> Select Your Search Criteria</li>
+      <li><strong>Third:</strong> Execute the Search</li>
+    </ul>
+  </div>
+  <div>
+    <dt>Choose What To Search</dt>
+    <dd>
+      The search tool allows you to search through several different tables of objects; right now, you may search
+      cases, courts, jurisdictions, and reporters. When you first arrive at the search page, it is set to search
+      cases. To search for something else, click on "Cases" and select something else from the dropdown menu. By
+      default, the search tool is set to search for Cases. To search for something else, click on "Cases" and select
+      something from the dropdown menu.
+    </dd>
+    <dd>
+      For example, you may want to search our jurisdiction list. At the top of the search form where it says "Search
+      for
+      <u>Cases</u>" (or whatever else it might be set to) you should click on the word "Cases" and select something
+      else
+      from the dropdown menu.
+    </dd>
+  </div>
+  <div>
+    <dt>Select Your Search Criteria</dt>
+    <dd>
+      Within each table of objects, there are several fields you can use to define your search. You could search for
+      cases by their citation or by full-text search, and you can search for reporters by their jurisdiction. You can
+      even precisely refine your search by using several fields at once. To add a field to your search, simply click
+      the
+      "Add Field" button, select the field you wish to add from the dropdown, add your search criteria, and press the
+      search button.
+    </dd>
+    <dd>
+      For example, if you were searching our Reporters, the default search field is Jurisdiction. Perhaps you'd like
+      to
+      search for reporters' names that start with a specific word: Press the "Add Field" button, and from the dropdown
+      box, and select "Full Name." There is no need to remove any field boxes you don't plan on entering search terms
+      into— they will not affect the search results— but it certainly might make complex searches easier to manage,
+      visually.
+    </dd>
+    <dt>Execute the Search</dt>
+    <dd>
+      Here's the easy part— just click on the Search button. The loading screen should pop up momentarily, and your
+      search results should appear below. If there was a problem contacting the search server, or the server returned
+      an error with one of your search fields, it appears on-screen.
+    </dd>
   </div>
 
   {# ==============> TIPS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="tips">Tips</h2>
-    <div>
-        <p>
-        You may use as many search field boxes as you like.
-        </p>
+  <h2 class="subtitle" id="tips">Tips</h2>
+  <div>
+      <p>
+      You may use as many search field boxes as you like.
+      </p>
 
-        <p>
-        For Full-Text searching (currently only available in Cases) each separate word is treated as a separate search
-          term bound with a logical "and." We don't yet offer phrase searching but plan to implement it soon.
-        </p>
+      <p>
+      For Full-Text searching (currently only available in Cases) each separate word is treated as a separate search
+        term bound with a logical "and." We don't yet offer phrase searching but plan to implement it soon.
+      </p>
 
-        <p>
-          Results in metadata searches allow you to efficiently perform a new search for all of the cases related to that
-          result. For example, if you're searching our jurisdiction list, each result on that list has a "See Cases"
-          button that starts a new search for all of the cases under the specified jurisdiction. Don't worry— you can
-          get back to your original search using the back button.
-        </p>
+      <p>
+        Results in metadata searches allow you to efficiently perform a new search for all of the cases related to that
+        result. For example, if you're searching our jurisdiction list, each result on that list has a "See Cases"
+        button that starts a new search for all of the cases under the specified jurisdiction. Don't worry— you can
+        get back to your original search using the back button.
+      </p>
 
-        <p>
-        You may use as many search field boxes as you like.
-        </p>
+      <p>
+      You may use as many search field boxes as you like.
+      </p>
 
-        <p>
-          To share a search, simply copy the URL and pass it along! It will link the user to the specific page of
-          results you're viewing. To send them to the first page of results, navigate to the first page of results
-          before copying the URL.
-        </p>
-    </div>
+      <p>
+        To share a search, simply copy the URL and pass it along! It will link the user to the specific page of
+        results you're viewing. To send them to the first page of results, navigate to the first page of results
+        before copying the URL.
+      </p>
   </div>
 
   {# ==============> TIPS <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="research">Getting Legal Help</h2>
-    <div>
-        <p>
-          Our caselaw search tool is not kept up to date. It currently has caselaw through
-          mid-2018, but may contain many mistakes as well. It is not intended for use in legal proceedings, and we
-          cannot provide individual assistance with legal research.
-        </p>
-        <p>
-          To find an attorney, get help with legal research skills, or find up-to-date databases for use in legal
-          proceedings, please see the <a href="{% url "about" %}#legal-help">"Getting Legal Help" section of our About
-          page</a>.
-        </p>
-    </div>
+  <h2 class="subtitle" id="research">Getting Legal Help</h2>
+  <div>
+      <p>
+        Our caselaw search tool is not kept up to date. It currently has caselaw through
+        mid-2018, but may contain many mistakes as well. It is not intended for use in legal proceedings, and we
+        cannot provide individual assistance with legal research.
+      </p>
+      <p>
+        To find an attorney, get help with legal research skills, or find up-to-date databases for use in legal
+        proceedings, please see the <a href="{% url "about" %}#legal-help">"Getting Legal Help" section of our About
+        page</a>.
+      </p>
   </div>
 
 {% endblock %}

--- a/capstone/capweb/templates/tools.html
+++ b/capstone/capweb/templates/tools.html
@@ -37,43 +37,36 @@
 {% block main_content_style %}{% endblock %}
 {% block main_content %}
   {# ==============> API  <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="api">The API</h2>
-    <p>
-      Our open-source API is the best option for anybody interested in programmatically accessing our
-      metadata, full-text search, or individual cases.
-    </p>
-    <div class="btn-group">
-      <a class="btn-primary" href="{% api_url "api-root" %}">API</a>
-      <a class="btn-secondary" href="{% url "api" %}">DOCS</a>
-    </div>
+  <h2 class="subtitle" id="api">The API</h2>
+  <p>
+    Our open-source API is the best option for anybody interested in programmatically accessing our
+    metadata, full-text search, or individual cases.
+  </p>
+  <div class="btn-group">
+    <a class="btn-primary" href="{% api_url "api-root" %}">API</a>
+    <a class="btn-secondary" href="{% url "api" %}">DOCS</a>
   </div>
 
   {# ==============> BULK!! <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="bulk">Bulk Data</h2>
-    <p>
-      If you need a large collection of cases, you will probably be best served by our bulk data downloads.
-      Bulk downloads for Illinois and Arkansas are available without a login, and unlimited bulk files are available to
-      research scholars.
-    </p>
-    <div class="btn-group">
-      <a class="btn-primary" href="{% url "bulk-download" %}">BULK DATA</a>
-      <a class="btn-secondary" href="{% url "bulk-docs" %}">DOCS</a>
-    </div>
-
+  <h2 class="subtitle" id="bulk">Bulk Data</h2>
+  <p>
+    If you need a large collection of cases, you will probably be best served by our bulk data downloads.
+    Bulk downloads for Illinois and Arkansas are available without a login, and unlimited bulk files are available to
+    research scholars.
+  </p>
+  <div class="btn-group">
+    <a class="btn-primary" href="{% url "bulk-download" %}">BULK DATA</a>
+    <a class="btn-secondary" href="{% url "bulk-docs" %}">DOCS</a>
   </div>
+
   {# ==============> SEARCH <============== #}
-  <div class="page-section">
-    <h2 class="subtitle" id="search">Search</h2>
-    <p>
-      Our search interface offers access to all of the same cases and most of our metadata with an intuitive,
-      flexible interface.
-    </p>
-    <div class="btn-group">
-      <a class="btn-primary" href="{% url "search" %}">SEARCH</a>
-      <a class="btn-secondary" href="{% url "search-docs" %}">DOCS</a>
-    </div>
+  <h2 class="subtitle" id="search">Search</h2>
+  <p>
+    Our search interface offers access to all of the same cases and most of our metadata with an intuitive,
+    flexible interface.
+  </p>
+  <div class="btn-group">
+    <a class="btn-primary" href="{% url "search" %}">SEARCH</a>
+    <a class="btn-secondary" href="{% url "search-docs" %}">DOCS</a>
   </div>
-
 {% endblock %}

--- a/capstone/cite/templates/cite/citation_failed.html
+++ b/capstone/cite/templates/cite/citation_failed.html
@@ -9,16 +9,14 @@
 {% block meta_description %}Caselaw Access Project cases{% endblock %}
 
 {% block main_content %}
-  <div class="page-section">
-    {% if not cases %}
-      Citation "{{ full_cite }}" not found. <a href="https://scholar.google.com/scholar?as_sdt=40000006&q={{ full_cite }}">Click here to search Google Scholar</a>.
-    {% else %}
-      <h2 class="subtitle">Multiple cases match "{{ full_cite }}"</h2>
-      <ul>
-        {% for case in cases %}
-          <li><a href="{% url 'citation' series_slug=series_slug volume_number=volume_number page_number=page_number case_id=case.id host 'cite' %}">{{ case.full_cite }}</a></li>
-        {% endfor %}
-      </ul>
-    {% endif %}
-  </div>
+  {% if not cases %}
+    Citation "{{ full_cite }}" not found. <a href="https://scholar.google.com/scholar?as_sdt=40000006&q={{ full_cite }}">Click here to search Google Scholar</a>.
+  {% else %}
+    <h2 class="subtitle">Multiple cases match "{{ full_cite }}"</h2>
+    <ul>
+      {% for case in cases %}
+        <li><a href="{% url 'citation' series_slug=series_slug volume_number=volume_number page_number=page_number case_id=case.id host 'cite' %}">{{ case.full_cite }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endif %}
 {% endblock %}

--- a/capstone/cite/templates/cite/home.html
+++ b/capstone/cite/templates/cite/home.html
@@ -18,19 +18,17 @@
 {% endblock %}
 
 {% block main_content %}
-  <div class="page-section">
-    {% for jurisdiction, reporters in jurisdictions %}
-      <h2 class="subtitle" id="{{ jurisdiction.slug }}">
-        {{ jurisdiction }}
-      </h2>
-      <ul>
-        {% for reporter in reporters %}
-          <li>
-            <strong><a href="{% url 'series' series_slug=reporter.short_name_slug host 'cite' %}">{{ reporter.short_name }}</a>:</strong>
-            {{ reporter.full_name }} ({{ reporter.start_year }}-{{ reporter.end_year }})
-          </li>
-        {% endfor %}
-      </ul>
-    {% endfor %}
-  </div>
+  {% for jurisdiction, reporters in jurisdictions %}
+    <h2 class="subtitle" id="{{ jurisdiction.slug }}">
+      {{ jurisdiction }}
+    </h2>
+    <ul>
+      {% for reporter in reporters %}
+        <li>
+          <strong><a href="{% url 'series' series_slug=reporter.short_name_slug host 'cite' %}">{{ reporter.short_name }}</a>:</strong>
+          {{ reporter.full_name }} ({{ reporter.start_year }}-{{ reporter.end_year }})
+        </li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
 {% endblock %}

--- a/capstone/cite/templates/cite/series.html
+++ b/capstone/cite/templates/cite/series.html
@@ -4,16 +4,14 @@
 {% block meta_description %}Caselaw Access Project cases{% endblock %}
 
 {% block main_content %}
-  <div class="page-section">
-    {% for reporter, volumes in reporters %}
-      <h2 class="subtitle">{{ reporter.short_name }}</h2>
-      <p>{{ reporter.full_name }} ({{ reporter.start_year }}-{{ reporter.end_year }})</p>
-      <p>
-        <strong>Volume number:</strong>
-        {% for volume in volumes %}
-          <a href="{% url 'volume' series_slug=reporter.short_name_slug volume_number=volume.volume_number host 'cite' %}">{{ volume.volume_number }}</a>
-        {% endfor %}
-      </p>
-    {% endfor %}
-  </div>
+  {% for reporter, volumes in reporters %}
+    <h2 class="subtitle">{{ reporter.short_name }}</h2>
+    <p>{{ reporter.full_name }} ({{ reporter.start_year }}-{{ reporter.end_year }})</p>
+    <p>
+      <strong>Volume number:</strong>
+      {% for volume in volumes %}
+        <a href="{% url 'volume' series_slug=reporter.short_name_slug volume_number=volume.volume_number host 'cite' %}">{{ volume.volume_number }}</a>
+      {% endfor %}
+    </p>
+  {% endfor %}
 {% endblock %}

--- a/capstone/cite/templates/cite/set_cookie.html
+++ b/capstone/cite/templates/cite/set_cookie.html
@@ -5,22 +5,20 @@
 {% block meta_description %}Caselaw Access Project cases{% endblock %}
 
 {% block main_content %}
-  <div class="page-section">
-    <p>
-      Welcome to the Caselaw Access Project! We offer free access without a login to up to 500 cases per person per day,
-      brought to you by the Harvard Law Library.
-    </p>
-    <p><strong>
-      If you continue to see this page, please check that you have cookies enabled for our site. We require cookies to
-      enforce the cases-per-person-per-day limit.
-    </strong></p>
-    <p>
-      This part of our site is for humans, not bots. If you need programmatic access, please check out our API. If you
-      need more than 500 cases per day, please see our docs on how to do that. You can also read our full terms of service.
-    </p>
-    <form method="post">
-      {% csrf_token %}
-      <button type="submit" name="not_a_bot" value="yes" id="not-a-bot">Great, take me to the cases!</button>
-    </form>
-  </div>
+  <p>
+    Welcome to the Caselaw Access Project! We offer free access without a login to up to 500 cases per person per day,
+    brought to you by the Harvard Law Library.
+  </p>
+  <p><strong>
+    If you continue to see this page, please check that you have cookies enabled for our site. We require cookies to
+    enforce the cases-per-person-per-day limit.
+  </strong></p>
+  <p>
+    This part of our site is for humans, not bots. If you need programmatic access, please check out our API. If you
+    need more than 500 cases per day, please see our docs on how to do that. You can also read our full terms of service.
+  </p>
+  <form method="post">
+    {% csrf_token %}
+    <button type="submit" name="not_a_bot" value="yes" id="not-a-bot">Great, take me to the cases!</button>
+  </form>
 {% endblock %}

--- a/capstone/cite/templates/cite/volume.html
+++ b/capstone/cite/templates/cite/volume.html
@@ -4,17 +4,15 @@
 {% block meta_description %}Caselaw Access Project cases{% endblock %}
 
 {% block main_content %}
-  <div class="page-section">
-    {% for volume, cases in volumes %}
-      {% with volume.reporter as reporter %}
-        <h2 class="subtitle">{{ reporter.short_name }}</h2>
-        <p>{{ reporter.full_name }} ({{ reporter.start_year }}-{{ reporter.end_year }}) volume {{ volume.volume_number }}</p>
-        <ul>
-          {% for case in cases %}
-            <li><a href="{% url 'citation' series_slug=reporter.short_name_slug volume_number=volume.volume_number page_number=case.citations.first.page_number host 'cite' %}">{{ case.full_cite }}</a></li>
-          {% endfor %}
-        </ul>
-      {% endwith %}
-    {% endfor %}
-  </div>
+  {% for volume, cases in volumes %}
+    {% with volume.reporter as reporter %}
+      <h2 class="subtitle">{{ reporter.short_name }}</h2>
+      <p>{{ reporter.full_name }} ({{ reporter.start_year }}-{{ reporter.end_year }}) volume {{ volume.volume_number }}</p>
+      <ul>
+        {% for case in cases %}
+          <li><a href="{% url 'citation' series_slug=reporter.short_name_slug volume_number=volume.volume_number page_number=case.citations.first.page_number host 'cite' %}">{{ case.full_cite }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endwith %}
+  {% endfor %}
 {% endblock %}

--- a/capstone/static/css/scss/_page-structure.scss
+++ b/capstone/static/css/scss/_page-structure.scss
@@ -9,17 +9,18 @@
   p, ul {
     margin-bottom: 2rem;
   }
+  p {
+    margin-top: 1.25rem;
+  }
   img {
     max-width: 100%;
   }
   h2.subtitle {
     display: block;
     position: relative;
+    padding-top: 1.5rem;
     &:first-child {
-      padding-top: 3.5rem;
-      @include media-breakpoint-down(md) {
-        padding-top: 1rem;
-      }
+      padding-top: 0;
     }
   }
   @include media-breakpoint-up(md) {
@@ -39,14 +40,8 @@
       padding-bottom: 6rem;
     }
   }
-  .page-section {
-    margin-bottom: 3rem;
-    margin-top: 1rem;
-    p {
-      margin-top: 20px;
-    }
-  }
   .main-content {
+    padding-top: 4.5rem;
     padding-bottom: 3rem;
     margin: 0 auto;
     @include media-breakpoint-up(lg) {

--- a/capstone/static/css/scss/_variables.scss
+++ b/capstone/static/css/scss/_variables.scss
@@ -134,3 +134,13 @@ $font-serif-fancy: "Libre Baskerville", "Baskerville", serif;
 $font-monospace: "source-code", monospace;
 
 $header-margin-size: 4rem;
+
+%footer-lil-logo-white {
+  background: url("../../img/logos/lil-white.svg") no-repeat;
+  background-size: contain !important;
+}
+
+%footer-lil-logo-black {
+  background: url("../../img/logos/lil-black.svg") no-repeat;
+  background-size: contain !important;
+}

--- a/capstone/static/css/scss/about.scss
+++ b/capstone/static/css/scss/about.scss
@@ -1,3 +1,2 @@
 @import 'variables';
-@import 'base.scss';
 @import 'footer/yellow';

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -309,20 +309,18 @@ li.item-set {
 }
 
 /* logos */
-.footer-lil-logo {
+footer .lil-logo {
   width: 173px;
   height: 90px;
   display: block;
 }
 
 .footer-lil-logo-white {
-  @extend .footer-lil-logo;
   background: url("../../img/logos/lil-white.svg") no-repeat;
   background-size: contain !important;
 }
 
 .footer-lil-logo-black {
-  @extend .footer-lil-logo;
   background: url("../../img/logos/lil-black.svg") no-repeat;
   background-size: contain !important;
 }

--- a/capstone/static/css/scss/contact.scss
+++ b/capstone/static/css/scss/contact.scss
@@ -1,5 +1,4 @@
 @import 'variables';
-@import 'base.scss';
 @import 'footer/black';
 
 .basic-page {

--- a/capstone/static/css/scss/footer/black.scss
+++ b/capstone/static/css/scss/footer/black.scss
@@ -13,6 +13,6 @@ footer {
     }
   }
   .lil-logo {
-    @extend .footer-lil-logo-white;
+    @extend %footer-lil-logo-white;
   }
 }

--- a/capstone/static/css/scss/footer/magenta.scss
+++ b/capstone/static/css/scss/footer/magenta.scss
@@ -1,6 +1,6 @@
 footer {
   background-color: $color-magenta;
   .lil-logo {
-    @extend .footer-lil-logo-black;
+    @extend %footer-lil-logo-black;
   }
 }

--- a/capstone/static/css/scss/footer/red.scss
+++ b/capstone/static/css/scss/footer/red.scss
@@ -1,7 +1,7 @@
 footer {
   background-color: $color-red;
   .lil-logo {
-    @extend .footer-lil-logo-black;
+    @extend %footer-lil-logo-black;
   }
   @include media-breakpoint-down(md) {
     .credits { color: $color-white; }

--- a/capstone/static/css/scss/footer/yellow.scss
+++ b/capstone/static/css/scss/footer/yellow.scss
@@ -1,6 +1,6 @@
 footer {
   background-color: $color-yellow;
   .lil-logo {
-    @extend .footer-lil-logo-black;
+    @extend %footer-lil-logo-black;
   }
 }

--- a/capstone/static/css/scss/gallery.scss
+++ b/capstone/static/css/scss/gallery.scss
@@ -1,5 +1,4 @@
 @import 'variables';
-@import 'base.scss';
 @import 'footer/magenta';
 
 @include media-breakpoint-down(md) {

--- a/capstone/static/css/scss/gallery.scss
+++ b/capstone/static/css/scss/gallery.scss
@@ -10,7 +10,6 @@
 }
 
 .subtitle.simple-subtitle {
-  margin-top: 2em;
   &:before {
     content: "";
     margin: 0;
@@ -24,7 +23,7 @@
 }
 
 .page-section {
-  padding-bottom: 3rem;
+  padding-bottom: 6rem;
   &:last-child {
     border-bottom: 0;
     padding-bottom: 0;
@@ -51,7 +50,6 @@
     @include make-col(3);
     .main-img {
       max-width: 80%;
-      margin-top: 50%;
     }
   }
   @include media-breakpoint-down(md) {

--- a/capstone/static/css/scss/tools.scss
+++ b/capstone/static/css/scss/tools.scss
@@ -1,4 +1,3 @@
 @import 'variables';
-@import 'base.scss';
 @import 'docs.scss';
 @import 'footer/black';


### PR DESCRIPTION
This should get margins looking right on the /terms page, and adjust the margins between sections on all the other pages.

Terms:

![image](https://user-images.githubusercontent.com/376272/57090482-e5749480-6cd4-11e9-8bfa-5b9e6f6e62d3.png)

Other pages using h2.subtitle for section headers:

![image](https://user-images.githubusercontent.com/376272/57090519-fa512800-6cd4-11e9-8791-2fa64b80a551.png)

Gallery:

![image](https://user-images.githubusercontent.com/376272/57090529-0341f980-6cd5-11e9-9e49-f13464b2ed6b.png)

Specific changes in the PR:

- Refactor some scss files to avoid redundant imports. Mostly that was by moving a mixin for the colored-footer files from base.scss to variables.scss. One exception, index.scss has to import base.scss, so I tweaked main_base.html and index.html to make sure that base.scss itself wasn't also included on the homepage.

- Remove the `<div class="page-section">` element (almost all the changes here are just removing that element and reindenting).

- Move the margin-top and margin-bottom that were on .page-section to be on .main-content and h2.subtitle instead.

- Custom padding in gallery.scss since it wasn't using h2.subtitle for spacing between projects