### PR TITLE
Tweak changelog

### DIFF
--- a/capstone/capweb/templates/api.md
+++ b/capstone/capweb/templates/api.md
@@ -1100,11 +1100,11 @@ the urls in the `next` and `previous` fields.
 
 
 {# ==============> CHANGES AND STABILITY <============== #}
-# Changes and Stablity {: class="subtitle" data-toc-label='Stability'  }
+# Changes and Stability {: class="subtitle" data-toc-label='Stability'  }
 
 
 This API is a work in progress. The format of the data it serves may change, and features will be added and possibly 
 removed or replaced. If your work relies on access to specific data in a specific format, you should download the data 
 and use local copies. If you have specific concerns about a particular feature of the API or future availability of 
 specific data, [get in touch]({% url "contact" %}). To see what we've changed recently, check out our 
-[change log]({% url "change-log" %}).
+[changelog]({% url "changelog" %}).

--- a/capstone/capweb/templates/changelog.md
+++ b/capstone/capweb/templates/changelog.md
@@ -1,7 +1,7 @@
 {% load static %}
 {% load pipeline %}
 {% load api_url %}
-title: Change Log
+title: Changelog
 page_image: 'img/og_image/tools.png'
 meta_description: CAP Data/Feature Change Log
 explainer: If our data or user-facing research features change in significant ways&mdash; beyond bug fixes and minor changes&mdash; we'll record those changes here.
@@ -13,15 +13,15 @@ extra_head: {% stylesheet 'docs' %}
 
 * **June 19, 2019**{: class='list-header' }
 {: add_list_class="bullets" }
-    * We added the [ngrams]({% api_url "ngrams-list" %}) endpoint to our API. Here are the 
-    [docs]({% url 'api' %}#endpoint-ngrams)
+    * We added the [ngrams]({% api_url "ngrams-list" %}) endpoint to our API. Here are the
+    [docs]({% url 'api' %}#endpoint-ngrams).
 
 
 # Website {: class="subtitle" }
 
 * **June 19, 2019**{: class='list-header' }
 {: add_list_class="bullets" }
-    * We started recording this public change log.
+    * We started recording this public changelog.
     * We added the [historic trends]({% url 'trends' %}) tool to our website.
 
 <!--
@@ -37,10 +37,10 @@ Make subsequent entries bump up right against the initial list, like this:
     * Documentation to come soon.
 * **June 19, 2019**{: class='list-header' }
 {: add_list_class="bullets" }
-    * We added a new endpoint to our API: `ngrams`. 
+    * We added a new endpoint to our API: `ngrams`.
     * Documentation to come soon.
 
-    
+
 To add a new section, just add another headline with {: class="subtitle" }... there must be exactly one
 space in between the curly brace and the last letter of the headline: like this:
 

--- a/capstone/capweb/templates/changelog.md
+++ b/capstone/capweb/templates/changelog.md
@@ -4,7 +4,7 @@
 title: Changelog
 page_image: 'img/og_image/tools.png'
 meta_description: CAP Data/Feature Change Log
-explainer: If our data or user-facing research features change in significant ways&mdash; beyond bug fixes and minor changes&mdash; we'll record those changes here.
+explainer: If our data or user-facing research features change in significant ways&mdash;beyond bug fixes and minor changes&mdash;we'll record those changes here.
 top_section_style: bg-black
 row_style: bg-tan
 extra_head: {% stylesheet 'docs' %}

--- a/capstone/capweb/urls.py
+++ b/capstone/capweb/urls.py
@@ -28,7 +28,7 @@ urlpatterns = [
 
     path('terms', MarkdownView.as_view(template_name='terms-of-use.md'), name='terms'),
     path('privacy', MarkdownView.as_view(template_name='privacy-policy.md'), name='privacy'),
-    path('change-log', MarkdownView.as_view(template_name='change_log.md'), name='change-log'),
+    path('changelog', MarkdownView.as_view(template_name='changelog.md'), name='changelog'),
 
     path('gallery/wordclouds', views.wordclouds, name='wordclouds'),
     path('gallery/limericks', views.limericks, name='limericks'),


### PR DESCRIPTION
A few minor fixes, plus renaming the template, title, and URL to changelog per https://en.wikipedia.org/wiki/Changelog -- but happy to discuss.