### PR TITLE
Match elasticsearch version on stage, beta, prod

### DIFF
--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 #            - RABBITMQ_DEFAULT_PASS=mypass
 ##        mem_limit: 128M
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.0
+        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.1
         environment:
           - node.name=es01
           - bootstrap.memory_lock=true


### PR DESCRIPTION
6.8.2 is available on the minions, but not yet in Docker Hub. When it is, I'll either update this PR, if not merged, or file a new one.