### PR TITLE
Another error in the API documentation - cite vs citation

### DIFF
--- a/capstone/capweb/templates/api.md
+++ b/capstone/capweb/templates/api.md
@@ -411,7 +411,7 @@ Endpoint Parameters:
 {: class="list-group-item" add_list_class="parameter-list" }
     * An arbitrary [string](#def-string)
     {: class="param-data-type" }
-* `citation`{: class="parameter-name" }
+* `cite`{: class="parameter-name" }
 {: class="list-group-item" add_list_class="parameter-list" }
     * e.g. `1 Ill. 21`
     {: class="param-data-type" }


### PR DESCRIPTION
Small fix in API documentation again, compare

https://api.case.law/v1/cases/?cite=409 U.S. 188 (works, count = 1)
to
https://api.case.law/v1/cases/?citation=409%20U.S.%20188 (does not work)