### PR TITLE
Case viewer tweaks

### DIFF
--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -45,11 +45,9 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
 
         template = loader.get_template('case.html')
 
-        # TODO: add html renderer to court and others. For now here's a quick fix
-        data['court']['url'] = data['court']['url'].split("format=html")[0]
-
         sorted_cites = sorted(data['citations'], key=lambda c: Citation.citation_type_sort_order[c['type']])
         citations = ", ".join(c['cite'] for c in sorted_cites)
+        non_vendor_citations = ", ".join(c['cite'] for c in sorted_cites if c['type'] != 'vendor')
 
         try:
             cit_year = data["decision_date"][0:4]
@@ -58,7 +56,7 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
             cit_year = data["decision_date"].strftime('%Y')
             dec_date = data["decision_date"].strftime('%b. %-d, %Y')
 
-        citation_full = data["name_abbreviation"] + ", " + citations + " (" + cit_year + ")"
+        citation_full = data["name_abbreviation"] + ", " + non_vendor_citations + " (" + cit_year + ")"
 
         context = {
             **renderer_context,
@@ -78,6 +76,7 @@ class HTMLRenderer(renderers.StaticHTMLRenderer):
                 "court": data["court"],
                 "jurisdiction": data["jurisdiction"]},
             'citation_full': citation_full,
+            'id': data['id'],
         }
 
         # if user requested format=html without requesting full casebody

--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -2,6 +2,7 @@
 {% load pipeline %}
 {% load static %}
 {% load render_bundle from webpack_loader %}
+{% load api_url %}
 
 {% load capweb_static %}
 
@@ -21,9 +22,14 @@
         </div>
       {% endif %}
       <div class="full_cite">{{ citation_full }}</div>
+      <div class="small">
+        <a href="{% api_url 'cases-detail' id %}">view API</a>
+        {% if request.user.is_staff %}
+          • <a href="{% url 'admin:capdb_casemetadata_change' id %}">Django admin</a>
+        {% endif %}
+      </div>
       <div class="court">
-        <a href="{{ metadata.court.url }}">
-          {{ metadata.court.name }}</a>
+        {{ metadata.court.name }}
       </div>
       <h4 class="case-name">{{ metadata.name }}</h4>
       <div class="citations">


### PR DESCRIPTION
A couple of small tweaks to the case viewer:

-  hide vendor citations from the short citation at the top of the page
- remove the link to the Court api, which doesn't offer anything useful
- add a link to "view API" to see the API endpoint for this case
- if staff, add a link to view the case in the Django admin

![image](https://user-images.githubusercontent.com/376272/72563975-c9258180-387c-11ea-91c7-9bbcd6fa1899.png)

