### PR TITLE
Restore serializers for the moment

### DIFF
--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -43,6 +43,72 @@ class JurisdictionSerializer(serializers.ModelSerializer):
         fields = ('url', 'id', 'slug', 'name', 'name_long', 'whitelisted')
 
 
+class CourtSerializer(serializers.ModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name="court-detail",
+        lookup_field='slug')
+
+    class Meta:
+        model = models.Court
+        fields = ('url', 'id', 'slug', 'name', 'name_abbreviation')
+
+
+class CaseVolumeSerializer(serializers.ModelSerializer):
+    """ Abbreviated version of VolumeSerializer for embedding in CaseSerializer. """
+    volume_number = serializers.ReadOnlyField(source='xml_volume_number')
+
+    class Meta:
+        model = models.VolumeMetadata
+        fields = ('url', 'barcode','volume_number')
+
+
+class CaseReporterSerializer(serializers.ModelSerializer):
+    """ Abbreviated version of CaseSerializer for embedding in CaseSerializer. """
+    class Meta:
+        model = models.Reporter
+        fields = (
+            'url',
+            'id',
+            'full_name',
+        )
+
+
+class CaseSerializer(serializers.HyperlinkedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(
+        view_name="cases-detail", lookup_field="id")
+    frontend_url = serializers.SerializerMethodField()
+    court = CourtSerializer(source='denormalized_court')
+    jurisdiction = JurisdictionSerializer(source='denormalized_jurisdiction')
+    citations = CitationSerializer(many=True)
+    volume = CaseVolumeSerializer()
+    reporter = CaseReporterSerializer()
+    decision_date = serializers.DateField(source='decision_date_original')
+
+    class Meta:
+        model = models.CaseMetadata
+        fields = (
+            'id',
+            'url',
+            'frontend_url',
+            'name',
+            'name_abbreviation',
+            'decision_date',
+            'docket_number',
+            'first_page',
+            'last_page',
+            'citations',
+            'volume',
+            'reporter',
+            'court',
+            'jurisdiction',
+        )
+
+    def get_frontend_url(self, obj):
+        if not hasattr(self, '_frontend_url_base'):
+            CaseSerializer._frontend_url_base = reverse('cite_home', host='cite').rstrip('/')
+        return self._frontend_url_base + (obj.frontend_url or '')
+
+
 # for elasticsearch
 class CaseDocumentSerializer(DocumentSerializer):
     url = serializers.SerializerMethodField()


### PR DESCRIPTION
Fixes #1234, though it might be better to follow the instruction at https://github.com/harvard-lil/capstone/blob/develop/capstone/capweb/views.py#L161, `# TODO: Trim what we don't need here`.