### PR TITLE
Fixes API documentation on the ngrams endpoint

### DIFF
--- a/capstone/capweb/templates/api.md
+++ b/capstone/capweb/templates/api.md
@@ -757,7 +757,7 @@ If you set the optional `jurisdiction` parameter, your results will be limited t
 Endpoint Parameters:
 {: class="list-header mb-2" }
 
-* `words`{: class="parameter-name" }
+* `q`{: class="parameter-name" }
 {: class="list-group-item" add_list_class="parameter-list" }
     * up to 3 space separated [strings](#def-string)
     {: class="param-data-type" }


### PR DESCRIPTION
Hi,

This is a small issue. I just read the [documentation on the ngrams endpoint](https://case.law/api/#endpoints) but the "words" parameter is unsupported. According to the example in the documentation, the working parameter is just "q".
So this pull request just adjusts the documentation to make this clear.

Alternatively, the API could be changed apparently in [this file and line](https://github.com/harvard-lil/capstone/blob/5429b5ad6a7bbb976fd159ffa48f979b7f347814/capstone/capapi/views/api_views.py#L294) in order to accept the "words" parameter.


Thank you for your work.