### PR TITLE
Add a new storage for PDF downloads

### DIFF
--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -428,6 +428,12 @@ STORAGES = {
             'location': os.path.join(BASE_DIR, 'downloads'),
             'base_url': 'http://case.test:8000/download/',
         }
+    },
+    'writeable_download_files_storage': {
+        'class': 'CapFileStorage',
+        'kwargs': {
+            'location': os.path.join(BASE_DIR, 'downloads'),
+        }
     }
 }
 


### PR DESCRIPTION
Because we're using a read-only overlay to expose downloadable files in production, this PR adds a storage for the fab task to write PDFs to; locally, this will be the same as `download_files_storage`, but in production should be set something like this:

    STORAGES['writeable_download_files_storage']['kwargs']['location'] = '/mnt/storage/beta'