### PR TITLE
Use correct IP headers

### DIFF
--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -89,7 +89,7 @@ def wrap_user(request, user):
     """
     def inner_wrap_user():
         wrapped_user = TrackingWrapper(user)
-        wrapped_user.ip_address = request.META.get('HTTP_X_FORWARDED_FOR')
+        wrapped_user.ip_address = request.META.get('HTTP_CF_CONNECTING_IP')
         return wrapped_user
     return SimpleLazyObject(inner_wrap_user)
 

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -243,7 +243,7 @@ def test_harvard_access(request, restricted_case, client_fixture_name, elasticse
     case_url = api_reverse("cases-detail", args=[restricted_case.id])
 
     # request works when IP address provided
-    response = client.get(case_url, {"full_case": "true"}, HTTP_X_FORWARDED_FOR='128.103.1.1')
+    response = client.get(case_url, {"full_case": "true"}, HTTP_CF_CONNECTING_IP='128.103.1.1')
     check_response(response)
     result = response.json()
     assert result['casebody']['status'] == 'ok'
@@ -253,7 +253,7 @@ def test_harvard_access(request, restricted_case, client_fixture_name, elasticse
     assert user.case_allowance_remaining == 1
 
     # request succeeds when IP address is wrong, using case allowance
-    response = client.get(case_url, {"full_case": "true"}, HTTP_X_FORWARDED_FOR='1.1.1.1')
+    response = client.get(case_url, {"full_case": "true"}, HTTP_CF_CONNECTING_IP='1.1.1.1')
     check_response(response)
     result = response.json()
     assert result['casebody']['status'] == 'ok'
@@ -263,7 +263,7 @@ def test_harvard_access(request, restricted_case, client_fixture_name, elasticse
     assert user.case_allowance_remaining == 0
 
     # request fails when case allowance exhausted
-    response = client.get(case_url, {"full_case": "true"}, HTTP_X_FORWARDED_FOR='1.1.1.1')
+    response = client.get(case_url, {"full_case": "true"}, HTTP_CF_CONNECTING_IP='1.1.1.1')
     check_response(response)
     result = response.json()
     assert result['casebody']['status'] != 'ok'

--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -274,9 +274,11 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
 
         serialized_data['casebody']['data'] = data
 
-        if settings.GEOLOCATION_FEATURE and request.user.ip_address:
+        if settings.GEOLOCATION_FEATURE and request.META.get('HTTP_X_FORWARDED_FOR'):
+            # Trust x-forwarded-for in this case because we don't mind being lied to, and would rather show accurate
+            # results for users using honest proxies.
             try:
-                location = geolocate(request.user.ip_address)
+                location = geolocate(request.META['HTTP_X_FORWARDED_FOR'].split(',')[-1])
                 state = location.subdivisions.most_specific.name
                 country = location.country.name
                 location_str = state if country == "United States" else "%s, %s" % (state, country)


### PR DESCRIPTION
Use `CF-Connecting-IP` header instead of `X-Forwarded-For` for proper IP checking; use last entry in `X-Forwarded-For` for state-level geolocation logging where we don't care if the results can be faked.