### PR TITLE
Case API endpoint updates

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -1,7 +1,12 @@
+import re
 from functools import lru_cache
 import rest_framework_filters as filters
 
 from django.utils.functional import SimpleLazyObject
+from django_elasticsearch_dsl_drf.filter_backends import FilteringFilterBackend, SimpleQueryStringSearchFilterBackend, \
+    OrderingFilterBackend
+from rest_framework.exceptions import ParseError
+from rest_framework_filters.backends import RestFrameworkFilterBackend
 
 from capdb import models
 from user_data.models import UserHistory
@@ -146,3 +151,109 @@ class UserHistoryFilter(filters.FilterSet):
     class Meta:
         model = UserHistory
         fields = ['case_id', 'date']
+
+
+class CaseFilter(filters.FilterSet):
+    """
+        This is only used for HTML display; it is rendered by CaseFilterBackend, which applies filters to the ES query.
+    """
+    search = filters.CharFilter(
+        label='Full-Text Search',
+        help_text='Search for words separated by spaces. All words are required in results. Words less than 3 characters are ignored.')
+    cite = filters.CharFilter(label='Citation')
+    name_abbreviation = filters.CharFilter(label='Name Abbreviation (contains)')
+    jurisdiction = filters.ChoiceFilter(choices=jur_choices)
+    reporter = filters.ChoiceFilter(choices=reporter_choices, label='Reporter Series')
+    decision_date_min = filters.CharFilter(label='Earliest Decision Date (Format YYYY-MM-DD)')
+    decision_date_max = filters.CharFilter(label='Latest Decision Date (Format YYYY-MM-DD)')
+    docket_number = filters.CharFilter(label='Docket Number (contains)')
+    court = filters.ChoiceFilter(choices=court_choices)
+    court_id = filters.NumberFilter(label='Court ID')
+    full_case = filters.ChoiceFilter(
+        label='Include full case text or just metadata?',
+        choices=(('', 'Just metadata (default)'), ('true', 'Full case text')),
+    )
+    body_format = filters.ChoiceFilter(
+        label='Format for case text (applies only if including case text)',
+        choices=(('text', 'text only (default)'), ('html', 'HTML'), ('xml', 'XML'), ('tokens', 'debug tokens')),
+    )
+    ordering = filters.ChoiceFilter(
+        label='Sort order',
+        choices=(
+            ('', 'Relevance, then decision date (default)'),
+            ('decision_date', 'Decision date'),
+            ('-decision_date', 'Reverse decision date'),
+            ('name_abbreviation', 'Name abbreviation'),
+            ('-name_abbreviation', 'Reverse name abbreviation'),
+            ('id', 'id'),
+            ('-id', 'Reverse id'),
+        ),
+    )
+    page_size = filters.NumberFilter(label='Results per page (1 to 10,000; default 100)')
+
+
+class CaseFilterBackend(FilteringFilterBackend, RestFrameworkFilterBackend):
+    def get_filter_query_params(self, request, view):
+        def lc_values(values):
+            return [value.lower() for value in values if isinstance(value, str)]
+
+        def tokenize(filter_values):
+            # takes each entry in filter_values and splits them on non alphanumeric characters into separate entries
+            return [s for current_term in filter_values for s in re.split(r'[^a-zA-Z0-9]+', current_term) if s]
+
+        query_params = super().get_filter_query_params(request, view)
+
+        for suffix in ['min', 'max']:
+            date_param = 'decision_date_{}'.format(suffix)
+            if date_param in query_params:
+                if not re.match(r'\d\d\d\d-\d\d-\d\d', query_params[date_param]['values'][0]):
+                    raise ParseError('Invalid date format: must be YYYY-MM-DD')
+
+        if 'cite' in query_params:
+            query_params['cite']['values'] = [models.Citation.normalize_cite(cite) for cite in
+                                              lc_values(query_params['cite']['values']) ]
+
+        if 'court_id' in query_params:
+            query_params['court_id']['values'] = [ court_id for court_id
+                                                   in query_params['court_id']['values'] if court_id.isdigit() ]
+            if len(query_params['court_id']['values']) < 1:
+                del query_params['court_id']
+
+        if 'name' in query_params:
+            query_params['name']['values'] = lc_values(tokenize(query_params['name']['values']))
+            query_params['name']['lookup'] = 'in'
+
+        if 'name_abbreviation' in query_params:
+            query_params['name_abbreviation']['values'] = lc_values(tokenize(query_params['name_abbreviation']['values']))
+            query_params['name_abbreviation']['lookup'] = 'in'
+
+        if 'court' in query_params:
+            query_params['court']['values'] = lc_values(query_params['court']['values'])
+
+        if 'jurisdiction' in query_params:
+            query_params['jurisdiction']['values'] = lc_values(query_params['jurisdiction']['values'])
+
+        if 'docket_number' in query_params:
+            query_params['docket_number']['values'] = lc_values(tokenize(query_params['docket_number']['values']))
+
+        return query_params
+
+
+class CAPFTSFilter(SimpleQueryStringSearchFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        # ignores empty searches
+        if 'search' in request.GET and request.GET['search'] is not '':
+            queryset = super().filter_queryset(request, queryset, view)
+        return queryset
+
+    search_param = 'search'
+
+
+class CAPOrderingFilterBackend(OrderingFilterBackend):
+    @classmethod
+    def transform_ordering_params(cls, ordering_params, ordering_fields):
+        # changes relevance to -relevance (and vice versa) to avoid the rather unintuitive reverse-relevance sort
+        # when sort=relevance
+        return super().transform_ordering_params(
+            ['relevance' if sort == '-relevance' else '-relevance' if sort == 'relevance' else sort for sort in ordering_params],
+            ordering_fields)

--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -142,10 +142,9 @@ class CapUser(PermissionsMixin, AbstractBaseUser):
             raise PermissionDenied
 
     def reset_api_key(self):
-        if self.get_api_key() and self.email_verified:
-            Token.objects.get(user=self).delete()
+        if self.email_verified:
+            Token.objects.filter(user=self).delete()
             Token.objects.create(user=self)
-            self.save()
         else:
             raise PermissionDenied
 

--- a/capstone/capapi/pagination.py
+++ b/capstone/capapi/pagination.py
@@ -2,6 +2,8 @@ import json
 import warnings
 from base64 import b64decode, b64encode
 from collections import OrderedDict
+
+from django.conf import settings
 from django_elasticsearch_dsl_drf.versions import ELASTICSEARCH_GTE_6_0
 
 from rest_framework.exceptions import NotFound
@@ -247,5 +249,5 @@ class CapESCursorPagination(ESCursorPagination):
         CAP-specific customization of elasticsearch search_after pagination.
     """
     page_size_query_param = 'page_size'
-    max_page_size = 100
+    max_page_size = settings.MAX_PAGE_SIZE
     fallback_sort_field = "id"

--- a/capstone/capapi/templates/rest_framework/api.html
+++ b/capstone/capapi/templates/rest_framework/api.html
@@ -277,6 +277,11 @@
   <script>
     $(document).ready(function () {
       $('form').ajaxForm();
+
+      // avoid submitting empty filter fields
+      $('#filtersModal form').submit(function() {
+        $(this).find('input,select').filter(function(){return $(this).val() === ''}).attr('name', '');
+      });
     });
   </script>
 {% endblock %}

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -3,21 +3,20 @@ import re
 import urllib
 from collections import OrderedDict, defaultdict
 from pathlib import Path
-from rest_framework import viewsets, renderers, mixins, exceptions
+
+from rest_framework import viewsets, renderers, mixins
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
 from django_elasticsearch_dsl_drf.constants import LOOKUP_FILTER_RANGE, LOOKUP_QUERY_IN, LOOKUP_QUERY_GT, \
     LOOKUP_QUERY_GTE, LOOKUP_QUERY_LT, LOOKUP_QUERY_LTE
-from django_elasticsearch_dsl_drf.filter_backends import FilteringFilterBackend, IdsFilterBackend, \
-    OrderingFilterBackend, DefaultOrderingFilterBackend, SimpleQueryStringSearchFilterBackend, HighlightBackend
+from django_elasticsearch_dsl_drf.filter_backends import IdsFilterBackend, DefaultOrderingFilterBackend, HighlightBackend
 from django_elasticsearch_dsl_drf.viewsets import BaseDocumentViewSet
-
 from django.http import HttpResponseRedirect, FileResponse
-from django.template import loader
 
 from capapi import serializers, filters, permissions, renderers as capapi_renderers
 from capapi.documents import CaseDocument, RawSearch
+from capapi.filters import CAPFTSFilter, CAPOrderingFilterBackend, CaseFilterBackend
 from capapi.pagination import CapESCursorPagination
 from capapi.serializers import CaseDocumentSerializer
 from capapi.middleware import add_cache_header
@@ -64,196 +63,6 @@ class CitationViewSet(BaseViewSet):
     queryset = models.Citation.objects.order_by('pk')
 
 
-class CAPFiltering(FilteringFilterBackend):
-    def get_filter_query_params(self, request, view):
-        def lc_values(values):
-            return [value.lower() for value in values if isinstance(value, str)]
-
-        def tokenize(filter_values):
-            # takes each entry in filter_values and splits them on non alphanumeric characters into separate entries
-            return [s for current_term in filter_values for s in re.split(r'[^a-zA-Z0-9]+', current_term) if s]
-
-        query_params = super().get_filter_query_params(request, view)
-
-        for suffix in ['min', 'max']:
-            date_param = 'decision_date_{}'.format(suffix)
-            if date_param in query_params:
-                if not re.match(r'\d\d\d\d-\d\d-\d\d', query_params[date_param]['values'][0]):
-                    raise exceptions.ParseError('Invalid date format: must be YYYY-MM-DD')
-
-        if 'cite' in query_params:
-            query_params['cite']['values'] = [Citation.normalize_cite(cite) for cite in
-                                              lc_values(query_params['cite']['values']) ]
-
-        if 'court_id' in query_params:
-            query_params['court_id']['values'] = [ court_id for court_id
-                                                   in query_params['court_id']['values'] if court_id.isdigit() ]
-            if len(query_params['court_id']['values']) < 1:
-                del query_params['court_id']
-
-        if 'name' in query_params:
-            query_params['name']['values'] = lc_values(tokenize(query_params['name']['values']))
-            query_params['name']['lookup'] = 'in'
-
-        if 'name_abbreviation' in query_params:
-            query_params['name_abbreviation']['values'] = lc_values(tokenize(query_params['name_abbreviation']['values']))
-            query_params['name_abbreviation']['lookup'] = 'in'
-
-        if 'court' in query_params:
-            query_params['court']['values'] = lc_values(query_params['court']['values'])
-
-        if 'jurisdiction' in query_params:
-            query_params['jurisdiction']['values'] = lc_values(query_params['jurisdiction']['values'])
-
-        if 'docket_number' in query_params:
-            query_params['docket_number']['values'] = lc_values(tokenize(query_params['docket_number']['values']))
-
-        return query_params
-
-    def to_html(self, request, queryset, view):
-        """ This makes the html that goes inside the filters modal in the browsable API. Returns HTML string."""
-
-        query_params = self.get_filter_query_params(request, view)
-        filter_values = { param_name: param_data['values'] for param_name, param_data in query_params.items() }
-
-        # this is for the content of the dropdown menus for jurisdiction, court, and reporter
-        options = {}
-        options['jurisdiction'] = [ {
-                'value': jurisdiction[0],
-                'label': jurisdiction[1],
-                'selected': 'selected' if 'jurisdiction' in filter_values
-                                          and jurisdiction[0] in filter_values['jurisdiction'] else ''
-                }
-            for jurisdiction in filters.jur_choices]
-
-        options['court'] = [ {
-                'value': court[0],
-                'label': court[1],
-                'selected': 'selected' if 'court' in filter_values and court[0] in filter_values['court'] else ''
-                }
-            for court in filters.court_choices]
-        options['reporter'] = [{
-            'value': str(reporter[0]),
-            'label': reporter[1],
-            'selected': 'selected' if 'reporter' in filter_values
-                                      and str(reporter[0]) in filter_values['reporter'] else ''
-            }
-            for reporter in filters.reporter_choices]
-
-        # For fields that look better with custom labels
-        labels = {
-                  'reporter': 'Reporter Series',
-                  'decision_date_min': 'Earliest Decision Date (Format YYYY-MM-DD)',
-                  'decision_date_max': 'Latest Decision Date (Format YYYY-MM-DD)',
-                  'cite': 'Citation',
-                  'docket_number': 'Docket Number (contains)',
-                  'id': 'ID',
-                  'court_id': 'Court ID'
-                  }
-
-        # this creates a dictionary that holds each field and data about it
-        fields = OrderedDict()
-        fields['cite']= {}
-        fields['name_abbreviation']= {}
-        fields['jurisdiction']= {}
-        fields['reporter']= {}
-        fields['decision_date_min']= {}
-        fields['decision_date_max']= {}
-        fields['docket_number']= {}
-        fields['court']= {}
-        fields['court_id']= {}
-        fields['search']= {}
-        fields['full_case']= {}
-        fields['body_format']= {}
-
-        for f in view.filter_fields:
-            if f not in fields:
-                if f == 'decision_date' or f == 'id' or f == 'name':
-                    continue
-                fields[f] = {}
-
-            fields[f]['id'] = f
-
-            if f.endswith('id'):
-                fields[f]['type'] = 'number'
-                fields[f]['step'] = 'any'
-            elif f not in options:
-                fields[f]['type'] = 'text'
-
-            if f in options:
-                fields[f]['options'] = options[f]
-            else:
-                fields[f]['value'] = ''
-
-            if f in filter_values:
-                fields[f]['value'] = ' '.join(filter_values[f])
-
-            fields[f]['label'] = labels[f] if f in labels else f.replace('_', ' ').title()
-
-        # full_case and body_format aren't part of the filters so I add them separately
-        full_case = True if 'full_case' in request.GET and request.GET['full_case'] != '' else False
-        fields['full_case'] = {
-            'id': 'full_case',
-            'label': 'Include full case text or just metadata?',
-            'options': [
-                {'value': 'true',
-                 'label': 'Full case text',
-                 'selected': 'selected' if  full_case else '',
-                 },
-                {'value': '',
-                 'label': 'Just metadata (default)',
-                 'selected': '' if  full_case else 'selected',
-                 }]
-        }
-
-        body_format = request.GET['body_format'] if 'body_format' in request.GET else ''
-        fields['body_format'] = {
-            'id': 'body_format',
-            'label': 'Format for case text (applies only if including case text):',
-            'options': [
-                {'value': 'text',
-                 'label': 'Text Only (default)',
-                 'selected': 'selected' if body_format == 'text' or body_format == '' else '',
-                 },
-                {'value': 'html',
-                 'label': 'HTML',
-                 'selected': 'selected' if body_format == 'html' else '',
-                 },
-                {'value': 'xml',
-                 'label': 'XML',
-                 'selected': 'selected' if body_format == 'xml' else '',
-                 }]
-        }
-
-        # search is also separate from a filter, so it needs to be added separately
-        fields['search'] = {
-            'id': 'search',
-            'value': request.query_params.get('search', ''),
-            'label': 'Full-Text Search',
-            'type': 'search'
-        }
-
-        template = loader.get_template('rest_framework/filters/cases.html')
-        return template.render({'fields': fields })
-
-class CAPFTSFilter(SimpleQueryStringSearchFilterBackend):
-    def filter_queryset(self, request, queryset, view):
-        # ignores empty searches
-        if 'search' in request.GET and request.GET['search'] is not '':
-            queryset = super().filter_queryset(request, queryset, view)
-        return queryset
-
-    search_param = 'search'
-
-class CAPOrderingFilterBackend(OrderingFilterBackend):
-    @classmethod
-    def transform_ordering_params(cls, ordering_params, ordering_fields):
-        # changes relevance to -relevance (and vice versa) to avoid the rather unintuitive reverse-relevance sort
-        # when sort=relevance
-        return super(OrderingFilterBackend, cls).transform_ordering_params(
-            ['relevance' if sort == '-relevance' else '-relevance' if sort == 'relevance' else sort for sort in ordering_params],
-            ordering_fields)
-
 class CaseDocumentViewSet(BaseDocumentViewSet):
     """The CaseDocument view."""
 
@@ -268,6 +77,7 @@ class CaseDocumentViewSet(BaseDocumentViewSet):
     document = CaseDocument
     serializer_class = CaseDocumentSerializer
     pagination_class = CapESCursorPagination
+    filterset_class = filters.CaseFilter
 
     renderer_classes = (
         renderers.JSONRenderer,
@@ -278,7 +88,7 @@ class CaseDocumentViewSet(BaseDocumentViewSet):
 
     filter_backends = [
         CAPFTSFilter, # Facilitates FTS
-        CAPFiltering, # Facilitates Filtering (Filters)
+        CaseFilterBackend, # Facilitates Filtering (Filters)
         IdsFilterBackend, # Filtering based on IDs
         CAPOrderingFilterBackend, # Orders Document
         HighlightBackend, # for search preview

--- a/capstone/capweb/templates/api.md
+++ b/capstone/capweb/templates/api.md
@@ -75,13 +75,13 @@ __Example:__ With an API key of `abcd12345`, you would pass `Token abcd12345` to
 
 A curl command would look like this:
   
-`curl -H "Authorization: Token abcd12345" "{% api_url "cases-list" %}{{case_id}}/?full_case=true"`
+`curl -H "Authorization: Token abcd12345" "{% api_url "cases-list" %}{{case.id}}/?full_case=true"`
 {: class="code-block" }
 
 In a program, (python's request library in this example,) it would look something like this:
 
 `response = requests.get(
-    '{% api_url "cases-list" %}{{case_id}}/?full_case=true',
+    '{% api_url "cases-list" %}{{case.id}}/?full_case=true',
     headers={'Authorization': 'Token abcd12345'}
 )`
 {: class="code-block" }
@@ -310,7 +310,7 @@ comprehensive documentation about the URLs and their parameters.
 Retrieve a single case by ID
 {: class="topic-header" }
 
-[{% api_url "cases-detail" case_id %}]({% api_url "cases-detail" case_id %})
+[{% api_url "cases-detail" case.id %}]({% api_url "cases-detail" case.id %})
 {: class="example-link mt-0" }
 
 This example uses the [single case](#endpoint-case) endpoint, and will retrieve the metadata for a single 
@@ -321,11 +321,11 @@ case.
 Retrieve a list of cases using a metadata filter
 {: class="topic-header" }
 
-[{% api_url "cases-list" %}?cite={{ citation }}]({% api_url "cases-list" %}?cite={{ citation }})
+[{% api_url "cases-list" %}?cite={{ case.citations.0.cite }}]({% api_url "cases-list" %}?cite={{ case.citations.0.cite }})
 {: class="example-link mt-0" }
 
 This example uses the [cases](#endpoint-cases) endpoint, and will retrieve every case with the citation 
-{{ citation }}. 
+{{ case.citations.0.cite }}. 
 
 There are many parameters with which you can filter the cases result. Check the 
 [cases](#endpoint-cases) endpoint documentation for a complete list of the parameters, and what values they accept.
@@ -335,7 +335,7 @@ Modification with Parameters:
 
 * **Add a date range filter**
 {: class="list-group-item" add_list_class="parameter-list" }
-    * [{% api_url "cases-list" %}?cite={{ citation }}&decision_date_min=1900-12-30&decision_date_max=2000-12-30]({% api_url "cases-list" %}?cite={{ citation }}&decision_date_min=1900-12-30&decision_date_max=2000-12-30)
+    * [{% api_url "cases-list" %}?cite={{ case.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-12-30]({% api_url "cases-list" %}?cite={{ case.citations.0.cite }}&decision_date_min=1900-12-30&decision_date_max=2000-12-30)
     {: add_list_class="example-mod-url" }
     * You can combine any of these parameters to refine your search. Here, we have the same search as in the first 
     example, but will only receive results from within the specified dates.
@@ -483,7 +483,7 @@ Endpoint Parameters:
 Single Case Endpoint
 {: class="topic-header", id="endpoint-case" }
 
-[{% api_url "cases-detail" case_id %}]({% api_url "cases-detail" case_id %})
+[{% api_url "cases-detail" case.id %}]({% api_url "cases-detail" case.id %})
 {: class="endpoint-link" style="margin-top: 0px;" }
 
 Use this endpoint to retrieve a single case.

--- a/capstone/capweb/views.py
+++ b/capstone/capweb/views.py
@@ -166,12 +166,12 @@ def api(request):
     try:
         case = CaseDocument.get(id=settings.API_DOCS_CASE_ID)
     except NotFoundError:
-        case = CaseDocument.search().filter("term", jurisdiction__slug="ill").execute()[0]
+        try:
+            case = CaseDocument.search().execute()[0]
+        except NotFoundError:
+            case = None
 
-    markdown_doc = render_to_string("api.md", {
-        "citation": case.citations[0].cite,
-        "case_id": case.id,
-    }, request)
+    markdown_doc = render_to_string("api.md", {"case": case}, request)
 
     # render markdown document to html
     html, toc, meta = render_markdown(markdown_doc)

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -628,6 +628,7 @@ MAINTAIN_ELASTICSEARCH_INDEX = True  # whether to update index when changing cas
 ELASTICSEARCH_INDEXES={
     'cases_endpoint': 'cases',
 }
+MAX_PAGE_SIZE = 10000
 
 # for views decorated with @password_protected_page('some_key')
 PASSWORD_PROTECTED_PAGES = {

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -90,8 +90,8 @@ MIDDLEWARE = [
     # - WhiteNoiseMiddleware, because whitenoise already sets cache headers on static assets
     'capapi.middleware.cache_header_middleware',
 
+    'capapi.middleware.GZipJsonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    # custom CommonMiddleware for adding CORS header in API
     'capapi.middleware.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'capapi.middleware.AuthenticationMiddleware',

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -78,7 +78,7 @@ else:
                 'debug_toolbar',
             )
             MIDDLEWARE.insert(
-                MIDDLEWARE.index('django_hosts.middleware.HostsRequestMiddleware')+1,
+                MIDDLEWARE.index('django.contrib.sessions.middleware.SessionMiddleware'),
                 'debug_toolbar.middleware.DebugToolbarMiddleware',
             )
             DEBUG_TOOLBAR_CONFIG = {

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -267,6 +267,14 @@ def rebuild_search_index(force=False):
     populate_search_index()
 
 @task
+def update_search_index_settings():
+    """ Update settings on existing index, based on the case_index.settings() call in capapi.documents. """
+    from capapi.documents import case_index
+    # remove settings that cannot be changed on existing indexes
+    new_settings = {k:v for k, v in case_index._settings.items() if k not in ('number_of_shards')}
+    case_index.put_settings(body={"index": new_settings})
+
+@task
 def load_test_data():
     ingest_fixtures()
     total_sync_with_s3()


### PR DESCRIPTION
A few changes to the cases API endpoint:

* Try a configurable max page_size -- let's see if we can handle increasing the max to 10,000 instead of 100, now that rendering is faster. If you increase `MAX_PAGE_SIZE` with an existing ES index, you then have to run `fab update_search_index_settings`.
* Avoid submitting empty form fields on the API browser (fixes #1340).
* Gzip-compress our responses if we're returning JSON.
* Add page size and order options to the API viewer.