### PR TITLE
Case sensitive filter fix

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -24,9 +24,9 @@ class CaseDocument(DocType):
 
     frontend_url = fields.KeywordField()
 
-    docket_numbers = fields.KeywordField(multi=True)
+    docket_numbers = fields.TextField(multi=True)
 
-    docket_number = fields.KeywordField()
+    docket_number = fields.TextField()
 
     volume = fields.ObjectField(properties={
         "barcode": fields.TextField(),

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -135,15 +135,34 @@ class CaseViewSet(BaseViewSet):
 
 class CAPFiltering(FilteringFilterBackend):
     def get_filter_query_params(self, request, view):
+        def lc_values(values):
+            return [value.lower() for value in values if isinstance(value, str)]
+
         query_params = super().get_filter_query_params(request, view)
         if 'cite' in query_params:
-            query_params['cite']['values'] = [Citation.normalize_cite(cite) for cite in query_params['cite']['values']]
+            query_params['cite']['values'] = [Citation.normalize_cite(cite) for cite in
+                                              lc_values(query_params['cite']['values']) ]
 
         if 'court_id' in query_params:
             query_params['court_id']['values'] = [ court_id for court_id
                                                    in query_params['court_id']['values'] if court_id.isdigit() ]
             if len(query_params['court_id']['values']) < 1:
                 del query_params['court_id']
+
+        if 'name' in query_params:
+            query_params['name']['values'] = lc_values(query_params['name']['values'])
+
+        if 'name_abbreviation' in query_params:
+            query_params['name_abbreviation']['values'] = lc_values(query_params['name_abbreviation']['values'])
+
+        if 'court' in query_params:
+            query_params['court']['values'] = lc_values(query_params['court']['values'])
+
+        if 'jurisdiction' in query_params:
+            query_params['jurisdiction']['values'] = lc_values(query_params['jurisdiction']['values'])
+
+        if 'docket_number' in query_params:
+            query_params['docket_number']['values'] = lc_values(query_params['docket_number']['values'])
 
         return query_params
 


### PR DESCRIPTION
I'm modifying the filters that take string values to .lower all of the values for now. This is simple and fixes the problem. The more official way to fix this seems to be to add a custom ES analyzer. We can discuss the value of that approach at the DEV meeting. This also changes the docket_number field from a KeywordField to a TextField, which is going to require an ES reindex. 