### PR TITLE
Contact Page Docs Link

### DIFF
--- a/capstone/capweb/templates/contact.html
+++ b/capstone/capweb/templates/contact.html
@@ -13,6 +13,10 @@
 {% block main_content %}
   Email us at <a class="contact_email" href="mailto:{{ email }}">{{ email }}</a> or fill out this form.
   <br/><br/>
+  <small>If you're reporting a problem with the case data, including typos or OCR problems in cases, please read the
+    <a href="{% url 'api' %}#reporting-problems-and-enhancement-requests">Reporting Problems section of our API docs.
+    </a> before submitting this form.</small>
+  <br/><br/>
   <form action="{% url 'contact' %}" method="post">
     {% csrf_token %}
     {% bootstrap_form form %}

--- a/capstone/capweb/templates/contact.html
+++ b/capstone/capweb/templates/contact.html
@@ -13,9 +13,11 @@
 {% block main_content %}
   Email us at <a class="contact_email" href="mailto:{{ email }}">{{ email }}</a> or fill out this form.
   <br/><br/>
-  <small>If you're reporting a problem with the case data, including typos or OCR problems in cases, please read the
-    <a href="{% url 'api' %}#reporting-problems-and-enhancement-requests">Reporting Problems section of our API docs.
-    </a> before submitting this form.</small>
+  <small>
+    If you're reporting a problem with the case data, including typos or OCR problems in cases, please read the
+    <a href="{% url 'api' %}#reporting-problems-and-enhancement-requests">Reporting Problems section of our API docs</a>
+    before submitting this form.
+  </small>
   <br/><br/>
   <form action="{% url 'contact' %}" method="post">
     {% csrf_token %}


### PR DESCRIPTION
Redirect people trying to report OCR problems through the contact form to the API problem reporting section. Save 'em the effort of typing it up and waiting for a response when we're not going to do anything about it.