### PR TITLE
Make multiline explainer

### DIFF
--- a/capstone/capweb/helpers.py
+++ b/capstone/capweb/helpers.py
@@ -174,5 +174,5 @@ def render_markdown(markdown_doc):
         .replace('<h2 ', '<h2 class="subtitle" ')
     toc = md.toc.replace('<a ', '<a class="list-group-item" ')
     toc = "".join(toc.splitlines(True)[2:-2])  # strip <div><ul> around toc by dropping first and last two lines
-    meta = {k:''.join(v) for k, v in md.Meta.items()}
+    meta = {k:' '.join(v) for k, v in md.Meta.items()}
     return html, toc, meta

--- a/capstone/capweb/templates/privacy-policy.md
+++ b/capstone/capweb/templates/privacy-policy.md
@@ -1,6 +1,16 @@
 title: Privacy Policy
 meta_description: Caselaw Access Project Privacy Policy
-explainer: Caselaw Access Project is operated by the President and Fellows of Harvard College (“Harvard”) in support of its mission to educate and disseminate knowledge and information. As used in this Privacy Policy, “CAP” refers to the Caselaw Access Project and to Harvard more generally. <br/><br/> CAP is committed to preserving your privacy and being transparent about how we use information collected through the case.law website (the “Website”) and any other applications, functionality or services offered by CAP (collectively with the Website, the “Services”). This privacy policy describes how CAP uses, collects, and shares information through the Services.
+explainer: Caselaw Access Project is operated by the President and Fellows
+    of Harvard College (“Harvard”) in support of its mission to
+    educate and disseminate knowledge and information. As used in this
+    Privacy Policy, “CAP” refers to the Caselaw Access Project and to
+    Harvard more generally. <br /><br /> CAP is committed to
+    preserving your privacy and being transparent about how we use
+    information collected through the case.law website (the “Website”)
+    and any other applications, functionality or services offered by
+    CAP (collectively with the Website, the “Services”). This privacy
+    policy describes how CAP uses, collects, and shares information
+    through the Services.
 
 ## What types of information does CAP collect?
 


### PR DESCRIPTION
(Also adds a space in the br tags)

I don't think I feel very strongly about hard-wrapping paragraphs in Markdown, as discussed elsewhere, but I do think it makes for easier-to-read diffs. 

@rebeccacremona points out that developers reading zoomed text don't experience the "natural" sub-80-character line as a natural length.