### PR TITLE
Stabilize URL resolution; separate home from cite_home

### DIFF
--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -106,7 +106,7 @@ class CaseSerializer(serializers.HyperlinkedModelSerializer):
 
     def get_frontend_url(self, obj):
         if not hasattr(self, '_frontend_url_base'):
-            CaseSerializer._frontend_url_base = reverse('home', host='cite').rstrip('/')
+            CaseSerializer._frontend_url_base = reverse('cite_home', host='cite').rstrip('/')
         return self._frontend_url_base + (obj.frontend_url or '')
 
 

--- a/capstone/capweb/helpers.py
+++ b/capstone/capweb/helpers.py
@@ -15,7 +15,6 @@ from django.core.mail import EmailMessage
 from django.db import transaction, connections, OperationalError
 from django.urls import NoReverseMatch
 from django.utils.functional import lazy
-from django_hosts.resolvers import get_host_patterns
 
 
 def cache_func(key, timeout=None, cache_name='default'):
@@ -59,6 +58,8 @@ def get_data_from_lil_site(section="news"):
     data = json.loads(content.strip()[start_index + 1:end_index])
     return data[section]
 
+_host_names = sorted(settings.HOSTS.keys())
+
 def reverse(*args, **kwargs):
     """
         Wrap django_hosts.reverse() to try all known hosts.
@@ -70,14 +71,13 @@ def reverse(*args, **kwargs):
         return django_hosts.reverse(*args, **kwargs)
 
     # try each host
-    hosts = get_host_patterns()
-    for i, host in enumerate(reversed(hosts)):
-        kwargs['host'] = host.name
+    for i, host_name in enumerate(_host_names):
+        kwargs['host'] = host_name
         try:
             return django_hosts.reverse(*args, **kwargs)
         except NoReverseMatch:
             # raise NoReverseMatch only after testing final host
-            if i == len(hosts)-1:
+            if i == len(_host_names)-1:
                 raise
 
 reverse_lazy = lazy(reverse, str)

--- a/capstone/capweb/templates/index.html
+++ b/capstone/capweb/templates/index.html
@@ -13,7 +13,7 @@
     {% autoescape off %}
       const mapSettings = {
         "data": {% snippet 'map_numbers' %},
-        "jurisdictionUrl": "{% url "home" host "cite" %}#JURISDICTION"
+        "jurisdictionUrl": "{% url "cite_home" host "cite" %}#JURISDICTION"
       };
     {% endautoescape %}
   </script>

--- a/capstone/capweb/templates/tools.html
+++ b/capstone/capweb/templates/tools.html
@@ -14,13 +14,13 @@
     The capstone of the Caselaw Access Project is a robust set of tools which facilitate access to the cases
     and their associated metadata. We currently offer five ways to access the data:
     <a href="{% api_url "api-root" %}">API</a>, <a href="{% url "bulk-download" %}">bulk downloads</a>,
-    <a href="{% url "search" %}">search</a>, <a href="{% url "home" host "cite" %}">browse</a>, and an
+    <a href="{% url "search" %}">search</a>, <a href="{% url "cite_home" host "cite" %}">browse</a>, and an
     <a href="{% url "ngrams" %}">Ngram viewer</a>.
   {% else %}
     The capstone of the Caselaw Access Project is a robust set of tools which facilitate access to the cases
     and their associated metadata. We currently offer four ways to access the data:
     <a href="{% api_url "api-root" %}">API</a>, <a href="{% url "bulk-download" %}">bulk downloads</a>,
-    <a href="{% url "search" %}">search</a>, and <a href="{% url "home" host "cite" %}">browse</a>.
+    <a href="{% url "search" %}">search</a>, and <a href="{% url "cite_home" host "cite" %}">browse</a>.
 
   {% endif %}
 {% endblock %}
@@ -97,7 +97,7 @@
     Browse and cite all of our cases sorted by jurisdiction, series, and volume.
   </p>
   <div class="btn-group">
-    <a class="btn-primary" href="{% url "home" host "cite" %}">BROWSE</a>
+    <a class="btn-primary" href="{% url "cite_home" host "cite" %}">BROWSE</a>
   </div>
 
   {# ==============> NGRAMS <============== #}

--- a/capstone/cite/tests/test_views.py
+++ b/capstone/cite/tests/test_views.py
@@ -13,7 +13,7 @@ from scripts.helpers import parse_xml
 def test_home(client, django_assert_num_queries, ingest_metadata):
     """ Test / """
     with django_assert_num_queries(select=2):
-        response = client.get(reverse('home', host='cite'))
+        response = client.get(reverse('cite_home', host='cite'))
     check_response(response, content_includes="Alabama Appellate Courts Reports")
 
 @pytest.mark.django_db

--- a/capstone/cite/urls.py
+++ b/capstone/cite/urls.py
@@ -8,5 +8,5 @@ urlpatterns = [
     path('<str:series_slug>/<str:volume_number>/<str:page_number>/', views.citation, name='citation'),
     path('<str:series_slug>/<str:volume_number>/', views.volume, name='volume'),
     path('<str:series_slug>/', views.series, name='series'),
-    path('', views.home, name='home'),
+    path('', views.home, name='cite_home'),
 ]


### PR DESCRIPTION
This avoids links to case.law and cite.case.law getting mixed up. Also stabilizes our `reverse()` function so routes with the same name will always resolve in a predictable order (though overlap should be avoided).