### PR TITLE
Sort jurisdictions in case browser by display name

### DIFF
--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -69,7 +69,7 @@ def home(request):
             reporters_by_jurisdiction[jurisdiction].append(reporter)
 
     # prepare (jurisdiction, reporters) list
-    jurisdictions = sorted(reporters_by_jurisdiction.items(), key=lambda item: item[0].name)
+    jurisdictions = sorted(reporters_by_jurisdiction.items(), key=lambda item: item[0].name_long)
 
     return render(request, 'cite/home.html', {
         "jurisdictions": jurisdictions,


### PR DESCRIPTION
As suggested by email, fix sort order at cite.case.law