### PR TITLE
update title/description for trends and case browser

### DIFF
--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -55,11 +55,11 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
             if key + 1 < citation_count:
                 citations += "; "
 
+        citation_full = data["name_abbreviation"] + ", " + official_citation + " (" + data["decision_date"][0:4] + ")"
         context = {
             **renderer_context,
             'citation': official_citation,
-            'page_description': data['name'],
-            'page_title': data['name_abbreviation'],
+            'meta_description': "Full text of %s from the Caselaw Access Project." % citation_full,
             'frontend_url': data['frontend_url'],
             'metadata': {
                 "name": data["name"],
@@ -73,7 +73,7 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
                 "reporter": data["reporter"],
                 "court": data["court"],
                 "jurisdiction": data["jurisdiction"]},
-            'citation_full': data["name_abbreviation"] + ", " + official_citation + " (" + data["decision_date"][                                                                                   0:4] + ")"
+            'citation_full': citation_full,
         }
 
         # if user requested format=html without requesting full casebody
@@ -110,30 +110,30 @@ class BrowsableAPIRenderer(renderers.BrowsableAPIRenderer):
                 context['page_url'] = parsed_response['url']
 
                 if context['name'] == "Case Instance":
-                    context['page_title'] = parsed_response['name_abbreviation']
-                    context['page_description'] = parsed_response['name']
+                    context['title'] = parsed_response['name_abbreviation']
+                    context['meta_description'] = parsed_response['name']
 
                 if context['name'] == "Jurisdiction Instance":
-                    context['page_title'] = "Jurisdiction: {}".format(parsed_response['name'])
-                    context['page_description'] = "The CAPAPI Jurisdiction Entry for {}".format(parsed_response['name_long'])
+                    context['title'] = "Jurisdiction: {}".format(parsed_response['name'])
+                    context['meta_description'] = "The CAPAPI Jurisdiction Entry for {}".format(parsed_response['name_long'])
 
                 if context['name'] == "Court Instance":
-                    context['page_title'] = parsed_response['name_abbreviation']
-                    context['page_description'] = "The CAPAPI Court Entry for {}".format(parsed_response['name'])
+                    context['title'] = parsed_response['name_abbreviation']
+                    context['meta_description'] = "The CAPAPI Court Entry for {}".format(parsed_response['name'])
 
                 if context['name'] == "Volume Instance":
-                    context['page_title'] = "{} v.{} ({})".format(parsed_response['reporter'], parsed_response['volume_number'], parsed_response['publication_year'])
-                    context['page_description'] = "The CAPAPI Volume Entry for {} v. {} ({})".format(parsed_response['reporter'], parsed_response['volume_number'], parsed_response['publication_year'])
+                    context['title'] = "{} v.{} ({})".format(parsed_response['reporter'], parsed_response['volume_number'], parsed_response['publication_year'])
+                    context['meta_description'] = "The CAPAPI Volume Entry for {} v. {} ({})".format(parsed_response['reporter'], parsed_response['volume_number'], parsed_response['publication_year'])
 
                 if context['name'] == "Reporter Instance":
-                    context['page_title'] = parsed_response['short_name']
-                    context['page_description'] = "The CAPAPI Court Entry for {}".format(parsed_response['full_name'])
+                    context['title'] = parsed_response['short_name']
+                    context['meta_description'] = "The CAPAPI Court Entry for {}".format(parsed_response['full_name'])
 
             except:
                 return context
         else:
-            context['page_title'] = context['name']
-            context['page_description'] = "CAPAPI: The Caselaw Access Project API"
+            context['title'] = context['name']
+            context['meta_description'] = "CAPAPI: The Caselaw Access Project API"
         return context
 
 

--- a/capstone/capbrowse/templates/trends.html
+++ b/capstone/capbrowse/templates/trends.html
@@ -11,7 +11,6 @@
 {% endblock %}
 
 {% block top_section_style %}bg-tan simple-section{% endblock %}
-{% block title %}Historical Trends{% endblock %}
 {% block title_section %}
 {% endblock %}
 {% block meta_description %}

--- a/capstone/capbrowse/views.py
+++ b/capstone/capbrowse/views.py
@@ -63,4 +63,12 @@ def search(request):
 
 @password_protected_page('ngrams')
 def trends(request):
