### PR TITLE
ID redaction updates

### DIFF
--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -201,3 +201,39 @@ def test_update_case_frontend_url_bad_cite(case_metadata):
     assert case_metadata.frontend_url == "/%s/%s/%s/%s/" % (case_metadata.reporter.short_name_slug, case_metadata.volume.volume_number, case_metadata.first_page, citation.case_id)
 
 
+
+@pytest.mark.django_db
+def test_redact_id_numbers(case_factory):
+    # redact some numbers
+    case = case_factory(body_cache__text="text 123-45-6789  # normal SSN")
+    fabfile.redact_id_numbers()
+    case.refresh_from_db()
+    assert case.no_index_redacted == {'123-45-6789': 'XXX-XX-XXXX'}
+
+    # test updating existing no_index_redacted
+    case.no_index_redacted['foo'] = 'bar'
+    case.save()
+    case.body_cache.text += "more text 123 — 45 — 6789  # mdashes and whitespace "
+    case.body_cache.save()
+    fabfile.redact_id_numbers()
+    case.refresh_from_db()
+    assert case.no_index_redacted == {'123 — 45 — 6789': 'XXX — XX — XXXX', '123-45-6789': 'XXX-XX-XXXX', 'foo': 'bar'}
+
+    # test A-numbers
+    case.body_cache.text="""
+        A12345678  # 8 digit A-number
+        A123456789  # 9 digit A-number
+        A-12345678  # 8 digit A-number with hyphen
+        A — 123456789  # 9 digit A-number with mdash and spaces
+    """
+    case.no_index_redacted = {}
+    case.body_cache.save()
+    case.save()
+    fabfile.redact_id_numbers()
+    case.refresh_from_db()
+    assert case.no_index_redacted == {
+        'A12345678': 'AXXXXXXXX',
+        'A — 123456789': 'A — XXXXXXXXX',
+        'A123456789': 'AXXXXXXXXX',
+        'A-12345678': 'A-XXXXXXXX',
+    }


### PR DESCRIPTION
- Fix the regex format for A-numbers that I got wrong last time.
- Add tests for `fab no_index_redacted`.
- Some tweaks to the task for simplicity/query efficiency.