### PR TITLE
display decision_date_original instead of decision_date

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -107,6 +107,7 @@ class CaseDocument(DocType):
         fields = [
             'id',
             'decision_date',
+            'decision_date_original',
             'date_added',
         ]
         ignore_signals = True

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -51,6 +51,7 @@ class CaseDocumentSerializer(DocumentSerializer):
     court = serializers.SerializerMethodField()
     jurisdiction = serializers.SerializerMethodField()
     citations = serializers.SerializerMethodField()
+    decision_date = serializers.SerializerMethodField()
 
     class Meta:
         document = CaseDocument
@@ -128,6 +129,9 @@ class CaseDocumentSerializer(DocumentSerializer):
 
     def get_url(self, obj):
         return api_reverse('cases-detail', [obj.id])
+
+    def get_decision_date(self, obj):
+        return obj.decision_date_original
 
 class CaseAllowanceMixin:
     """


### PR DESCRIPTION
Previously we were displaying decision_date_original which, in some cases, might have a month granularity rather than a day granularity. For search, we create the decision_date field which sets the month-granularity dates to the first of the month, for search purposes. Currently, we are incorrectly stating that the decision date for those cases is on the first of the month. This PR goes back to displaying decision_date_original. This PR creates a new ES field and will require reindexing. 