### PR TITLE
Fix calculation of reporter years

### DIFF
--- a/capstone/capdb/admin.py
+++ b/capstone/capdb/admin.py
@@ -167,9 +167,10 @@ class EditLogAdmin(admin.ModelAdmin):
         return CapUser.objects.get(id=obj.user_id)
 
 
-# models with no admin class yet
-
-admin.site.register(VolumeMetadata)
-# admin.site.register(ProcessStep)
-# admin.site.register(BookRequest)
-# admin.site.register(TrackingToolUser)
+@admin.register(VolumeMetadata)
+class VolumeMetadataAdmin(admin.ModelAdmin):
+    raw_id_fields = ['duplicate_of', 'reporter', 'nominative_reporter', 'request']
+    list_display = ['pk', 'volume_number', 'reporter', 'out_of_scope', 'duplicate']
+    list_select_related = ['reporter']
+    ordering = ['reporter__full_name', 'volume_number']
+    search_fields = ['reporter__short_name', 'reporter__full_name']

--- a/capstone/capweb/helpers.py
+++ b/capstone/capweb/helpers.py
@@ -101,8 +101,7 @@ def show_toolbar_callback(request):
         Whether to show django-debug-toolbar.
         This adds an optout for urls with ?no_toolbar
     """
-    from debug_toolbar.middleware import show_toolbar
-    return False if 'no_toolbar' in request.GET else show_toolbar(request)
+    return False if 'no_toolbar' in request.GET else bool(settings.DEBUG)
 
 
 class StatementTimeout(Exception):


### PR DESCRIPTION
We calculate reporter years in `fab update_reporter_years`. This was taking into account cases or volumes marked out of scope. Fix the calculation to only include valid cases.

Also in this PR: customize the VolumeMetadata django admin screen, and make django debug toolbar show in docker.