### PR TITLE
Add fix_ct_cl_cites task

### DIFF
--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -78,7 +78,7 @@ def update_elasticsearch_for_vol(self, volume_id):
         cases = (CaseMetadata.objects
             .in_scope()
             .filter(volume_id=volume_id)
-            .select_related('volume', 'reporter', 'court', 'jurisdiction', 'reporter', 'body_cache')
+            .select_related('volume', 'reporter', 'court', 'jurisdiction', 'body_cache')
             .exclude(body_cache=None))
 
         # attempt to store 10 times, with linearly increasing backoff. this gives time for the bulk queue to be processed

--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -191,10 +191,37 @@ def test_withdraw_case(case_factory):
     assert 'This case was withdrawn and replaced' in withdrawn.body_cache.html
     assert 'This case was withdrawn and replaced' in withdrawn.body_cache.xml
 
+@pytest.mark.django_db
+def test_update_frontend_urls(case_factory, django_assert_num_queries):
+    case1 = case_factory(citations__cite="123 Test 456", citations__type="official")
+    case2 = case_factory(citations__cite="124 Test 456", citations__type="official")
+    cite2 = case2.citations.first()
+
+    assert case1.frontend_url == "/test/123/456/"
+    assert case2.frontend_url == "/test/124/456/"
+
+    cite2.cite = "123 Test 456"
+    cite2.save()
+    with django_assert_num_queries(select=1, update=1):
+        CaseMetadata.update_frontend_urls(["124 Test 456", "123 Test 456"], update_elasticsearch=False)
+    case1.refresh_from_db()
+    case2.refresh_from_db()
+
+    assert case1.frontend_url == "/test/123/456/%s/" % case1.id
+    assert case2.frontend_url == "/test/123/456/%s/" % case2.id
+
+    cite2.cite = "124 Test 456"
+    cite2.save()
+    CaseMetadata.update_frontend_urls(["124 Test 456", "123 Test 456"], update_elasticsearch=False)
+    case1.refresh_from_db()
+    case2.refresh_from_db()
+
+    assert case1.frontend_url == "/test/123/456/"
+    assert case2.frontend_url == "/test/124/456/"
 
 ### Case Full Text Search ###
 @pytest.mark.django_db
-def test_fts_create_index(ingest_case_xml, django_assert_num_queries):
+def test_fts_create_index(ingest_case_xml):
     case_text = ingest_case_xml.metadata.case_text
 
     assert '4rgum3nt' not in case_text.tsv

--- a/capstone/scripts/fix_ct_cl_cites.py
+++ b/capstone/scripts/fix_ct_cl_cites.py
@@ -1,0 +1,92 @@
+import csv
+import re
+import sys
+
+from capdb.models import Citation, EditLog, Reporter, CaseMetadata
+
+"""
+    Usage: fab run_script:scripts.fix_ct_cl_cites
+
+    This script deletes or updates incorrectly-detected citations from the Court of Claims Reports (Ct. Cl.) reporter.
+    Additional citations were incorrectly detected for these volumes because case head matter often lists the citations 
+    of earlier cases in the procedural history ( https://github.com/harvard-lil/capstone/issues/1192 ).
+    
+    Cases in this reporter come in four varieties:
+    
+        1) Correct:                                                    1 Ct. Cl. 1
+        2) Correct, with a correctly detected parallel cite to F.2d:   206 Ct. Cl. 354, 513 F.2d 1342
+        3) Incorrect cite appended to F.2d cite with semicolon:        207 Ct. Cl. 254, "518 F.2d 556; 31 Ind. Cl. Comm. 89"
+        4) Incorrect additional cites:                                 19 Ct. Cl. 714, "16 Ct. Cl. 361; 111 U. S. 609"
+     
+    This script should ignore type 1 and type 2; edit the second cite in type 3; and delete the second cite for type 4.
+"""
+
+def main(dry_run='true'):
+    # get cases with at least one cite not matching 123 Ct. Cl. 456 (non-type-1 cases):
+    ct_cl_reporter = Reporter.objects.get(full_name='Court of Claims Reports')
+    bad_cites = Citation.objects.filter(case__reporter=ct_cl_reporter).select_related('case').extra(
+        where=[r"NOT cite ~ '^\d+ Ct\. Cl\. \d+$'"]).prefetch_related('case__citations')
+    bad_cases = set(c.case for c in bad_cites)
+    to_delete = []
+    to_update = []
+    changed_cites = set()
+    out = csv.writer(sys.stdout)
+    out.writerow(['case.id', 'result', 'val1', 'val2'])
+
+    # handle each bad case:
+    for case in bad_cases:
+        first, *rest = case.citations.all()
+
+        # special case -- doesn't follow the pattern
+        if case.id == 10809316:
+            old_val = first.cite
+            first.cite = "122 Ct. Cl. 348"
+            to_update.append(first)
+            if dry_run == 'true':
+                out.writerow([case.id, "special case", old_val, first.cite])
+            continue
+
+        # we should always have one correct cite at the front of the list:
+        if not re.match(r'\d+ Ct. Cl. \d+$', first.cite):
+            if dry_run == 'true':
+                out.writerow([case.id, "error", first, str(rest)])
+            continue
+
+        # handle skipping or updating F.2d cites:
+        if len(rest) == 1:
+            second = rest[0]
+
+            # type 2:
+            if re.match(r'\d+ F.2d \d+$', second.cite):
+                if dry_run == 'true':
+                    out.writerow([case.id, "skip", second.cite])
+                continue
+
+            # type 3:
+            if re.match(r'\d+ F.2d \d+;.*$', second.cite):
+                old_val = second.cite
+                second.cite = old_val.split(';', 1)[0]
+                to_update.append(second)
+                changed_cites.add(old_val)
+                changed_cites.add(second.cite)
+                if dry_run == 'true':
+                    out.writerow([case.id, "update", old_val, second.cite])
+                continue
+
+        # type 4:
+        delete_cites = [c.cite for c in rest]
+        changed_cites.update(delete_cites)
+        if dry_run == 'true':
+            out.writerow([case.id, "delete"]+delete_cites)
+        to_delete.append(rest)
+
+    # apply edits:
+    if dry_run == 'false':
+        with EditLog(
+                description='Remove incorrectly-detected citations from Ct. Cl. reporter. '
+                            'See https://github.com/harvard-lil/capstone/issues/1192'
+        ).record():
+            Citation.objects.update(to_update)
+            for obj in to_delete:
+                obj.delete()
+            CaseMetadata.update_frontend_urls(changed_cites)


### PR DESCRIPTION
Add a fix_ct_cl_cites script to address #1192. This should delete incorrect cites from Ct. Cl. that cause multiple cases for cites like this: https://cite.case.law/us/376/221/

![image](https://user-images.githubusercontent.com/376272/65911140-1e0abe00-e39a-11e9-8d10-16f19a3544e1.png)

Script can be dry-run with:

  fab run_script:scripts.fix_ct_cl_cites

And for real with:

  fab run_script:scripts.fix_ct_cl_cites,dry_run=false

This csv is the dry-run output, showing all changes:

[ct_cl_updates.txt](https://github.com/harvard-lil/capstone/files/3672998/ct_cl_updates.txt)

This script includes the first use of a new `CaseMetadata.update_frontend_urls` function, which (hopefully!) will avoid the need to run `fab update_case_frontend_url` or `fab populate_search_index` after updating case citations. It works by having the caller keep track of the old and new values for all citations that have changed, and then efficiently recalculating frontend_urls and reindexing just the affected cases.

PR also includes some WIP on link_scdb.py, which prompted this effort.