### PR TITLE
Update pip-tools and simplify pip_compile fab task

### DIFF
--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -35,7 +35,7 @@ services:
           - 9200:9200
     worker:
         build: .
-        image: capstone:0.3.7
+        image: capstone:0.3.8
         volumes:
             # NAMED VOLUMES
             # Use a named, persistent volume so that the node_modules directory,
@@ -62,7 +62,7 @@ services:
           - "api.case.test:127.0.0.1"
     web:
         build: .
-        image: capstone:0.3.7
+        image: capstone:0.3.8
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -60,16 +60,7 @@ def pip_compile(args=''):
         and convert them to https form with hashes once they're written to requirements.txt:
             https://github.com/jcushman/email-normalize/archive/6b5088bd05de247a9a33ad4e5c7911b676d6daf2.tar.gz#egg=email-normalize --hash=sha256:530851e150781c5208f0b60a278a902a3e5c6b98cd31d21f86eba54335134766
     """
-    import requests, hashlib, re, subprocess
-
-    def git_to_https(m):
-        url = 'https://%s/archive/%s.tar.gz#%s' % (m.group(1), m.group(2), m.group(3))
-        return '%s --hash=sha256:%s' % (url, hashlib.sha256(requests.get(url).content).hexdigest())
-
-    # convert https form to git form
-    reqs = Path('requirements.txt').read_text()
-    reqs = re.sub(r'https://(.*?)/archive/(.*?).tar.gz(\S*).*?\n', r'-e git+git://\1.git@\2\3\n', reqs)
-    Path('requirements.txt').write_text(reqs)
+    import subprocess
 
     # run pip-compile
     # Use --allow-unsafe because pip --require-hashes needs all requirements to be pinned, including those like
@@ -77,11 +68,6 @@ def pip_compile(args=''):
     command = ['pip-compile', '--generate-hashes', '--allow-unsafe']+args.split()
     print("Calling %s" % " ".join(command))
     subprocess.check_call(command, env=dict(os.environ, CUSTOM_COMPILE_COMMAND='fab pip-compile'))
-
-    # convert git form to https form
-    reqs = Path('requirements.txt').read_text()
-    reqs = re.sub(r'-e git\+git://(.*?).git@(.*?)#(\S*)', git_to_https, reqs)
-    Path('requirements.txt').write_text(reqs)
 
 @task
 def show_urls():

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -16,8 +16,7 @@ flower              # monitoring
 lxml
 xmltodict
 #pyquery
-# use this until https://github.com/gawel/pyquery/pull/183 lands:
--e git://github.com/jcushman/pyquery.git@115173a#egg=pyquery # Fix issues related to 1.4.x branch (https://github.com/harvard-lil/capstone/issues/745)
+https://github.com/gawel/pyquery/archive/2351446c56d5c3df93e3fd81a2b828cf00e3b648.zip#egg=pyquery  # Can be dropped on release of 1.4.1 (https://github.com/gawel/pyquery/pull/183)
 
 # database
 psycopg2            # postgres connector
@@ -30,7 +29,7 @@ django<2.2             # Fix issues related to 2.1.x branch (https://github.com/
 django-storages==1.6.6 # Fix issues related to 1.7.x branch (https://github.com/harvard-lil/capstone/issues/745)
 boto3==1.7.84          # Fix issues related to 1.9.x branch (https://github.com/harvard-lil/capstone/issues/745)
 whitenoise             # serve static assets
--e git://github.com/jcushman/django-model-utils.git@f2e97e41418788c81ee8e5ab1cec37ecff65a003#egg=django-model-utils  # PR: https://github.com/jazzband/django-model-utils/pull/369
+https://github.com/jcushman/django-model-utils/archive/f2e97e41418788c81ee8e5ab1cec37ecff65a003.zip#egg=django-model-utils  # PR: https://github.com/jazzband/django-model-utils/pull/369
 django-simple-history  # model versioning
 django-redis           # use redis as Django cache backend
 django-hosts           # URL routing across subdomains
@@ -66,7 +65,7 @@ django-bootstrap4   # render bootstrap forms in django templates
 drf-yasg            # expose API specification
 swagger_spec_validator  # optional package for schema validation by drf-yasg
 pyyaml==4.2b4       # only an indirect dependency; included here to pin beta version until 4.x released, as 3.x shows security warning on github
--e git://github.com/jcushman/email-normalize.git@6b5088bd05de247a9a33ad4e5c7911b676d6daf2#egg=email-normalize # Fix issues related to https://github.com/gmr/email-normalize/pull/3 (https://github.com/harvard-lil/capstone/issues/745)
+https://github.com/jcushman/email-normalize/archive/6b5088bd05de247a9a33ad4e5c7911b676d6daf2.zip#egg=email-normalize  # Fix issues related to https://github.com/gmr/email-normalize/pull/3 (https://github.com/harvard-lil/capstone/issues/745)
 
 # File conversion
 PyPDF2

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -4,9 +4,6 @@
 #
 #    fab pip-compile
 #
-https://github.com/jcushman/django-model-utils/archive/f2e97e41418788c81ee8e5ab1cec37ecff65a003.tar.gz#egg=django-model-utils --hash=sha256:70bb4dd4e5e4c91544ce645d65c7ef0c58bc4711da45feccd902d5747abc6bae
-https://github.com/jcushman/email-normalize/archive/6b5088bd05de247a9a33ad4e5c7911b676d6daf2.tar.gz#egg=email-normalize --hash=sha256:95aa7e2d9c44cb91e12dfff8f08fb6373bc3ca791c44a2c422986b84645c5d2e
-https://github.com/jcushman/pyquery/archive/115173a.tar.gz#egg=pyquery --hash=sha256:086e838487a2849eb64b0df29522c5a1e53c08bedbe0920ffd00bee485aff432
 amqp==2.4.0 \
     --hash=sha256:9f181e4aef6562e6f9f45660578fc1556150ca06e836ecb9e733e6ea10b48464 \
     --hash=sha256:c3d7126bfbc640d076a01f1f4f6e609c0e4348508150c1f61336b0d83c738d2b \
@@ -225,6 +222,8 @@ django-hosts==3.0 \
     --hash=sha256:8e83232dbd7ff0d9de5c814f16bdf4cd1971bd00c54fa1f3e507aed4f93215a8
 django-libsass==0.7 \
     --hash=sha256:49db3334b87e1f7955c4f9fb9945bc296f8bfd27a14d6d89706e4b0e5dc5de1c
+https://github.com/jcushman/django-model-utils/archive/f2e97e41418788c81ee8e5ab1cec37ecff65a003.zip#egg=django-model-utils \
+    --hash=sha256:e52b087de48c8ca8406304fd26a79de3fd2cb94d7b30f92cb3d0542dd579cc03
 django-nine==0.1.13 \
     --hash=sha256:cf1d2a3725a24c97fff307cc8d8daf476aa67ceefe86dcd9586d19106af2af16 \
     --hash=sha256:cf2a775dc1ba44aa2a9aec3a09130df108def55ff63074a33fe44bd531177da1 \
@@ -283,6 +282,8 @@ elasticsearch==6.3.1 \
     --hash=sha256:7546cc08e3899716e12fe67d12d7cfe9a64647014d1134b014c3c392b63cad42 \
     --hash=sha256:aada5cfdc4a543c47098eb3aca6663848ef5d04b4324935ced441debc11ec98b \
     # via django-elasticsearch-dsl-drf, elasticsearch-dsl
+https://github.com/jcushman/email-normalize/archive/6b5088bd05de247a9a33ad4e5c7911b676d6daf2.zip#egg=email-normalize \
+    --hash=sha256:366bdd6870b59aee8bf7aed1e22533eb0ceb78d008513a7add9098311cc2a97a
 execnet==1.5.0 \
     --hash=sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a \
     --hash=sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83 \
@@ -500,9 +501,9 @@ pillow==5.4.1 \
     --hash=sha256:e9c8066249c040efdda84793a2a669076f92a301ceabe69202446abb4c5c5ef9 \
     --hash=sha256:f227d7e574d050ff3996049e086e1f18c7bd2d067ef24131e50a1d3fe5831fbc \
     --hash=sha256:fc9a12aad714af36cf3ad0275a96a733526571e52710319855628f476dcb144e
-pip-tools==3.6.1 \
-    --hash=sha256:603d374e43bfa02e7a775b58c25a203799155d42f89ef94ee445eb7ae116439f \
-    --hash=sha256:7c52bd17e8b8003a0d8daf5ac6e98c38097223508993fefb440c7e333a09f345
+pip-tools==3.7.0 \
+    --hash=sha256:4ff38ab655bec47db2d5a82fa6c6807e231ecddf3b7cbb2f2b957a9b11f016c3 \
+    --hash=sha256:542cc32393ec8e97932b4710462567e3ecbd0a1d483d8b1d5ef05bc6ef83f7f8
 pluggy==0.8.1 \
     --hash=sha256:8ddc32f03971bfdf900a81961a48ccf2fb677cf7715108f85295c67405798616 \
     --hash=sha256:980710797ff6a041e9a73a5787804f848996ecaa6f8a1b1e08224a5894f2074a \
@@ -637,6 +638,8 @@ pynacl==1.3.0 \
     # via paramiko
 pypdf2==1.26.0 \
     --hash=sha256:e28f902f2f0a1603ea95ebe21dff311ef09be3d0f0ef29a3e44a932729564385
+https://github.com/gawel/pyquery/archive/2351446c56d5c3df93e3fd81a2b828cf00e3b648.zip#egg=pyquery \
+    --hash=sha256:0629b8ffb14e2b60c62f5331a150a2829d24727514ed2f56135ecd753b858950
 pytest-cov==2.6.1 \
     --hash=sha256:0ab664b25c6aa9716cbf203b17ddb301932383046082c081b9848a0edf5add33 \
     --hash=sha256:230ef817450ab0699c6cc3c9c8f7a829c34674456f2ed8df1fe1d39780f7c87f


### PR DESCRIPTION
This updates pip-tools to take advantage of the new URL code. pip-sync will hopefully work again for deploys if you want to use it.