### PR TITLE
filter tokenization

### DIFF
--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -140,8 +140,11 @@ class CAPFiltering(FilteringFilterBackend):
             return [value.lower() for value in values if isinstance(value, str)]
 
         def tokenize(filter_values):
-            # takes each entry in filter_values and splits them on whitespace into separate entries
-            return reduce(lambda tokenized_list, current_term: tokenized_list + current_term.split(), filter_values, [])
+            # takes each entry in filter_values and splits them on non alphanumeric characters into separate entries
+            output = reduce(
+                lambda tokenized_list, current_term: tokenized_list + re.split(r'[^a-zA-Z0-9]', current_term),
+                filter_values, [])
+            return(output)
 
         query_params = super().get_filter_query_params(request, view)
         if 'cite' in query_params:


### PR DESCRIPTION
Looks like the name, name_abbreviation, and docket_number filters don't handle whitespace or other non-alphanum characters, which means that people searching for complete case names, case name abbreviations and docket numbers won't get the result they're looking for. This is a (probably temporary) fix that will alleviate that problem until we start digging into the analyzers a bit more.