### PR TITLE
updated view api link in html case

### DIFF
--- a/capstone/capapi/templates/case.html
+++ b/capstone/capapi/templates/case.html
@@ -23,7 +23,11 @@
       {% endif %}
       <div class="full_cite">{{ citation_full }}</div>
       <div class="small">
-        <a href="{% api_url 'cases-detail' id %}">view API</a>
+        {% if request.user.is_authenticated or metadata.jurisdiction.whitelisted %}
+          <a href="{% api_url 'cases-detail' id %}?full_case=true">view API</a>
+        {% else %}
+          <a href="{% api_url 'cases-detail' id %}">view API</a>
+        {% endif %}
         {% if can_render_pdf %}
           • <a href="{{ db_case.get_pdf_url }}">view PDF</a>
         {% endif %}


### PR DESCRIPTION
In the HTML case viewer, if the user is logged in or the case is whitelisted, the view API link will append full_case=true to the link as requested in #1383 