### PR TITLE
Downloads tweaks

### DIFF
--- a/capstone/capweb/helpers.py
+++ b/capstone/capweb/helpers.py
@@ -261,13 +261,6 @@ def password_protected_page(key):
         return inner
     return outer
 
-def natural_sort_key(text):
-    """
-        Sort numeric parts of text numerically and text parts alphabetically. Example:
-            >>> sorted(["9 Foo", "10 Foo", "9A Foo"], key=natural_sort_key)
-            ['9 Foo', '9A Foo', '10 Foo']
-    """
-    return [int(part) if part.isdigit() else part for word in text.split() for part in re.split('(\d+)', word)]
 
 def page_image_url(url, targets=[], waits=[], fallback=None, timeout=None):
     """

--- a/capstone/scripts/fix_nominative_reporters/main.py
+++ b/capstone/scripts/fix_nominative_reporters/main.py
@@ -2,9 +2,9 @@ import csv
 import re
 from copy import deepcopy
 from pathlib import Path
+from natsort import natsorted
 
 from capdb.models import Reporter, EditLog, VolumeMetadata, Citation
-from capweb.helpers import natural_sort_key
 
 """
     This script fixes our handling of nominative reporters. We currently handle nominative reporters like this:
@@ -139,8 +139,7 @@ def main(dry_run='true'):
             ## prepare to process each volume in nominative reporter
 
             print("- update volumes")
-            volumes = list(nominative_reporter.volumes.filter(duplicate=False).order_by('volume_number'))
-            volumes.sort(key=lambda v: natural_sort_key(v.volume_number))
+            volumes = natsorted(nominative_reporter.volumes.filter(duplicate=False).order_by('volume_number'), key=lambda v: v.volume_number)
             last_volume_numbers = []
             volume_index = 0
 


### PR DESCRIPTION
- use natsorted to sort download files so "75 N.C." comes before "345 N.C."
- don't use `Content-Disposition: attachment`, so PDFs can show in browser instead of being automatically downloaded