### PR TITLE
Run some tests in parallel with pytest -n 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,8 @@ jobs:
             docker-compose exec web pytest \
               --junitxml=junit/pytest/test-results.xml       `# write test results so they can be displayed by circleci` \
               --cov --cov-config=setup.cfg --cov-report xml  `# write coverage data to .coverage for upload by codecov` \
-              --fail-on-template-vars
+              --fail-on-template-vars \
+              -n 2                                           `# run tests in parallel`
 
       # Upload test details to circleci
       - store_test_results:

--- a/capstone/capapi/tests/test_admin.py
+++ b/capstone/capapi/tests/test_admin.py
@@ -3,7 +3,7 @@ import pytest
 from django.contrib.auth.models import Permission
 
 
-def test_admin_view(admin_client):
+def test_admin_view__parallel(admin_client):
     response = admin_client.get('/admin/')
     assert response.status_code == 200
 

--- a/capstone/capdb/tests/test_build.py
+++ b/capstone/capdb/tests/test_build.py
@@ -19,7 +19,7 @@ def test_makemigrations():
     management.call_command('makemigrations', dry_run=True, stdout=out)
     assert out.getvalue() == 'No changes detected\n', "Model changes detected. Please run ./manage.py makemigrations"
 
-def test_pip_compile():
+def test_pip_compile__parallel():
     existing_requirements = Path('requirements.txt').read_bytes()
     subprocess.check_call(["fab", "pip-compile"], stdout=subprocess.PIPE,
                           # strip COV_ environment variables so pip-compile doesn't try to report test coverage
@@ -27,11 +27,11 @@ def test_pip_compile():
     new_requirements = Path('requirements.txt').read_bytes()
     assert new_requirements == existing_requirements, "Changes detected to requirements.in. Please run fab pip-compile"
 
-def test_flake8():
+def test_flake8__parallel():
     subprocess.check_call('flake8')
 
 @pytest.mark.skipif(not os.environ.get('DOCKERIZED'), reason="npm build can only be tested in docker")
-def test_npm_build():
+def test_npm_build__parallel():
     dist_dir = Path(settings.STATICFILES_DIRS[0], settings.WEBPACK_LOADER['DEFAULT']['BUNDLE_DIR_NAME'])
     stats_file = settings.WEBPACK_LOADER['DEFAULT']['STATS_FILE']
 
@@ -46,7 +46,7 @@ def test_npm_build():
     assert dist_hash == dist_hash2, "'yarn build' updated files in %s" % dist_dir
     assert stats_hash == stats_hash2, "'yarn build' updated %s" % stats_file
 
-def test_docker_compose_version():
+def test_docker_compose_version__parallel():
     docker_compose_path = Path(settings.BASE_DIR, 'docker-compose.yml')
     existing_docker_compose = docker_compose_path.read_text()
     fabfile.update_docker_image_version()

--- a/capstone/capdb/tests/test_storages.py
+++ b/capstone/capdb/tests/test_storages.py
@@ -1,10 +1,10 @@
 from io import BytesIO
 
 
-def test_iter_files_s3_storage(s3_storage):
+def test_iter_files_s3_storage__parallel(s3_storage):
     base_test_iter_files(s3_storage)
 
-def test_iter_files_file_storage(file_storage):
+def test_iter_files_file_storage__parallel(file_storage):
     base_test_iter_files(file_storage)
 
 def base_test_iter_files(storage):
@@ -26,7 +26,7 @@ def base_test_iter_files(storage):
     assert set(sub_dir) == set(storage.iter_files_recursive('d'))
 
 
-def test_isfile(file_storage):
+def test_isfile__parallel(file_storage):
     file_names = ['a/b.txt', 'c.txt']
     for file_name in file_names:
         file_storage.save(file_name, BytesIO(b'content'))
@@ -37,7 +37,7 @@ def test_isfile(file_storage):
     assert not file_storage.isfile('a')
 
 
-def test_isdir(file_storage):
+def test_isdir__parallel(file_storage):
     file_storage.save('a/b.txt', BytesIO(b'content'))
 
     assert file_storage.isdir('a')

--- a/capstone/capweb/tests/test_ui.py
+++ b/capstone/capweb/tests/test_ui.py
@@ -70,7 +70,7 @@ def test_contact(client, auth_client, mailoutbox):
     assert len(mailoutbox) == 1
 
 
-def test_screenshot(client, live_server, settings, ngrammed_cases):
+def test_screenshot__parallel(client, live_server, settings, ngrammed_cases):
     # set up conditions for /screenshot/ route to work
     settings.SCREENSHOT_FEATURE = True
     settings.DEBUG = True  # so view expects an http url


### PR DESCRIPTION
Experimental -- if this works on Circle, it means that tests that don't access the db don't have to wait for those that do.