### PR TITLE
Fix prefix search

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -13,7 +13,10 @@ case.settings(
 )
 
 def SuggestField():
-    return fields.StringField(
+    """
+        Query 'foo' to get the TextField, or 'foo.raw' to get the KeywordField, or 'foo.suggest' to get the CompletionField.
+    """
+    return fields.TextField(
         fields={
             'raw': fields.KeywordField(),
             'suggest': fields.CompletionField(),

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -286,7 +286,7 @@ class CaseDocumentViewSet(BaseDocumentViewSet):
     # Define search fields
     simple_query_string_search_fields = (
         'name',
-        'name_abbreviation.suggest',
+        'name_abbreviation',
         'jurisdiction.name_long',
         'court.name',
         # these are included in head_matter or text:

--- a/capstone/test_data/test_fixtures/factories.py
+++ b/capstone/test_data/test_fixtures/factories.py
@@ -302,7 +302,8 @@ class CaseFactory(factory.DjangoModelFactory):
     class Meta:
         model = CaseMetadata
 
-    name = factory.Faker('sentence', nb_words=5)
+    name = factory.Sequence(lambda n: 'First Foo%s versus First Bar%s' % (n, n))
+    name_abbreviation = factory.Sequence(lambda n: 'Foo%s v. Bar%s' % (n, n))
     jurisdiction = factory.SubFactory(JurisdictionFactory)
     first_page = factory.Sequence(lambda n: str((n+1)*4))
     last_page = factory.LazyAttribute(lambda o: str(int(o.first_page)+4))
@@ -315,7 +316,6 @@ class CaseFactory(factory.DjangoModelFactory):
     structure = factory.RelatedFactory(CaseStructureFactory, 'metadata')
     citations = factory.RelatedFactory(CitationFactory, 'case')
     body_cache = factory.RelatedFactory(CaseBodyCacheFactory, 'metadata')
-    name_abbreviation = factory.Sequence(lambda n: 'Foo%s v. Bar%s' % (n, n))
 
     @post_generation
     def post(obj, create, extracted, **kwargs):


### PR DESCRIPTION
Allow for prefix search by searching `name_abbreviation` instead of `name_abbreviation.suggest`. Fixes #1345.

Use `TextField`, which is identical to and replaces `StringField`, for consistency.

Add tests for phrase, OR, and prefix search.