-    return render(request, "trends.html")
+    q = request.GET.get('q')
+    if q:
+        title_suffix = ' for "%s"' % q
+    else:
+        title_suffix = ''
+    return render(request, "trends.html", {
+        'title': 'Historical Trends' + title_suffix,
+        'page_image': None,
+    })

--- a/capstone/capweb/templates/main_base.html
+++ b/capstone/capweb/templates/main_base.html
@@ -1,12 +1,25 @@
-{% load static %}{% load pipeline %}{% load capweb_static %}{% load render_bundle from webpack_loader %}<!DOCTYPE html>
+{% load static %}{% load pipeline %}{% load capweb_static %}{% load render_bundle from webpack_loader %}{% load capture_tags %}<!DOCTYPE html>
 <html lang="en">
   <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    {# title #}
+    {% capture as title_out silent %}{% block title %}{% if title %}{{ title }}{% endif %}{% endblock title %}{% block title_suffix %} | Caselaw Access Project{% endblock title_suffix %}{% endcapture %}
+    <title>{{ title_out }}</title>
+    <meta property="og:title" content="{% if og_title %}{{ og_title }}{% else %}{{ title_out }}{% endif %}">
+    <meta property="twitter:title" content="{% if og_title %}{{ og_title }}{% else %}{{ title_out }}{% endif %}">
+
+    {# description #}
+    {% capture as meta_description_out silent %}{% block meta_description %}{% if meta_description %}{{ meta_description }}{% else %}Explore American Caselaw{% endif %}{% endblock meta_description %}{% endcapture %}
+    <meta name="description" content="{{ meta_description_out }}">
+    <meta property="og:description" content="{% if og_description %}{{ og_description }}{% else %}{{ meta_description_out }}{% endif %}">
+    <meta name="twitter:description" content="{% if og_description %}{{ og_description }}{% else %}{{ meta_description_out }}{% endif %}">
+
     {# social #}
-    {% if page_image %}
+    {% if page_image is None %}
+    {% elif page_image %}
       <meta name="twitter:card" content="summary_large_image">
       <meta name="twitter:image" content="{% capweb_static page_image %}">
       <meta property="og:image"  content="{% capweb_static page_image %}">
@@ -18,22 +31,6 @@
 
     <meta name="twitter:site" content="@caselawaccess">
     <meta name="twitter:creator" content="@HarvardLIL">
-
-    {% if page_title %}
-      <meta property="og:title" content="{{ page_title }}">
-      <meta name="twitter:title" content="{{ page_title }}">
-    {% else %}
-      <meta property="og:title" content="Caselaw Access Project">
-      <meta name="twitter:title" content="Caselaw Access Project">
-    {% endif %}
-
-    {% if page_description %}
-      <meta property="og:description" content="{{ page_description }}">
-      <meta name="twitter:description" content="{{ page_description }}">
-    {% else %}
-      <meta property="og:description" content="Explore American Caselaw">
-      <meta name="twitter:description" content="Explore American Caselaw">
-    {% endif %}
 
     {% if page_url %}
       <meta property="og:url" content="{{ page_url }}">
@@ -64,9 +61,6 @@
     <meta name="msapplication-TileColor" content="#2b5797">
     <meta name="msapplication-TileImage" content="{% static "img/favicon/mstile-150x150.png" %}">
     <meta name="theme-color" content="#ffffff">
-
-    <title>{% block title %}{% if title %}{{ title }}{% endif %}{% endblock title %}{% block title_suffix %} | Caselaw Access Project{% endblock title_suffix %}</title>
-    <meta name="description" content="{% block meta_description %}{% if meta_description %}{{ meta_description }}{% else %}Explore American Caselaw{% endif %}{% endblock meta_description %}">
 
     {# if a stylesheet has to import base.scss, it should override this block instead of going in extra_head to avoid double import #}
     {% block base_css %}{% stylesheet "base" %}{% endblock %}

--- a/capstone/capweb/views.py
+++ b/capstone/capweb/views.py
@@ -89,8 +89,7 @@ def contact(request):
         "form": form,
         "email": settings.DEFAULT_FROM_EMAIL,
         'page_image': 'img/og_image/contact.png',
-        'page_title': 'Contact Caselaw Access Project',
-        'page_description': 'Email us at %s or fill out this form. ' % settings.DEFAULT_FROM_EMAIL,
+        'meta_description': 'Email us at %s or fill out this form. ' % settings.DEFAULT_FROM_EMAIL,
     })
 
 
@@ -137,8 +136,7 @@ def gallery(request):
     return render(request, 'gallery.html', {
         'email': settings.DEFAULT_FROM_EMAIL,
         'page_image': 'img/og_image/gallery.png',
-        'page_title': 'Caselaw Access Project Project Gallery',
-        'page_description': 'Sky is the limit! Here are some examples of what’s possible.'
+        'meta_description': 'Sky is the limit! Here are some examples of what’s possible.'
     })
 
 
@@ -150,8 +148,7 @@ def maintenance_mode(request):
         "bottom": "${bottom}",
         "action": "${action}",
         'page_image': 'img/og_image/api.png',
-        'page_title': 'Caselaw Access Project: Error',
-        'page_description': 'This page is broken. Let us know if this should be working.'
+        'meta_description': 'This page is broken. Let us know if this should be working.'
     })
 
 
