### PR TITLE
Tweak token stream case rendering and display

### DIFF
--- a/capstone/scripts/render_case.py
+++ b/capstone/scripts/render_case.py
@@ -258,26 +258,6 @@ class VolumeRenderer:
 
         return etree.tostring(case_el, encoding=str)
 
-    ### TEXT RENDERING ###
-
-    def render_text(self, case):
-        """
-            Render <casebody> as plain text
-        """
-        case_structure = case.structure
-        pars = []
-        for par in iter_pars(case_structure.opinions):
-            if par.get("redacted"):
-                continue
-            words = []
-            for block_id in par['block_ids']:
-                block = self.blocks_by_id[block_id]
-                if block.get("redacted"):
-                    continue
-                words.extend(filter_tokens(block, {}))
-            pars.append("".join(words))
-        return "\n\n".join(pars)
-
     ### XML/HTML RENDERING ###
 
     html_token_filter = {'footnotemark', 'bracketnum', 'font'}
@@ -288,7 +268,7 @@ class VolumeRenderer:
             Render <casebody> as HTML
         """
         self.format = 'html'
-        return self.render_markup(case)
+        return self.render_markup(case).replace('\xad', '')
 
     def render_xml(self, case):
         """
@@ -296,7 +276,7 @@ class VolumeRenderer:
         """
         self.format = 'xml'
         self.original_xml = False
-        return self.render_markup(case)
+        return self.render_markup(case).replace('\xad', '')
 
     def render_orig_xml(self, case):
         """

--- a/capstone/static/css/scss/case.scss
+++ b/capstone/static/css/scss/case.scss
@@ -119,7 +119,6 @@ h4.case-name {
 section.head-matter {
   padding-bottom: 0;
   p, aside {
-    position: relative;
     // on large screens, head matter goes into a narrower column
     margin-top: 1em;
     margin-bottom: 1em;
@@ -276,4 +275,8 @@ section.head-matter {
     padding-right: 1em;
     font-size: 1.2rem;
   }
+}
+// to position .page-label:before
+.head-matter > *, .opinion > * {
+  position: relative;
 }


### PR DESCRIPTION
- Strip \xad from token stream version of cases
- Strip page numbers and footnote references from plain text version of cases (not helpful for nlp)
- Fix page number display in css

After this goes to beta we should run `fab refresh_case_body_cache`