### PR TITLE
Elasticsearch updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This is the source code for [case.law](https://case.law), a website written by t
   - [Download real data locally](#download-real-data-locally )
   - [Model versioning](#model-versioning)
   - [Working with javascript](#working-with-javascript)
+  - [Elasticsearch](#elasticsearch)
 - [Documentation](#documentation)
 - [Examples](#examples)
 
@@ -295,6 +296,21 @@ get the updates.
 
 `yarn` packages inside docker are stored in `/node_modules`. The `/app/capstone/node_modules` folder is just an empty
 mount to block out any `node_modules` folder that might exist on the host.
+
+### Elasticsearch <a id="elasticsearch"></a>
+
+For local dev, Elasticsearch will automatically be started by `docker-compose up -d`. You can then run
+`fab refresh_case_body_cache` to populate CaseBodyCache for all cases, and `fab rebuild_search_index` to populate the
+search index.
+
+For debugging, see settings.py.example for an example of how to log all requests to and from Elasticsearch.
+
+It may also be useful to run Kibana to directly query Elasticsearch from a browser GUI:
+
+    $ brew install kibana
+    $ kibana -e http://127.0.0.1:9200
+
+You can then go to Kibana -> Dev Tools to run any of the logged queries, or `GET /_mapping` to see the search indexes.
 
 ## Documentation <a id="documentation"></a>
 This readme, code comments, and the API usage docs are the only docs we have. If you want something documented more thoroughly, file an issue and we'll get back to you.

--- a/capstone/capapi/pagination.py
+++ b/capstone/capapi/pagination.py
@@ -1,6 +1,13 @@
+import json
+import warnings
+from base64 import b64decode, b64encode
 from collections import OrderedDict
+from django_elasticsearch_dsl_drf.versions import ELASTICSEARCH_GTE_6_0
+
+from rest_framework.exceptions import NotFound
 from rest_framework.pagination import CursorPagination, _reverse_ordering, Cursor
 from rest_framework.response import Response
+from rest_framework.utils.urls import replace_query_param
 
 from capapi.resources import CachedCountQuerySet
 
@@ -150,3 +157,203 @@ class CapPagination(FTSPagination):
 class SmallCapPagination(CapPagination):
     page_size = 10
     max_page_size = 10
+
+
+class ESPaginatorMixin:
+    """
+        Parent class for pagination functions common to django_elasticsearch_dsl_drf paginators.
+        TODO: This could potentially be contributed upstream instead of staying in CAP.
+    """
+    template = None
+    facets = None
+    count = None
+
+    def paginate_queryset(self, queryset, request, view=None):
+        # Check if there are suggest queries in the queryset,
+        # ``execute_suggest`` method shall be called, instead of the
+        # ``execute`` method and results shall be returned back immediately.
+        # Placing this code at the very start of ``paginate_queryset`` method
+        # saves us unnecessary queries.
+        is_suggest = getattr(queryset, '_suggest', False)
+        if is_suggest:
+            if ELASTICSEARCH_GTE_6_0:
+                return queryset.execute().to_dict().get('suggest')
+            return queryset.execute_suggest().to_dict()
+
+        # Check if we're using paginate queryset from `functional_suggest`
+        # backend.
+        if view.action == 'functional_suggest':
+            return queryset
+
+        self.resp = resp = self._paginate_queryset(queryset, request, view)
+        self.facets = getattr(resp, 'aggregations', None)
+        self.display_page_controls = self.has_next and self.template is not None
+        return list(resp)
+
+    def _paginate_queryset(self, queryset, request, view):
+        """
+            subclasses should:
+             - set self.has_next
+             - set self.has_previous
+             - set self.count
+             - return elasticsearch Response object
+        """
+        raise NotImplementedError
+
+    def get_facets(self, facets=None):
+        """Get facets.
+
+        :param facets:
+        :return:
+        """
+        if facets is None:
+            facets = self.facets
+
+        if facets is None:
+            return None
+
+        if hasattr(facets, '_d_'):
+            return facets._d_
+
+    def get_paginated_response_context(self, data):
+        """Get paginated response data.
+
+        :param data:
+        :return:
+        """
+        __data = [
+            ('count', self.count),
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+        ]
+        __facets = self.get_facets()
+        if __facets is not None:
+            __data.append(
+                ('facets', __facets),
+            )
+        __data.append(
+            ('results', data),
+        )
+        return __data
+
+    def get_paginated_response(self, data):
+        """Get paginated response.
+
+        :param data:
+        :return:
+        """
+        return Response(OrderedDict(self.get_paginated_response_context(data)))
+
+    def get_count(self, es_response):
+        return es_response.hits.total
+
+
+class ESCursorPagination(ESPaginatorMixin, CursorPagination):
+    """
+        Generic class for paginating django_elasticsearch_dsl_drf queries using search_after.
+        TODO: This could potentially be contributed upstream instead of staying in CAP.
+    """
+    fallback_sort_field = "_id"
+
+    def __init__(self, *args, **kwargs):
+        if self.fallback_sort_field == "_id":
+            warnings.warn(
+                "fallback_sort_field of '_id' is inefficient. Consider changing it in a subclass. "
+                "See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-after.html")
+        super(ESCursorPagination, self).__init__(*args, **kwargs)
+
+    @staticmethod
+    def reverse_sort(queryset):
+        new_sort = []
+        for item in queryset._sort:
+            if type(item) == str:
+                item = {item: {"order": "asc" if item == "_score" else "desc"}}
+            elif type(item) == dict  and item:
+                k = next(iter(item))
+                v = dict(item[k])
+                v["order"] = "desc" if v.get("order", "desc" if k == "_score" else "asc") == "asc" else "desc"
+                item = {k: v}
+            else:
+                raise TypeError("Unrecognized sort order: %s" % item)
+            new_sort.append(item)
+        return queryset.sort(*new_sort)
+
+    def _paginate_queryset(self, queryset, request, view):
+        # read query parameters
+        self.page_size = self.get_page_size(request)
+        if not self.page_size:
+            return None
+        self.base_url = request.build_absolute_uri()
+        self.cursor = self.decode_cursor(request)
+        self.reversed = self.cursor['r']
+        self.search_after = self.cursor['p']
+
+        # ensure sort order includes fallback_sort_field
+        if not any(k == self.fallback_sort_field or self.fallback_sort_field in k.keys() for k in queryset._sort):
+            queryset = queryset.sort(*(queryset._sort + [self.fallback_sort_field]))
+
+        if self.reversed:
+            queryset = self.reverse_sort(queryset)
+        if self.search_after:
+            queryset = queryset.extra(search_after=self.search_after)
+
+        resp = queryset[:self.page_size+1].execute()
+        self.count = self.get_count(resp)
+
+        hits = resp.hits
+        has_extra = len(hits) > self.page_size
+        if has_extra:
+            hits.pop()
+        if self.reversed:
+            hits.reverse()
+            self.has_next = True
+            self.has_previous = has_extra
+        else:
+            self.has_next = has_extra
+            self.has_previous = bool(self.search_after)
+
+        return resp
+
+    def decode_cursor(self, request):
+        """
+        Given a request with a cursor, return a search_after list.
+        """
+        # Determine if we have a cursor, and if so then decode it.
+        encoded = request.query_params.get(self.cursor_query_param)
+        if encoded is None:
+            return {'p': [], 'r': False}
+        try:
+            querystring = b64decode(encoded.encode('ascii')).decode('utf8')
+            cursor = json.loads(querystring)
+            if not type(cursor['p']) == list or any(type(i) not in (str, int, float) for i in cursor['p']):
+                raise TypeError
+            cursor['r'] = 'r' in cursor
+        except (TypeError, ValueError):
+            raise NotFound(self.invalid_cursor_message)
+        return cursor
+
+    def encode_cursor(self, cursor):
+        """
+        Given a search_after list, return an url with encoded cursor.
+        """
+        querystring = json.dumps(cursor)
+        encoded = b64encode(querystring.encode('utf8')).decode('ascii')
+        return replace_query_param(self.base_url, self.cursor_query_param, encoded)
+
+    def get_next_link(self):
+        if not self.has_next:
+            return None
+        return self.encode_cursor({'p': list(self.resp.hits[-1].meta.sort)})
+
+    def get_previous_link(self):
+        if not self.has_previous:
+            return None
+        return self.encode_cursor({'p': list(self.resp.hits[0].meta.sort), 'r':1})
+
+class CapESCursorPagination(ESCursorPagination):
+    """
+        CAP-specific customization of elasticsearch search_after pagination.
+    """
+    page_size_query_param = 'page_size'
+    max_page_size = 100
+    fallback_sort_field = "id"

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -203,17 +203,17 @@ class CaseDocumentSerializerWithCasebody(CaseAllowanceMixin, CaseDocumentSeriali
 
             if body_format == 'html':
                 return {
-                    'data': case.casebody_data['data']['html'],
+                    'data': case.casebody_data['html'],
                     'status': status
                 }
             elif body_format == 'xml':
                 return {
-                    'data': case.casebody_data['data']['xml'],
+                    'data': case.casebody_data['xml'],
                     'status': status
                 }
             else:
                 return {
-                    'data': case.casebody_data['data']['structured'],
+                    'data': case.casebody_data['structured'].to_dict(),
                     'status': status
                 }
         return {'status': status, 'data': None}

--- a/capstone/config/settings/settings.py.example
+++ b/capstone/config/settings/settings.py.example
@@ -1,18 +1,22 @@
 from .settings_dev import *
 
-DATABASES['tracking_tool']['PASSWORD'] = ''
-DATABASES['tracking_tool']['HOST'] = ''
+# # log all SQL statements:
+# LOGGING['loggers']['django.db.backends'] = {
+#     'level': 'DEBUG',
+#     'handlers': ['console'],
+#     'propagate': False,
+# }
 
-# for production access -- not needed for testing
-INGEST_STORAGE = {
-    'class': 'cap.storages.CapS3Storage',
-    'kwargs': {
-        'location': 'from_vendor',
-        'access_key': '',
-        'secret_key': '',
-        'bucket_name': '',
-    }
-}
+# # log all elasticsearch queries:
+# LOGGING['loggers']['elasticsearch'] = {
+#     'level': 'DEBUG',
+#     'handlers': ['console'],
+#     'propagate': False,
+# }
 
-# for production
-CELERY_BROKER_URL = 'amqp://admin:mypass@localhost'
+# # log EVERYTHING:
+# LOGGING['loggers'][''] = {
+#     'handlers': ['console'],
+#     'level': 'DEBUG',
+#     'propagate': True,
+# }

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -504,7 +504,6 @@ LOGGING = {
         's3transfer': {
             'level': 'WARNING',
         },
-
     },
     'formatters': {
         'verbose': {
@@ -599,7 +598,7 @@ HEALTHCHECK_URL = {
 
 ELASTICSEARCH_DSL={
     'default': {
-        'hosts': 'elasticsearch:9200'
+        'hosts': 'localhost:9200'
     },
 }
 

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -28,6 +28,7 @@ if os.environ.get('DOCKERIZED'):
     CELERY_BROKER_URL = 'redis://redis'
     CELERY_RESULT_BACKEND = 'redis://redis'
 
+    ELASTICSEARCH_DSL['default']['hosts'] = 'elasticsearch:9200'
 
 # turn sql console logging on by setting DEBUG_SQL = True
 DEBUG_SQL = False

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -221,8 +221,14 @@ def migrate():
     update_postgres_env()
 
 @task
+def populate_search_index():
+    tasks.update_elasticsearch_for_all_vols()
+
+@task
 def rebuild_search_index():
-    management.call_command('search_index', '--rebuild')
+    management.call_command('search_index', '--delete')
+    management.call_command('search_index', '--create')
+    populate_search_index()
 
 @task
 def load_test_data():


### PR DESCRIPTION
Playing around with our experimental Elasticsearch endpoint:

- Add some README notes on debugging.
- Update the document schema so `casebody_data` is not a nested document. This will let us query `text` and other fields with `simple_query_string`. Also tweak some other fields. This will require reindexing.
- Update indexing code to draw contents from `body_cache`, and to run in parallel celery workers.
- Add cursor-based paginator.
- Fix full_case=true response
- Avoid fetching unused data when preparing response
- Tweak settings so `fab rebuild_search_index` works outside Docker