### PR TITLE
Empty search fix

### DIFF
--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -256,6 +256,7 @@ class CAPFiltering(FilteringFilterBackend):
 
 class CAPFTSFilter(SimpleQueryStringSearchFilterBackend):
     def filter_queryset(self, request, queryset, view):
+        # ignores empty searches
         if 'search' in request.GET and request.GET['search'] is not '':
             queryset = super().filter_queryset(request, queryset, view)
         return queryset

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -255,6 +255,11 @@ class CAPFiltering(FilteringFilterBackend):
         return template.render({'fields': fields })
 
 class CAPFTSFilter(SimpleQueryStringSearchFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        if 'search' in request.GET and request.GET['search'] is not '':
+            queryset = super().filter_queryset(request, queryset, view)
+        return queryset
+
     search_param = 'search'
 
 class CaseDocumentViewSet(BaseDocumentViewSet):


### PR DESCRIPTION
Now ignores an empty search field which the filters box adds in the browsable API