### PR TITLE
Put an empty string in filter values, not None

### DIFF
--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -190,7 +190,7 @@ class CAPFiltering(FilteringFilterBackend):
             if f in options:
                 fields[f]['options'] = options[f]
             else:
-                fields[f]['value'] = None
+                fields[f]['value'] = ''
 
             if f in filter_values:
                 fields[f]['value'] = ' '.join(filter_values[f])


### PR DESCRIPTION
This makes the query string look like e.g. `decision_date_min=&decision_date_max=` instead of `decision_date_min=None&decision_date_max=None`, which causes Elasticsearch to throw `elasticsearch.exceptions.RequestError: RequestError(400, 'search_phase_execution_exception', 'failed to parse date field [None] with format [strict_date_optional_time||epoch_millis]')`. Thanks @jcushman!