### PR TITLE
add recovery key to cases endpoint

### DIFF
--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -137,7 +137,7 @@ class CapUser(PermissionsMixin, AbstractBaseUser):
 
     def authenticate_user(self, activation_nonce):
         if self.activation_nonce == activation_nonce and self.nonce_expires + timedelta(hours=24) > timezone.now():
-            Token.objects.create(user=self)
+            Token.objects.get_or_create(user=self)
             self.activation_nonce = ''
             self.email_verified = True
             self.save()

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -8,7 +8,7 @@ from rest_framework.serializers import ListSerializer
 from capapi.models import SiteLimits
 from capapi.renderers import HTMLRenderer, XMLRenderer
 from capdb import models
-from capdb.models import CaseBodyCache
+from capdb.models import CaseBodyCache, CaseMetadata
 from capweb.helpers import reverse
 from scripts import helpers
 from .permissions import check_update_case_permissions
@@ -231,10 +231,15 @@ class CaseDocumentSerializerWithCasebody(CaseAllowanceMixin, CaseDocumentSeriali
                 except AttributeError:
                     data = case.casebody_data['text']
 
-            return {
+            out = {
                 'data': data,
                 'status': status
             }
+
+            if check_permissions and not case.jurisdiction['whitelisted'] and 'request' in self.context:
+                out['recovery_key'] = CaseMetadata(id=case.id).get_recovery_key(self.context['request'].user)
+
+            return out
 
         return {'status': status, 'data': None}
 

--- a/capstone/capapi/tests/test_admin.py
+++ b/capstone/capapi/tests/test_admin.py
@@ -11,24 +11,7 @@ def test_admin_view(admin_client):
 @pytest.mark.django_db
 def test_admin_user_authenticate(admin_client, cap_user):
     """
-    Test if we can authenticate user through the admin panel
-    """
-    data = {
-        'action': 'authenticate_user',
-        '_selected_action': cap_user.id,
-    }
-    response = admin_client.post('/admin/capapi/capuser/', data, follow=True)
-    cap_user.refresh_from_db()
-
-    assert response.status_code == 200
-    assert cap_user.is_authenticated
-    assert cap_user.get_api_key()
-
-
-@pytest.mark.django_db
-def test_admin_user_authenticate_without_nonce_expires(admin_client, cap_user):
-    """
-    Test if we can authenticate even if nonce_expires is missing
+    Test if we can activate users through the admin panel
     """
     cap_user.nonce_expires = None
     cap_user.save()

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -154,6 +154,45 @@ def test_authenticated_full_case_blacklisted(auth_user, auth_client, non_whiteli
 
 
 @pytest.mark.django_db
+def test_recovery_key(auth_user, auth_client, non_whitelisted_case_document, auth_user_factory):
+    ### blacklisted jurisdiction cases should be counted against the user
+
+    # initial fetch
+    url = api_reverse("cases-detail", args=[non_whitelisted_case_document.id])
+    kwargs = {"full_case": "true"}
+    response = auth_client.get(url, kwargs)
+    check_response(response)
+    result = response.json()
+    assert result['casebody']['status'] == 'ok'
+    recovery_key = result['casebody']['recovery_key']
+
+    # make sure the auth_user's case download number has gone down by 1
+    auth_user.refresh_from_db()
+    assert auth_user.case_allowance_remaining == auth_user.total_case_allowance - 1
+
+    # fetch again with recovery key -- allowance doesn't go down
+    response = auth_client.get(url, {'recovery_key': recovery_key, **kwargs})
+    result = response.json()
+    assert result['casebody']['status'] == 'ok'
+    auth_user.refresh_from_db()
+    assert auth_user.case_allowance_remaining == auth_user.total_case_allowance - 1
+
+    # cannot fetch with invalid key
+    response = auth_client.get(url, {'recovery_key': recovery_key+'1', **kwargs})
+    result = response.json()
+    assert result['casebody']['status'] == 'error_invalid_recovery_key'
+    assert result['casebody']['data'] is None
+    auth_user.refresh_from_db()
+    assert auth_user.case_allowance_remaining == auth_user.total_case_allowance - 1
+
+    # cannot fetch as another user
+    response = auth_client.get(url, {'recovery_key': recovery_key, **kwargs}, as_user=auth_user_factory())
+    result = response.json()
+    assert result['casebody']['status'] == 'error_invalid_recovery_key'
+    assert result['casebody']['data'] is None
+
+
+@pytest.mark.django_db
 def test_unlimited_access(auth_user, auth_client, non_whitelisted_case_document):
     ### user with unlimited access should not have blacklisted cases count against them
     auth_user.total_case_allowance = settings.API_CASE_DAILY_ALLOWANCE

--- a/capstone/capapi/views/user_views.py
+++ b/capstone/capapi/views/user_views.py
@@ -43,8 +43,7 @@ def register_user(request):
 def verify_user(request, user_id, activation_nonce):
     """ Verify email and assign api token """
     try:
-        mailing_list_message = "We have not signed you up for our newsletter, Lawvocado. Sign up any time from" \
-                               "our homepage."
+        mailing_list_message = "We have not signed you up for our newsletter, Lawvocado. Sign up any time from our homepage."
         user = CapUser.objects.get(pk=user_id)
         user.authenticate_user(activation_nonce=activation_nonce)
     except (CapUser.DoesNotExist, PermissionDenied):

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -7,22 +7,23 @@ from contextlib import contextmanager
 import struct
 import base64
 import nacl
+import nacl.encoding
+import nacl.secret
+from lxml import etree
+from model_utils import FieldTracker
+from pyquery import PyQuery
+from bs4 import BeautifulSoup
 
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField, ArrayField
 import django.contrib.postgres.search as pg_search
 from django.core.exceptions import ObjectDoesNotExist
+from django.core.signing import Signer, BadSignature
 from django.db import models, IntegrityError, transaction
 from django.db.models import Q
 from django.utils.text import slugify
 from django.utils.encoding import force_bytes, force_str
 from django.core.files.base import ContentFile
-from lxml import etree
-from model_utils import FieldTracker
-import nacl.encoding
-import nacl.secret
-from pyquery import PyQuery
-from bs4 import BeautifulSoup
 
 from capdb.storages import bulk_export_storage, case_image_storage
 from capdb.versioning import TemporalHistoricalRecords, TemporalQuerySet
@@ -1245,6 +1246,34 @@ class CaseMetadata(models.Model):
         # handle deleted images
         if known_hashes:
             CaseImage.objects.filter(case=self, hash__in=known_hashes).delete()
+
+    def get_recovery_key(self, user):
+        """
+            Get a recovery key that can be used to re-fetch this case by this user.
+
+            >>> from capapi.models import CapUser
+            >>> CaseMetadata(id=1).get_recovery_key(CapUser(id=1))
+        """
+        return Signer(salt='recovery_key').sign('%s-%s' % (user.id, self.id)).split(':', 1)[1]
+
+    def valid_recovery_key(self, user, key):
+        """
+            Return True if key is a valid recovery key for this user and case.
+
+            >>> from capapi.models import CapUser
+            >>> user = CapUser(id=1)
+            >>> case = CaseMetadata(id=1)
+            >>> key = case.get_recovery_key(user)
+            >>> assert case.valid_recovery_key(user, key)
+            >>> assert not case.valid_recovery_key(user, key+'1')
+            >>> assert not case.valid_recovery_key(CapUser(id=2), key)
+        """
+        try:
+            Signer(salt='recovery_key').unsign('%s-%s:%s' % (user.id, self.id, key))
+            return True
+        except BadSignature:
+            return False
+
 
 class CaseXML(BaseXMLModel):
     metadata = models.OneToOneField(CaseMetadata, blank=True, null=True, related_name='case_xml',

--- a/capstone/capdb/tests/test_versioning.py
+++ b/capstone/capdb/tests/test_versioning.py
@@ -11,8 +11,7 @@ from scripts.helpers import parse_xml, serialize_xml
     'case_xml',
     'page_xml'
 ])
-@pytest.mark.django_db(transaction=True)
-def test_versioning(versioned_fixture_name, request):
+def test_versioning(transactional_db, versioned_fixture_name, request):
     # load initial volume_xml/case_xml/page_xml
     versioned_instance = request.getfuncargvalue(versioned_fixture_name)
     original_instance = deepcopy(versioned_instance)

--- a/capstone/capweb/tests/test_helpers.py
+++ b/capstone/capweb/tests/test_helpers.py
@@ -1,5 +1,7 @@
 import pytest
 import socket
+
+from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from capweb.helpers import is_google_bot
 
@@ -8,7 +10,7 @@ user_agent_other = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:67.0) Gecko
 
 
 @pytest.mark.django_db
-def x_test_is_google_bot_with_dns_lookup(anonymous_user):
+def x_test_is_google_bot_with_dns_lookup():
     """
     This test is brittle and assumes Google's IP address. It will perform an DNS lookup.
 
@@ -24,7 +26,7 @@ def x_test_is_google_bot_with_dns_lookup(anonymous_user):
     """
 
     request = RequestFactory().get('/')
-    request.user = anonymous_user
+    request.user = AnonymousUser()
 
     # User agent and IP look like Google
     request.META["HTTP_USER_AGENT"] = user_agent_google
@@ -43,7 +45,7 @@ def x_test_is_google_bot_with_dns_lookup(anonymous_user):
 
 
 @pytest.mark.django_db
-def test_is_google_bot_without_dns_lookup(monkeypatch, anonymous_user):
+def test_is_google_bot_without_dns_lookup(monkeypatch):
     """
     Stubbing out DNS lookup, returning a google bot host string.
 
@@ -54,7 +56,7 @@ def test_is_google_bot_without_dns_lookup(monkeypatch, anonymous_user):
 
     monkeypatch.setattr(socket, "gethostbyaddr", mock_get_googlehost)
     request = RequestFactory().get('/')
-    request.user = anonymous_user
+    request.user = AnonymousUser()
 
     # User agent and IP look like Google
     request.META["HTTP_USER_AGENT"] = user_agent_google

--- a/capstone/cite/tests/test_views.py
+++ b/capstone/cite/tests/test_views.py
@@ -34,12 +34,12 @@ def test_home(client, django_assert_num_queries, ingest_metadata):
 
 
 @pytest.mark.django_db
-def test_series(client, django_assert_num_queries, volume_factory, whitelisted_case_document):
+def test_series(client, django_assert_num_queries, volume_metadata_factory, whitelisted_case_document):
 
     """ Test /series/ """
 
     # make sure we correctly handle multiple reporters with same slug
-    volume_1, volume_2 = [volume_factory() for _ in range(2)]
+    volume_1, volume_2 = [volume_metadata_factory() for _ in range(2)]
     volume_2.reporter.short_name_slug = volume_1.reporter.short_name_slug
     volume_2.reporter.save()
 

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -35,7 +35,7 @@ services:
           - 9200:9200
     worker:
         build: .
-        image: capstone:0.3.63-8cb2eead90e2c4c884beac0119ad9efa
+        image: capstone:0.3.64-ff8d1161b17c2c3924b230b6d39bdcaf
         volumes:
             # NAMED VOLUMES
             # Use a named, persistent volume so that the node_modules directory,
@@ -62,7 +62,7 @@ services:
           - "api.case.test:127.0.0.1"
     web:
         build: .
-        image: capstone:0.3.63-8cb2eead90e2c4c884beac0119ad9efa
+        image: capstone:0.3.64-ff8d1161b17c2c3924b230b6d39bdcaf
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -52,7 +52,6 @@ pytest-redis       # redisdb fixture
 moto
 flake8
 factory-boy        # mocking
-pytest-factoryboy  # inject factory-boy factories into pytest fixtures
 bagit              # validate BagIt bag
 flaky              # retry flaky tests
 retry              # re-run blocks of code until the ES index updates, but fail if they don't end up working

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -336,7 +336,7 @@ img2pdf==0.3.3 \
     --hash=sha256:9d77c17ee65a736abe92ef8cba9cca009c064ea4ed74492c01aea596e41856cf
 inflection==0.3.1 \
     --hash=sha256:18ea7fb7a7d152853386523def08736aa8c32636b047ade55f7578c4edeb16ca \
-    # via drf-yasg, pytest-factoryboy
+    # via drf-yasg
 itypes==1.1.0 \
     --hash=sha256:c6e77bb9fd68a4bfeb9d958fea421802282451a25bac4913ec94db82a899c073 \
     # via coreapi
@@ -662,8 +662,6 @@ pytest-cov==2.6.1 \
 pytest-django==3.4.5 \
     --hash=sha256:1a5d33be930e3172fa238643a380414dc369fe8fa4b3c3de25e59ed142950736 \
     --hash=sha256:e88e471d3d0f9acfb6293bb03d0ee8a33ed978734e92ea6b5312163a6c9e87cc
-pytest-factoryboy==2.0.3 \
-    --hash=sha256:ffef3fb7ddec1299d3df0d334846259023f3d1da5ab887ad880139a8253a5a1a
 pytest-forked==1.0.1 \
     --hash=sha256:260d03fbd38d5ce41a657759e8d19bc7c8cfa6d0dcfa36c0bc9742d33bc30742 \
     --hash=sha256:8d05c2e6f33cd4422571b2b1bb309720c398b0549cff499e3e4cde661875ab54 \

--- a/services/postgres/denormalize_source.js
+++ b/services/postgres/denormalize_source.js
@@ -42,7 +42,6 @@ $$
 
     // update destination fields
     var sql = 'UPDATE ' + dest_table + ' SET ' + dest_columns.join(', ') + ' WHERE ' + dest_id_column + '=$' + (index+1);
-    plv8.elog(WARNING, sql, JSON.stringify(dest_values));
     plv8.execute(sql, dest_values);
   }
 


### PR DESCRIPTION
The primary goal of this PR is to add `"recovery_key"` to the cases endpoint.

In adding tests for that, I also brought some test helpers and refactoring over from h2o:

- new `as_user` parameter for client.get()
- replace pytest-factoryboy with a simpler and more reliable `@register` decorator
- refactor user and client fixtures