### PR TITLE
Add hidden field to contact form to filter spam

### DIFF
--- a/capstone/capweb/forms.py
+++ b/capstone/capweb/forms.py
@@ -2,6 +2,7 @@ from django import forms
 
 class ContactForm(forms.Form):
     subject = forms.CharField(label="Message subject", required=True, max_length=100)
-    message = forms.CharField(label="Message content", required=True, widget=forms.Textarea)
+    box1 = forms.CharField(label="Do not fill out this box", required=False, widget=forms.Textarea)  # fake message box to fool bots
+    box2 = forms.CharField(label="Message content", required=False, widget=forms.Textarea)
     email = forms.EmailField(label="Your email address", required=True)
 

--- a/capstone/capweb/templates/contact.html
+++ b/capstone/capweb/templates/contact.html
@@ -19,7 +19,7 @@
     before submitting this form.
   </small>
   <br/><br/>
-  <form action="{% url 'contact' %}" method="post">
+  <form action="{% url 'contact' %}" method="post" class="contact-form">
     {% csrf_token %}
     {% bootstrap_form form %}
     <br/>

--- a/capstone/capweb/urls.py
+++ b/capstone/capweb/urls.py
@@ -43,7 +43,7 @@ urlpatterns = [
     path('contact-success/', TemplateView.as_view(template_name='form_success.html',
                                                   extra_context={
                                                       'form_title': 'contact',
-                                                      'message': 'We\'ll be in touch, shortly.'
+                                                      'message': 'We\'ll be in touch shortly.'
                                                   }),  name='contact-success'),
 
     ### admin stuff ###

--- a/capstone/capweb/views.py
+++ b/capstone/capweb/views.py
@@ -93,8 +93,13 @@ def contact(request):
 
     if request.method == 'POST' and form.is_valid():
         data = form.data
-        send_contact_email(data.get('subject'), data.get('message'), data.get('email'))
-        logger.info("sent contact email: %s" % data)
+        # Only send email if box2 is filled out and box1 is not.
+        # box1 is display: none, so should never be filled out except by spam bots.
+        if data.get('box2') and not data.get('box1'):
+            send_contact_email(data.get('subject'), data.get('box2'), data.get('email'))
+            logger.info("sent contact email: %s" % data)
+        else:
+            logger.info("suppressing invalid contact email: %s" % data)
         return HttpResponseRedirect(reverse('contact-success'))
 
     email_from = request.user.email if request.user.is_authenticated else ""

--- a/capstone/static/css/scss/contact.scss
+++ b/capstone/static/css/scss/contact.scss
@@ -31,3 +31,13 @@ input, textarea {
     font-size: 0.9rem;
   }
 }
+
+.contact-form {
+  // hide box1 so it will only be filled by spam bots
+  label[for="id_box1"] {
+    display: none;
+  }
+  textarea[name="box1"] {
+    display: none;
+  }
+}


### PR DESCRIPTION
This is the simplest approach to filtering spam from our contact form -- include `box1` and `box2` in the html, make `box1` be `display: none` in the css, and drop any emails that have it filled out. We can get trickier if form spam still comes through after this.

@bensteinberg, I'd be curious if `logger.info` makes it to our log -- I think we do want to log these.