@@ -160,16 +157,14 @@ def wordclouds(request):
     return render(request, "gallery/wordclouds.html", {
         "wordclouds": wordclouds,
         'page_image': 'img/og_image/wordclouds.png',
-        'page_title': 'Caselaw Access Project Project California Wordclouds',
-        'page_description': 'Most used words in California caselaw from 1853 to 2015'
+        'meta_description': 'Most used words in California caselaw from 1853 to 2015'
     })
 
 
 def limericks(request):
     return render(request, 'gallery/limericks.html', {
         'page_image': 'img/og_image/limericks.png',
-        'page_title': 'Caselaw Access Project Project Limericks!',
-        'page_description': 'Generate rhymes using caselaw!'
+        'meta_description': 'Generate rhymes using caselaw!'
     })
 
 

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'elasticsearch_dsl',
     'django_elasticsearch_dsl',
     'django_elasticsearch_dsl_drf',
+    'capture_tag',
 ]
 
 REST_FRAMEWORK = {

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -35,7 +35,7 @@ services:
           - 9200:9200
     worker:
         build: .
-        image: capstone:0.3.21-966e72e9dfdd644561e2498b834e77d3
+        image: capstone:0.3.22-2465c529fafb463187b267f9e845d904
         volumes:
             # NAMED VOLUMES
             # Use a named, persistent volume so that the node_modules directory,
@@ -62,7 +62,7 @@ services:
           - "api.case.test:127.0.0.1"
     web:
         build: .
-        image: capstone:0.3.21-966e72e9dfdd644561e2498b834e77d3
+        image: capstone:0.3.22-2465c529fafb463187b267f9e845d904
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -37,6 +37,7 @@ django-simple-history  # model versioning
 django-redis           # use redis as Django cache backend
 django-hosts           # URL routing across subdomains
 django-webpack-loader  # include assets from webpack
+django-capture-tag     # capture values in templates
 
 # Admin stuff
 pip-tools

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -200,6 +200,9 @@ django-appconf==1.0.2 \
     # via django-compressor
 django-bootstrap4==0.0.7 \
     --hash=sha256:32ffee49c4c8ca7df543aac8733a5d45ad304078f920a0167819525bd33a955a
+django-capture-tag==1.0 \
+    --hash=sha256:9c8a531687aac2a705a16a96c33930fb8193c17b641b7c24cd97ff180053d539 \
+    --hash=sha256:a996f64996830c00641b5b41503c62616f9613a478c84a303fc414e96bfb4891
 django-compressor==2.2 \
     --hash=sha256:7732676cfb9d58498dfb522b036f75f3f253f72ea1345ac036434fdc418c2e57 \
     --hash=sha256:9616570e5b08e92fa9eadc7a1b1b49639cce07ef392fc27c74230ab08075b30f \


### PR DESCRIPTION
- Refactor our base template so `title` and `meta_description` control both the page metadata and the social media metadata.
- Update metadata for Trends page and case browser page.
- Remove generic image from Trends for now.

Metadata will look like this:

![image](https://user-images.githubusercontent.com/376272/59798926-41a96d00-92b1-11e9-9f6e-99f18489f95e.png)
