### PR TITLE
update - changing default command to bash to allow for python debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ staticfiles/
 .sass-cache/
 .idea/
 settings.py
+docker-compose.override.yml
 __pycache__
 .vagrant/
 .virtualenvs/

--- a/README.md
+++ b/README.md
@@ -142,20 +142,38 @@ Capstone should now be running at 127.0.0.1:8000.
 
 We have initial support for local development via `docker compose`. Docker setup looks like this:
 
-    $ docker-compose up &
+    $ docker-compose up -d
     $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capdb;"
     $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capapi;"
     $ docker-compose exec web fab init_dev_db
     $ docker-compose exec web fab load_test_data
     $ docker-compose exec web fab update_all_snippets
-
+    $ docker-compose exec web fab run
+    
 Capstone should now be running at 127.0.0.1:8000.
 
-***tip**— these commands can be shortened by adding something like this to .bash_profile:*
+If you are working on frontend, you probably want to run yarn as well.
+In a new shell:
+    
+    $ docker-compose exec web yarn serve
+
+
+***tip***— these commands can be shortened by adding something like this to .bash_profile:*
 
     alias d="docker-compose exec"
     alias dfab="d web fab"
+    alias dyarn="d web yarn"
 
+Or:
+
+    alias d="docker-compose exec web"
+    
+And then:
+
+    $ d fab 
+    $ d yarn serve
+   
+    
 ## Administering and Developing Capstone <a id="administering-and-developing-capstone"></a>
 - [Testing](#testing)
 - [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ In a new shell:
     $ docker-compose exec web yarn serve
 
 
-***tip***— these commands can be shortened by adding something like this to .bash_profile:*
+***Tip***— these commands can be shortened by adding something like this to .bash_profile:
 
     alias d="docker-compose exec"
     alias dfab="d web fab"
@@ -173,7 +173,14 @@ And then:
     $ d fab 
     $ d yarn serve
    
+   
+***Tip***- If `docker-compose up -d` takes too long to run, you might consider the following:
     
+    $ cp docker-compose.override.yml.example docker-compose.override.yml
+
+This override file will point the `elasticsearch` service to a `hello-world` image instead of its real settings.
+Use this [override file](https://docs.docker.com/compose/extends/#multiple-compose-files) to override more settings for your own development environment.  
+
 ## Administering and Developing Capstone <a id="administering-and-developing-capstone"></a>
 - [Testing](#testing)
 - [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -142,20 +142,38 @@ Capstone should now be running at 127.0.0.1:8000.
 
 We have initial support for local development via `docker compose`. Docker setup looks like this:
 
-    $ docker-compose up &
+    $ docker-compose up -d
     $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capdb;"
     $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capapi;"
     $ docker-compose exec web fab init_dev_db
     $ docker-compose exec web fab load_test_data
     $ docker-compose exec web fab update_all_snippets
-
+    $ docker-compose exec web fab run
+    
 Capstone should now be running at 127.0.0.1:8000.
+
+If you are working on frontend, you probably want to run yarn as well.
+In a new shell:
+    
+    $ docker-compose exec web yarn serve
+
 
 ***tip**— these commands can be shortened by adding something like this to .bash_profile:*
 
     alias d="docker-compose exec"
     alias dfab="d web fab"
+    alias dyarn="d web yarn"
 
+Or:
+
+    alias d="docker-compose exec web"
+    
+And then:
+
+    $ d fab 
+    $ d yarn serve
+   
+    
 ## Administering and Developing Capstone <a id="administering-and-developing-capstone"></a>
 - [Testing](#testing)
 - [Requirements](#requirements)

--- a/capstone/docker-compose.override.yml.example
+++ b/capstone/docker-compose.override.yml.example
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  elasticsearch:
+    image: hello-world

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -73,7 +73,8 @@ services:
         depends_on:
             - redis
             - db
-        command: fab run:0.0.0.0:8000
+        command: /bin/bash
+        tty: true
         environment:
             # let Django load Docker-specific settings conditionally
             - DOCKERIZED=True

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -40,6 +40,8 @@ from scripts.helpers import parse_xml, serialize_xml, copy_file, resolve_namespa
 
 @task(alias='run')
 def run_django(port="127.0.0.1:8000"):
+    if os.environ.get('DOCKERIZED'):
+        port = "0.0.0.0:8000"
     management.call_command('runserver', port)
 
 @task


### PR DESCRIPTION
this is a suggestion PR!

Wondering what people think about making the docker flow a bit more extensive for the trade-off of being able to debug with pdb/ipdb (this is like the perma.cc flow -- thanks @rebeccacremona for the help)
The flow would be:
```
docker-compose up -d # run docker in background
dfab run:0.0.0.0:8000 # run django in container
dyarn serve # compile front-end assets
```

If this looks good to people, I would need to edit the README to reflect a different workflow.
