### PR TITLE
Linked data for case.html

### DIFF
--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -59,6 +59,7 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
             'citation': official_citation,
             'page_description': data['name'],
             'page_title': data['name_abbreviation'],
+            'frontend_url': data['frontend_url'],
             'metadata': {
                 "name": data["name"],
                 "name_abbreviation": data["name_abbreviation"],

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -1,6 +1,8 @@
 {% extends "layouts/centered.html" %}
 {% load pipeline %}
 {% load static %}
+{% load capweb_static %}
+
 {% block base_css %}{% stylesheet 'case' %}{% endblock %}
 {% block title %}{{ citation_full }}{% endblock %}
 
@@ -9,8 +11,10 @@
     <div class="metadata text-center col-centered">
       {% if not request.user.is_authenticated %}
         <div class="alert alert-success" role="alert">
-          Welcome to the Caselaw Access Project! We allow free access to up to 500 cases per person per day &mdash; see our
-          <a href="{% url 'terms' %}">terms of use</a> for details. <a href="{% url 'register' %}">Sign up for an account</a>
+          Welcome to the Caselaw Access Project! We allow free access to up to 500 cases per person per day &mdash; see
+          our
+          <a href="{% url 'terms' %}">terms of use</a> for details. <a href="{% url 'register' %}">Sign up for an
+          account</a>
           to use our API or apply for unlimited research scholar access.
         </div>
       {% endif %}
@@ -59,7 +63,9 @@
           Could not load case body</h6>
       </div>
     {% else %}
-      {{ case_html|safe }}
+      <div class="cookie-wall">
+        {{ case_html|safe }}
+      </div>
     {% endif %}
 
   </div>
@@ -76,5 +82,44 @@
       document.execCommand("copy");
       citation_container.classList.add("citation_copied");
     }
+  </script>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id":"{{ frontend_url }}"
+  },
+  "headline": "{{ metadata.name_abbreviation }}",
+  "isAccessibleForFree": "False",
+  "hasPart": {
+    "@type": "WebPageElement",
+    "isAccessibleForFree": "False",
+    "cssSelector": ".cookie-wall"
+  },
+  "author": {
+    "@type": "Organization",
+    "name": "{{ metadata.court.name }}"
+    },
+  "genre": "Law",
+  "keywords": "{{ metadata.citations }}, {{ metadata.name_abbreviation }}",
+  "publisher": {
+    "@type": "Organization",
+    "name": "Harvard Law School Library Innovation Lab",
+    "logo": {
+      "@type": "ImageObject",
+      "url":"{% capweb_static "img/lil-logo-black.png" %}",
+      "width: 693,
+      "height": 361
+    }
+  },
+   "image": "{% capweb_static "img/og_image/api.jpg" %}",
+   "datePublished": "{{ metadata.decision_date }}",
+   "dateModified": "2018-10-29",
+   "dateCreated": "{{ metadata.decision_date }}",
+   "description": "{{ metadata.name }}"
+ }
+
   </script>
 {% endblock %}

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -63,9 +63,7 @@
           Could not load case body</h6>
       </div>
     {% else %}
-      <div class="cookie-wall">
-        {{ case_html|safe }}
-      </div>
+      {{ case_html|safe }}
     {% endif %}
 
   </div>
@@ -84,7 +82,7 @@
     }
   </script>
   <script type="application/ld+json">
-{
+ {
   "@context": "https://schema.org",
   "@type": "Article",
   "mainEntityOfPage": {
@@ -93,11 +91,13 @@
   },
   "headline": "{{ metadata.name_abbreviation }}",
   "isAccessibleForFree": "False",
+  {% if not metadata.jurisdiction.whitelisted %}
   "hasPart": {
     "@type": "WebPageElement",
     "isAccessibleForFree": "False",
-    "cssSelector": ".cookie-wall"
+    "cssSelector": ".casebody"
   },
+  {% endif %}
   "author": {
     "@type": "Organization",
     "name": "{{ metadata.court.name }}"
@@ -110,7 +110,7 @@
     "logo": {
       "@type": "ImageObject",
       "url":"{% capweb_static "img/lil-logo-black.png" %}",
-      "width: 693,
+      "width": 693,
       "height": 361
     }
   },

--- a/capstone/static/css/scss/footer.scss
+++ b/capstone/static/css/scss/footer.scss
@@ -3,6 +3,9 @@ footer {
   font-size: 18px;
   background-color: $color-yellow;
   hyphens: none;
+  .lil-logo {
+    @extend %footer-lil-logo-black;
+  }
 }
 
 


### PR DESCRIPTION
- "Article" seems to be the closest match for our linked data object for case law.
https://developers.google.com/search/docs/data-types/article
- `isAccessibleForFree` is set to false: 
https://developers.google.com/search/docs/data-types/paywalled-content
- Courts are our "Author" (with type Organization)
- Date modified is set to our public release date for CAP (October 29, 2018), although maybe it should be more specific?
- keywords are all the citations and the name abbreviation (could be more entries?): https://schema.org/keywords
- Image seems to want to be a specific-to-the-article. Right now I'm only including our social media image. Maybe there's some cool way to include an image of a case? If not, and this seems fine, specifications recommend this image in various sizes so I will add that

To test
View any case, open dev tools, search for `application/ld+json` in the DOM, copy paste the object here:
https://search.google.com/structured-data/testing-tool?utm_campaign=devsite&utm_medium=jsonld&utm_source=article

<img width="1434" alt="Screen Shot 2019-05-15 at 11 33 54 AM" src="https://user-images.githubusercontent.com/1494102/57788613-6421f680-7705-11e9-9d08-dbe390a271a5.png">
