### PR TITLE
Avoid URL double-escape in API browser

### DIFF
--- a/capstone/capapi/templates/rest_framework/api.html
+++ b/capstone/capapi/templates/rest_framework/api.html
@@ -135,12 +135,11 @@
 
     <div class="response-info" aria-label="{% trans "response info" %}">
         <pre class="prettyprint"><span
-                class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>{% autoescape off %}
+                class="meta nocode"><b>HTTP {{ response.status_code }} {{ response.status_text }}</b>
           {% for key, val in response_headers|items %}
             <b>{{ key }}:</b><span class="lit">{{ val|break_long_headers|urlize_quoted_links }}</span>{% endfor %}
 
   </span>{{ content|urlize_url_fields_only }}</pre>
-      {% endautoescape %}
     </div>
   </div>
 

--- a/capstone/capapi/templatetags/urlize_url_fields_only.py
+++ b/capstone/capapi/templatetags/urlize_url_fields_only.py
@@ -1,17 +1,19 @@
-from re import sub
+import re
 
 from django import template
 from django.utils.html import escape
-
+from django.utils.safestring import mark_safe
 
 from rest_framework.templatetags.rest_framework import urlize_quoted_links
+
 
 register = template.Library()
 
 @register.filter()
 def urlize_url_fields_only(text):
-    ret = sub(
-        '&quot;(https?://.*)&quot;',
-        lambda url_match: '&quot;%s&quot;' % urlize_quoted_links(url_match.group(1)),
-        escape(text.decode()))
-    return ret
+    """
+        Split text into quoted urls, and other. Other text is escaped normally; quoted urls are passed through
+        urlize_quoted_links(), which performs escaping.
+    """
+    pieces = re.split(r'("https?://\S+")', text.decode())
+    return mark_safe(''.join(urlize_quoted_links(piece) if i % 2 else escape(piece) for i, piece in enumerate(pieces)))


### PR DESCRIPTION
Sometimes some things are escaped too many times, while other things are escaped not at all.