### PR TITLE
added exclusion for start_year in cite series view

### DIFF
--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -87,6 +87,7 @@ def series(request, series_slug):
         return HttpResponseRedirect(helpers.reverse('series', args=[slugify(series_slug)], host='cite'))
     reporters = list(Reporter.objects
         .filter(short_name_slug=series_slug)
+        .exclude(start_year=None)
         .prefetch_related(Prefetch('volumes', queryset=VolumeMetadata.objects.exclude(volume_number=None).exclude(volume_number='').exclude(duplicate=True).exclude(out_of_scope=True)))
         .order_by('full_name'))
     if not reporters:


### PR DESCRIPTION
In situations where a series slug points to more than one series, and one of those series contains no volumes, it will show up on the series page. This just adds the same start_page exclusion that's on the cite.case.law home view to the series view.