### PR TITLE
Remove format=html, move logic to case browser view function

### DIFF
--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -157,3 +157,28 @@ def api_reverse(viewname, args=None, kwargs=None, request=None, format=None, **e
 
     return out
 
+
+def apply_replacements(item, replacements, prefix="[ ", suffix=" ]"):
+    """ filters out terms in 'item' with the {'original_text': and 'replacement_text' }
+    >>> apply_replacements("Hello, what's your name?", {'name': 'game', 'Hello': 'Wow'})
+    "[ Wow ], what's your [ game ]?"
+
+    >>> apply_replacements({"test": "Hello, what's your name?" }, {'name': 'game', 'Hello': 'Wow'})
+    {'test': "[ Wow ], what's your [ game ]?"}
+    """
+
+    if not replacements:
+        return item
+
+    if isinstance(item, str):
+        for replacement in replacements.items():
+            item = item.replace(replacement[0], prefix + replacement[1] + suffix)
+    elif isinstance(item, list):
+        item = [apply_replacements(inner_item, replacements) for inner_item in item]
+    elif isinstance(item, dict):
+        item = {name: apply_replacements(inner_item, replacements) for (name, inner_item) in item.items()}
+    elif not item:
+        return item
+    else:
+        raise Exception("Unexpected redaction format")
+    return item

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -5,7 +5,6 @@ from rest_framework.serializers import ListSerializer
 from django_elasticsearch_dsl_drf.serializers import DocumentSerializer
 
 from .models import SiteLimits
-from .renderers import HTMLRenderer, XMLRenderer
 from .documents import CaseDocument
 from capdb import models
 from capweb.helpers import reverse
@@ -271,10 +270,10 @@ class CaseDocumentSerializerWithCasebody(CaseAllowanceMixin, CaseDocumentSeriali
         # render case
         data = None
         if status == 'ok':
-            body_format = request.query_params.get('body_format', None)
-            if body_format == 'html' or type(request.accepted_renderer) == HTMLRenderer:
+            body_format = self.context.get('force_body_format') or request.query_params.get('body_format')
+            if body_format == 'html':
                 data = case.casebody_data['html']
-            elif body_format == 'xml' or type(request.accepted_renderer) == XMLRenderer:
+            elif body_format == 'xml':
                 data = case.casebody_data['xml']
             else:
                 try:

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -104,12 +104,6 @@ def test_unauthenticated_full_case(unrestricted_case, restricted_case, client, e
     assert 'error_' in casebody['status']
     assert not casebody['data']
 
-    response = client.get(case_url, {"full_case": "true", "format": "xml"})
-    check_response(response, content_type="application/xml", content_includes='error_auth_required')
-
-    response = client.get(case_url, {"full_case": "true", "format": "html"})
-    check_response(response, content_type="text/html", content_includes='You must be signed in to see the full case')
-
 
 @pytest.mark.django_db
 def test_authenticated_full_case_whitelisted(auth_user, auth_client, unrestricted_case, elasticsearch):
@@ -527,27 +521,6 @@ def test_ngrams_api(client, ngrammed_cases):
             'total': [{'year': '2000', 'count': [1, 9], 'doc_count': [1, 3]}]},
         "three don't": {
             'total': [{'year': '2000', 'count': [2, 9], 'doc_count': [2, 3]}]}}
-
-
-# RESPONSE FORMATS
-@pytest.mark.django_db
-@pytest.mark.parametrize("format, content_type", [
-    ('html', 'text/html'),
-    ('xml', 'application/xml'),
-    ('json', 'application/json'),
-])
-def test_formats(client, auth_client, restricted_case, format, content_type, elasticsearch):
-    # test format without api_key
-    response = client.get(api_reverse("cases-detail", args=[restricted_case.id]), {"format": format, "full_case": "true"})
-    check_response(response, content_type=content_type)
-    response_content = response.content.decode()
-    assert 'error' in response_content.lower()
-
-    # test full, authorized case
-    response = auth_client.get(api_reverse("cases-detail", args=[restricted_case.id]), {"format": format, "full_case": "true"})
-    body_cache = restricted_case.body_cache
-    expected_content = body_cache.html if format == 'html' else body_cache.xml if format == 'xml' else body_cache.json['opinions'][0]['text']
-    check_response(response, content_type=content_type, content_includes=expected_content)
 
 
 # API SPECIFICATION ENDPOINTS

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -891,7 +891,7 @@ class CaseMetadata(models.Model):
     def full_cite(self):
         return "%s, %s%s" % (
             self.name_abbreviation,
-            ", ".join(cite.cite for cite in Citation.sorted_by_type(self.citations.all())),
+            ", ".join(cite.cite for cite in Citation.sorted_by_type(self.citations.all()) if cite.type != 'vendor'),
             " (%s)" % self.decision_date.year if self.decision_date else ""
         )
 
@@ -966,7 +966,7 @@ class CaseMetadata(models.Model):
         return url
 
     def get_full_frontend_url(self):
-        return reverse('cite_home') + self.frontend_url
+        return reverse('cite_home').rstrip('/') + self.frontend_url
 
     def get_pdf_url(self):
         pdf_name = re.sub(r'[\\/:*?"<>|]', '_', self.full_cite()) + ".pdf"

--- a/capstone/capweb/templates/api.md
+++ b/capstone/capweb/templates/api.md
@@ -102,14 +102,6 @@ represented by a JSON object which includes various pieces of metadata, and the 
 [individual case endpoint](#endpoint-case), the `casebody` parameter returns JSON structured plain text, but you can 
 change that to either HTML or XML by setting the `body_format` query parameter to either `html` or `xml`.
   
-In the [individual case endpoint](#endpoint-case), you can alternately pass `html` or `xml` to the `format` parameter to
-dispense with the JSON container and return only the HTML or XML formatted case. The HTML returned using the `format` 
-parameter is the same as the HTML returned in the JSON container with `body_format` set to `html`. The XML output is
-significantly more verbose&mdash; It includes METS, PREMIS and structural metadata.
-  
-Do not set both `format` and `body_format` in the same query, and always use them with the `full_case` parameter set to 
-`true`. Using the `format` parameter with the [case browse/search results endpoint](#endpoint-cases) will have no effect.
-  
 This is what you can expect from different format specifications using the `body_format` parameter.
 
 
@@ -163,13 +155,12 @@ HTML Format
 
 [{% api_url "cases-list" %}?jurisdiction=ill&full_case=true&body_format=html]({% api_url "cases-list" %}?jurisdiction=ill&full_case=true&body_format=html)
 {: class="example-link mt-0" }
-      
+
 The HTML format is best if you want to show readable, formatted caselaw to humans. It represents a best-effort attempt 
 to transform our XML-formatted data to semantic HTML ready for CSS formatting of your choice. Example response data:
-      
+
 `"data": "<section class=\"casebody\" data-firstpage=\"538\" data-lastpage=\"543\"> ..."`
 {: class="code-block" }
-
 
 
 {# ====> PAGINATION <==== #}
@@ -324,29 +315,6 @@ Retrieve a single case by ID
 
 This example uses the [single case](#endpoint-case) endpoint, and will retrieve the metadata for a single 
 case.
-
-Modification with Parameters:
-{: class="list-header mb-2" }
-
-* **Standalone HTML-formatted Case**
-{: class="list-group-item" add_list_class="parameter-list" }
-    * [{% api_url "cases-detail" case_id %}?full_case=true&format=html]({% api_url "cases-detail" case_id %}?full_case=true&format=html)
-    {: add_list_class="example-mod-url" }
-    * This will return a lightly styled, standalone HTML representation of the case with no accompanying metadata.
-    {: add_list_class="example-mod-description" }
-* **Plain Text Case in JSON container with metadata**
-{: class="list-group-item" add_list_class="parameter-list" }
-    * [{% api_url "cases-detail" case_id %}]({% api_url "cases-detail" case_id %})
-    {: add_list_class="example-mod-url" }
-    * This will return a lightly styled, standalone HTML representation of the case with no accompanying metadata.
-    {: add_list_class="example-mod-description" }
-* **Raw original XML document, with METS data**
-{: class="list-group-item" add_list_class="parameter-list" }
-    * [{% api_url "cases-detail" case_id %}?full_case=true&body_format=xml]({% api_url "cases-detail" case_id %}?full_case=true&body_format=xml)
-    {: add_list_class="example-mod-url" }
-    * To get the document by itself, without the JSON enclosure and metadata, use the `format` parameter. Set it to HTML
-     and get a display-ready, standalone HTML document.
-    {: add_list_class="example-mod-description" }
 
 
 {# ====> filter cases <==== #}
@@ -527,19 +495,13 @@ Endpoint Parameters:
 {: class="list-group-item" add_list_class="parameter-list" }
     * `true` or `false`
     {: class="param-data-type" }
-    * When set to `true`, this parameter loads the case body. It is required for setting both `body_format` and `format`.
+    * When set to `true`, this parameter loads the case body. It is required for setting `body_format`.
     {: class="param-description" }
 * `body_format`{: class="parameter-name" }
 {: class="list-group-item" add_list_class="parameter-list" }
     * `html` or `xml`
     {: class="param-data-type" }
     * This will return a JSON enclosure with metadata, and a field containing the case in XML or HTML.
-    {: class="param-description" }
-* `format`{: class="parameter-name" }
-{: class="list-group-item" add_list_class="parameter-list" }
-    * `html` or `xml`
-    {: class="param-data-type" }
-    * This will return the case in HTML or its original XML with no JSON enclosure or metadata.
     {: class="param-description" }
 * `cursor`{: class="parameter-name" }
 {: class="list-group-item" add_list_class="parameter-list" }

--- a/capstone/capweb/templates/changelog.md
+++ b/capstone/capweb/templates/changelog.md
@@ -10,6 +10,15 @@ row_style: bg-tan
 extra_head: {% stylesheet 'docs' %}
 
 <!-- UNRELEASED
+**API:**
+
+* Cases Endpoint:
+    * Removed the `format=html` and `format=xml` parameters, which previously caused the case detail endpoint to return
+      either HTML or XML instead of JSON. API will always return JSON, with case body format still
+      controllable via `body_format`. Requests for `format=html` will redirect to the frontend case browser, which
+      shows identical contents to what `format=html` used to return.
+-->
+
 # January 24, 2020
 
 **API:**
@@ -19,7 +28,6 @@ extra_head: {% stylesheet 'docs' %}
 * Search
     * Default sort for full-text search is now relevance, rather than decision date.
     * Added Sorting field to case endpoint searches. You can now sort by decision date, and relevance.
--->
 
 # January 19, 2020
 

--- a/capstone/cite/templates/cite/case.html
+++ b/capstone/cite/templates/cite/case.html
@@ -7,7 +7,8 @@
 {% load capweb_static %}
 
 {% block base_css %}{% stylesheet 'case' %}{% endblock %}
-{% block title %}{{ citation_full }}{% endblock %}
+{% block title %}{{ citation_full|striptags }}{% endblock %}
+{% block meta_description %}Full text of {{ citation_full|striptags }} from the Caselaw Access Project.{% endblock %}
 
 {% block content %}
   <div class="case-container header-margin">
@@ -21,38 +22,34 @@
           to use our API or apply for unlimited research scholar access.
         </div>
       {% endif %}
-      <div class="full_cite">{{ citation_full }}</div>
+      <div class="full_cite">{{ citation_full|safe }}</div>
       <div class="small">
-        {% if request.user.is_authenticated or metadata.jurisdiction.whitelisted %}
-          <a href="{% api_url 'cases-detail' id %}?full_case=true">view API</a>
-        {% else %}
-          <a href="{% api_url 'cases-detail' id %}">view API</a>
-        {% endif %}
+        <a href="{% api_url 'cases-detail' db_case.id %}{% if request.user.is_authenticated or es_case.jurisdiction.whitelisted %}?full_case=true{% endif %}">view API</a>
         {% if can_render_pdf %}
           • <a href="{{ db_case.get_pdf_url }}">view PDF</a>
         {% endif %}
         {% if request.user.is_staff %}
-          • <a href="{% url 'admin:capdb_casemetadata_change' id %}">Django admin</a>
+          • <a href="{% url 'admin:capdb_casemetadata_change' db_case.id %}">Django admin</a>
         {% endif %}
       </div>
       <div class="court">
-        {{ metadata.court.name }}
+        {{ es_case.court.name }}
       </div>
       <h4 class="case-name">
-        {{ metadata.name_with_html_markup|safe }}
+        {{ db_case.name|safe }} {# safe because elisions may have been inserted #}
       </h4>
       <div class="citations">
-        {{ metadata.citations }}
+        {{ citations }}
       </div>
       <div class="docket-number">
-        {{ metadata.docket_number }}
+        {{ db_case.docket_number }}
       </div>
       <div class="decision_date">
-        {{ metadata.decision_date }}
+        {{ db_case.decision_date }}
       </div>
     </div>
 
-    {% if reason == 'error_auth_required' %}
+    {% if status == 'error_auth_required' %}
       <div class="name">
         <div class="alert-warning text-center">
           <h6 class="case-viewing-error">
@@ -60,24 +57,9 @@
           </h6>
         </div>
       </div>
-    {% elif reason == 'full_case_param_missing' %}
-      <section class="name text-center">
-        <div class="alert-warning text-center">
-          <h6 class="case-viewing-error">
-            Full case parameter is missing in HTML request.</h6>
-        </div>
-        <p>
-          To retrieve the full case body, you must specify <span style='font-family: monospace; font-style: normal;'>full_case=true</span>
-          in the URL.
-        </p>
-        <p>If you only want metadata you must specify
-          <span style='font-family: monospace; font-style: normal;'>format=json</span>
-          in the URL.</p>
-        <p>We only serve standalone metadata in JSON format.")</p>
-      </section>
-    {% elif reason == 'other' %}
+    {% elif status != 'ok' %}
       <div class="alert-warning text-center">
-        <h6 class="case-viewing-error">Could not load case body: {{ message }}</h6>
+        <h6 class="case-viewing-error">Could not load case body: {{ status }}</h6>
       </div>
     {% else %}
       {{ case_html|safe }}
@@ -111,10 +93,10 @@
   "@type": "Article",
   "mainEntityOfPage": {
     "@type": "WebPage",
-    "@id":"{{ frontend_url }}"
+    "@id":"{{ db_case.get_full_frontend_url }}"
   },
-  "headline": "{{ metadata.name_abbreviation }}",
-  {% if not metadata.jurisdiction.whitelisted %}
+  "headline": "{{ db_case.name_abbreviation|striptags }}",
+  {% if not es_case.jurisdiction.whitelisted %}
   "hasPart": {
     "@type": "WebPageElement",
     "isAccessibleForFree": "False",
@@ -123,10 +105,10 @@
   {% endif %}
   "author": {
     "@type": "Organization",
-    "name": "{{ metadata.court.name }}"
+    "name": "{{ es_case.court.name }}"
     },
   "genre": "Law",
-  "keywords": "{{ metadata.citations }}, {{ metadata.name_abbreviation }}",
+  "keywords": "{{ citations }}, {{ db_case.name_abbreviation|striptags }}",
   "publisher": {
     "@type": "Organization",
     "name": "Harvard Law School Library Innovation Lab",
@@ -138,10 +120,10 @@
     }
   },
    "image": "{% capweb_static "img/og_image/api.jpg" %}",
-   "datePublished": "{{ metadata.decision_date }}",
+   "datePublished": "{{ db_case.decision_date }}",
    "dateModified": "2018-10-29",
-   "dateCreated": "{{ metadata.decision_date }}",
-   "description": "{{ metadata.name }}"
+   "dateCreated": "{{ db_case.decision_date }}",
+   "description": "{{ db_case.name|striptags }}"
  }
 
 

--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -20,9 +20,9 @@ from natsort import natsorted
 from capapi import serializers
 from capapi.documents import CaseDocument
 from capapi.authentication import SessionAuthentication
-from capapi.renderers import HTMLRenderer
-from capdb.models import Reporter, VolumeMetadata, CaseMetadata
-from capweb import helpers
+from capapi.resources import apply_replacements
+from capdb.models import Reporter, VolumeMetadata, CaseMetadata, Citation
+from capweb.helpers import reverse, is_google_bot
 from cite.helpers import geolocate
 from config.logging import logger
 
@@ -85,7 +85,7 @@ def series(request, series_slug):
     # redirect if series slug is in the wrong format
 
     if slugify(series_slug) != series_slug:
-        return HttpResponseRedirect(helpers.reverse('series', args=[slugify(series_slug)], host='cite'))
+        return HttpResponseRedirect(reverse('series', args=[slugify(series_slug)], host='cite'))
     reporters = list(Reporter.objects
         .filter(short_name_slug=series_slug)
         .exclude(start_year=None)
@@ -104,7 +104,7 @@ def volume(request, series_slug, volume_number_slug):
     # redirect if series slug or volume number slug is in the wrong format
 
     if slugify(series_slug) != series_slug or slugify(volume_number_slug) != volume_number_slug:
-        return HttpResponseRedirect(helpers.reverse('volume', args=[slugify(series_slug), slugify(volume_number_slug)], host='cite'))
+        return HttpResponseRedirect(reverse('volume', args=[slugify(series_slug), slugify(volume_number_slug)], host='cite'))
 
     cases_query = CaseDocument.search()\
         .filter("term", volume__volume_number_slug=volume_number_slug)\
@@ -156,20 +156,16 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
 
     # redirect if series slug or volume number slug is in the wrong format
     if not pdf and (slugify(series_slug) != series_slug or slugify(volume_number_slug) != volume_number_slug):
-        if case_id:
-            return HttpResponseRedirect(helpers.reverse('citation',
-                                                    args=[slugify(series_slug), slugify(volume_number_slug), page_number, case_id],
-                                                    host='cite'))
-        else:
-            return HttpResponseRedirect(helpers.reverse('citation',
-                                                        args=[slugify(series_slug), slugify(volume_number_slug), page_number],
-                                                        host='cite'))
+        return HttpResponseRedirect(reverse(
+            'citation',
+            args=[slugify(series_slug), slugify(volume_number_slug), page_number] + ([case_id] if case_id else []),
+            host='cite'))
 
     ### try to look up citation
 
     if case_id:
         try:
-            cases = [ CaseDocument.get(id=case_id) ]
+            case = CaseDocument.get(id=case_id)
         except NotFoundError:
             raise Http404
     else:
@@ -190,9 +186,7 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
                 "volume_number_slug": volume_number_slug,
                 "page_number": page_number,
             })
-
-    ### handle case where we found a unique case with that citation
-    case = cases[0]
+        case = cases[0]
 
     # handle whitelisted case or logged-in user
     if case.jurisdiction.whitelisted or request.user.is_authenticated:
@@ -218,27 +212,24 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
                 serializer = serializers.CaseDocumentSerializerWithCasebody
 
     # handle google crawler
-    elif helpers.is_google_bot(request):
+    elif is_google_bot(request):
         serializer = serializers.NoLoginCaseDocumentSerializer
 
     # if non-whitelisted case, not logged in, and no cookies set up, redirect to ?set_cookie=1
     else:
         request.session['case_allowance_remaining'] = settings.API_CASE_DAILY_ALLOWANCE
         request.session['case_allowance_last_updated'] = time.time()
-        return HttpResponseRedirect('%s?%s' % (helpers.reverse('set_cookie', host='cite'), urlencode({'next': request.get_full_path()})))
+        return HttpResponseRedirect('%s?%s' % (reverse('set_cookie', host='cite'), urlencode({'next': request.get_full_path()})))
 
     # render case using API serializer
     api_request = Request(request, authenticators=[SessionAuthentication()])
-    api_request.accepted_renderer = HTMLRenderer()
-    serialized = serializer(case, context={'request': api_request})
+    serialized = serializer(case, context={'request': api_request, 'force_body_format': 'html'})
     serialized_data = serialized.data
-    data = serialized_data['casebody']['data']
-    case_name_with_markup = serialized_data['name']
 
     # handle pdf output --
     # wait until here to do this so serializer() can apply case quotas
     db_case = db_case or CaseMetadata.objects.select_related('volume').prefetch_related('citations').get(pk=case.id)
-    can_render_pdf = db_case.volume.pdf_file and not db_case.no_index_redacted and settings.CASE_PDF_FEATURE
+    can_render_pdf = db_case.volume.pdf_file and not db_case.no_index_redacted and settings.CASE_PDF_FEATURE and serialized_data['casebody']['status'] == 'ok'
     if pdf:
         if serialized_data['casebody']['status'] != 'ok':
             return HttpResponseRedirect(db_case.get_full_frontend_url())
@@ -247,69 +238,37 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
         return HttpResponse(db_case.get_pdf(), content_type="application/pdf")
 
     # HTML output
-    context = {'request': api_request, 'meta_tags': [], 'can_render_pdf': can_render_pdf, 'db_case': db_case}
 
+    # meta tags
+    meta_tags = []
     if not case.jurisdiction.whitelisted:
         # blacklisted cases shouldn't show cached version in google search results
-        context['meta_tags'].append({"name": "googlebot", "content": "noarchive"})
+        meta_tags.append({"name": "googlebot", "content": "noarchive"})
+    if db_case.no_index:
+        meta_tags.append({"name": "robots", "content": "noindex"})
 
-    # This should probably change
-    if hasattr(case, 'no_index'):
-        if case.no_index:
-            context['meta_tags'].append({"name": "robots", "content": "noindex"})
-    else:
-        if db_case.no_index:
-            context['meta_tags'].append({"name": "robots", "content": "noindex"})
+    case_html = serialized_data['casebody']['data']
+    footer_message = db_case.custom_footer_message or ''
 
-    # insert redactions and elisions
-
+    # insert redactions
     if db_case.no_index_redacted:
-        redaction_count = 0
-        for redaction, val in db_case.no_index_redacted.items():
-            # redact from case body
-            data = re.sub(redaction, "<span class='redacted-text' data-redaction-id='%s'>%s</span>" %
-                          (redaction_count, val), data)
-            redaction_count += 1
+        case_html = apply_replacements(case_html, db_case.no_index_redacted)
+        db_case.name = apply_replacements(db_case.name, db_case.no_index_redacted)
+        db_case.name_abbreviation = apply_replacements(db_case.name_abbreviation, db_case.no_index_redacted)
+        footer_message += "Some text has been redacted. \n"
 
-            # redact from name
-            case_name_with_markup = re.sub(redaction, "[ %s ]" % val, case_name_with_markup)
-            serialized_data['name_abbreviation'] = re.sub(redaction, "[ %s ]" % val, serialized_data['name_abbreviation'])
-        # Also save as name for indexing
-        serialized_data['name'] = case_name_with_markup
-
-
-    elision_span = "<span class='elision-help-text' style='display: none'>hide</span><span class='elided-text' data-elision-reason='%s' role='button' tabindex='0' data-hidden-text='%s' data-elision-id='%s'>...</span>"
+    # insert elisions
     if db_case.no_index_elided:
-        elision_count = 0
-        for elision, val in db_case.no_index_elided.items():
+        elision_span = "<span class='elision-help-text' style='display: none'>hide</span>" \
+                       "<span class='elided-text' role='button' tabindex='0' data-hidden-text='%s'>%s</span>"
+        replacements = {k: elision_span % (k, v) for k, v in db_case.no_index_elided.items()}
+        case_html = apply_replacements(case_html, replacements, prefix="", suffix="")
+        db_case.name = apply_replacements(db_case.name, replacements, prefix="", suffix="")
+        db_case.name_abbreviation = apply_replacements(db_case.name_abbreviation, replacements, prefix="", suffix="")
+        footer_message += "Some text has been hidden for privacy from automated systems, but can be revealed by clicking the elided text. \n"
 
-            # elide from case body
-            data = re.sub(elision, elision_span % (val, elision, elision_count), data)
-
-            elision_count += 1
-
-            # elide from name with html markup
-            case_name_with_markup = re.sub(elision, elision_span % (val, elision, elision_count), case_name_with_markup)
-
-            # add elisions without html markup to case name and name_abbreviation for indexing
-            serialized_data['name'] = re.sub(elision, "...", serialized_data['name'])
-            serialized_data['name_abbreviation'] = re.sub(elision, "...", serialized_data['name_abbreviation'])
-
-    serialized_data['name_with_html_markup'] = case_name_with_markup
-
-    # Add a custom footer message if redactions or elisions exist but no text is provided
-    if not db_case.custom_footer_message and (db_case.no_index_redacted or db_case.no_index_elided):
-        db_case.custom_footer_message = ''
-        if db_case.no_index_redacted:
-            db_case.custom_footer_message += "Some text has been redacted by request of participating parties. \n"
-        if db_case.no_index_elided:
-            db_case.custom_footer_message += "Some text has been elided by request of participating parties. \n"
-
-    if db_case.custom_footer_message:
-        custom_footer_message = re.sub(r'\n', '<br/>', db_case.custom_footer_message)
-        data += "<hr/><footer class='custom-case-footer'>%s</footer>" % custom_footer_message
-
-    serialized_data['casebody']['data'] = data
+    if footer_message:
+        case_html += "<hr/><footer class='custom-case-footer'>%s</footer>" % footer_message.replace('\n', '<br>')
 
     if settings.GEOLOCATION_FEATURE and request.META.get('HTTP_X_FORWARDED_FOR'):
         # Trust x-forwarded-for in this case because we don't mind being lied to, and would rather show accurate
@@ -323,8 +282,16 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
         except Exception as e:
             logger.warning("Unable to geolocate %s: %s" % (request.user.ip_address, e))
 
-    rendered = HTMLRenderer().render(serialized_data, renderer_context=context)
-    return HttpResponse(rendered)
+    return render(request, 'cite/case.html', {
+        'meta_tags': meta_tags,
+        'can_render_pdf': can_render_pdf,
+        'db_case': db_case,
+        'es_case': serialized_data,
+        'status': serialized_data['casebody']['status'],
+        'case_html': case_html,
+        'citation_full': db_case.full_cite(),
+        'citations': ", ".join(c.cite for c in Citation.sorted_by_type(db_case.citations.all())),
+    })
 
 
 def set_cookie(request):
@@ -333,7 +300,7 @@ def set_cookie(request):
         /set_cookie/?no_js=1  -- ask user to click a button to set a 'not_a_bot=1' cookie
     """
     # user is actually a google bot
-    if helpers.is_google_bot(request):
+    if is_google_bot(request):
         return safe_redirect(request)
 
     # user already had a not_a_bot cookie and just needed a session cookie,


### PR DESCRIPTION
* Remove `format=html` from cases API endpoint and docs
* Move and simplify logic from HTMLRenderer to case browser's view function
* Make redaction in CaseDocument apply to name_abbreviation, to harmonize with current frontend redaction
* Make frontend redaction use same helper function as CaseDocument