### PR TITLE
Add phrase index to ES fields

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -20,7 +20,7 @@ def SuggestField():
 class CaseDocument(DocType):
     name_abbreviation = SuggestField()
 
-    name = fields.TextField()
+    name = fields.TextField(index_phrases=True)
 
     frontend_url = fields.KeywordField()
 
@@ -66,10 +66,10 @@ class CaseDocument(DocType):
             'attorneys': fields.TextField(multi=True),
             'judges': fields.TextField(multi=True),
             'parties': fields.TextField(multi=True),
-            'head_matter': fields.TextField(),
+            'head_matter': fields.TextField(index_phrases=True),
             'opinions': fields.ObjectField(multi=True, properties={
                 'author': fields.KeywordField(),
-                'text': fields.TextField(),
+                'text': fields.TextField(index_phrases=True),
                 'type': fields.KeywordField(),
             }),
             'corrections': fields.TextField(),

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -183,9 +183,10 @@ class CaseDocumentViewSet(BaseDocumentViewSet):
         'name_abbreviation',
         'jurisdiction.name_long',
         'court.name',
-        'casebody_data.text.attorneys',
-        'casebody_data.text.judges',
-        'casebody_data.text.parties',
+        # these are included in head_matter or text:
+        # 'casebody_data.text.attorneys',
+        # 'casebody_data.text.judges',
+        # 'casebody_data.text.parties',
         'casebody_data.text.head_matter',
         'casebody_data.text.opinions.author',
         'casebody_data.text.opinions.text',

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -24,7 +24,7 @@ from pyquery import PyQuery
 from bs4 import BeautifulSoup
 
 from capdb.storages import bulk_export_storage, case_image_storage
-from capdb.versioning import TemporalHistoricalRecords
+from capdb.versioning import TemporalHistoricalRecords, TemporalQuerySet
 from capweb.helpers import reverse, transaction_safe_exceptions
 from scripts import render_case
 from scripts.generate_case_html import generate_html
@@ -503,6 +503,7 @@ class Reporter(models.Model):
     nominative_for = models.ForeignKey("Reporter", on_delete=models.DO_NOTHING, related_name='nominative_reporters', blank=True, null=True)
 
     history = TemporalHistoricalRecords()
+    objects = TemporalQuerySet.as_manager()
 
     def __str__(self):
         return "%s: %s %s-%s" % (self.short_name, self.full_name, self.start_year or '', self.end_year or '')
@@ -610,6 +611,7 @@ class VolumeMetadata(models.Model):
 
     tracker = FieldTracker()
     history = TemporalHistoricalRecords()
+    objects = TemporalQuerySet.as_manager()
 
     class Meta:
         verbose_name_plural = "Volumes"
@@ -676,6 +678,7 @@ class VolumeXML(BaseXMLModel):
 
     tracker = FieldTracker()
     history = TemporalHistoricalRecords()
+    objects = TemporalQuerySet.as_manager()
 
     def __str__(self):
         return self.metadata_id
@@ -797,7 +800,7 @@ class Court(CachedLookupMixin, AutoSlugMixin, models.Model):
         return reverse('court-detail', args=[self.pk], scheme="https")
 
 
-class CaseMetadataQuerySet(models.QuerySet):
+class CaseMetadataQuerySet(TemporalQuerySet):
     def in_scope(self):
         """
             Return cases accessible from API
@@ -1188,6 +1191,7 @@ class CaseXML(BaseXMLModel):
 
     tracker = FieldTracker()
     history = TemporalHistoricalRecords()
+    objects = TemporalQuerySet.as_manager()
 
     @transaction.atomic(using='capdb')
     def save(self, update_related=True, *args, **kwargs):
@@ -1574,6 +1578,7 @@ class Citation(models.Model):
     case = models.ForeignKey('CaseMetadata', related_name='citations', null=True, on_delete=models.SET_NULL)
     tracker = FieldTracker()
     history = TemporalHistoricalRecords()
+    objects = TemporalQuerySet.as_manager()
 
     def __str__(self):
         return str(self.cite)
@@ -1602,6 +1607,7 @@ class PageXML(BaseXMLModel):
 
     tracker = FieldTracker()
     history = TemporalHistoricalRecords()
+    objects = TemporalQuerySet.as_manager()
 
     class Meta:
         ordering = ['barcode']

--- a/capstone/capdb/versioning.py
+++ b/capstone/capdb/versioning.py
@@ -89,3 +89,11 @@ class TemporalHistoricalRecords(HistoricalRecords):
     def post_delete(self, *args, **kwargs):
         pass
 
+
+class TemporalQuerySet(models.QuerySet):
+    """
+        Necessary for bulk_insert to work on history-tracked models.
+    """
+    def _batched_insert(self, objs, fields, *args, **kwargs):
+        fields = [f for f in fields if f.name != 'sys_period']
+        return super()._batched_insert(objs, fields, *args, **kwargs)


### PR DESCRIPTION
I think adding `index_phrases=True` should make phrase searches faster. This benefit won't apply until we rebuild the search index. I put it on the columns that showed as the slowest in a query profile.