### PR TITLE
Pin node and yarn versions in docker

### DIFF
--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -17,15 +17,16 @@ RUN pip install -U pip \
     && rm requirements.txt
 
 # nodejs
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash -
 # write a .yarnrc that will only be found inside the docker guest, and will cause
 # node_modules to be written to /node_modules instead of ./node_modules:
 RUN echo "--modules-folder /node_modules" > /.yarnrc
 COPY package.json /app
 COPY yarn.lock /app
-RUN apt-get update \
-    && apt-get install -y nodejs \
-    && npm install -g yarn \
+# pin node version -- see https://github.com/nodesource/distributions/issues/33
+RUN curl -o nodejs.deb https://deb.nodesource.com/node_11.x/pool/main/n/nodejs/nodejs_11.15.0-1nodesource1_amd64.deb \
+    && dpkg -i ./nodejs.deb \
+    && rm nodejs.deb \
+    && npm install -g yarn@1.16.0 \
     && yarn install --frozen-lockfile \
     && rm package.json \
     && rm yarn.lock

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -35,7 +35,7 @@ services:
           - 9200:9200
     worker:
         build: .
-        image: capstone:0.3.13-66026ea3ce22ab8a7ac1a61da96b7c36
+        image: capstone:0.3.14-c7b2e6f1fe6dffcb10893b59f791d852
         volumes:
             # NAMED VOLUMES
             # Use a named, persistent volume so that the node_modules directory,
@@ -62,7 +62,7 @@ services:
           - "api.case.test:127.0.0.1"
     web:
         build: .
-        image: capstone:0.3.13-66026ea3ce22ab8a7ac1a61da96b7c36
+        image: capstone:0.3.14-c7b2e6f1fe6dffcb10893b59f791d852
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated


### PR DESCRIPTION
Becky pointed out that it would be a good idea to pin the node and yarn versions in our Dockerfile to make sure devs don't end up with different versions.