### PR TITLE
Include all requirements in pip-compile

### DIFF
--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -72,7 +72,9 @@ def pip_compile(args=''):
     Path('requirements.txt').write_text(reqs)
 
     # run pip-compile
-    command = ['pip-compile', '--generate-hashes']+args.split()
+    # Use --allow-unsafe because pip --require-hashes needs all requirements to be pinned, including those like
+    # setuptools that pip-compile leaves out by default.
+    command = ['pip-compile', '--generate-hashes', '--allow-unsafe']+args.split()
     print("Calling %s" % " ".join(command))
     subprocess.check_call(command, env=dict(os.environ, CUSTOM_COMPILE_COMMAND='fab pip-compile'))
 

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -814,3 +814,9 @@ wrapt==1.11.1 \
 xmltodict==0.11.0 \
     --hash=sha256:8f8d7d40aa28d83f4109a7e8aa86e67a4df202d9538be40c0cb1d70da527b0df \
     --hash=sha256:add07d92089ff611badec526912747cf87afd4f9447af6661aca074eeaf32615
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==41.0.1 \
+    --hash=sha256:a222d126f5471598053c9a77f4b5d4f26eaa1f150ad6e01dcf1a42e185d05613 \
+    --hash=sha256:c7769ce668c7a333d84e17fe8b524b1c45e7ee9f7908ad0a73e1eda7e6a5aebf \
+    # via markdown, pytest


### PR DESCRIPTION
Should fix

```
In --require-hashes mode, all requirements must have their versions pinned with ==. These do not:
    setuptools>=36
```

When running `pip install -r requirements.txt` for the first time.