### PR TITLE
Cite extraction tweaks

### DIFF
--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -22,7 +22,7 @@ from capapi.tasks import cache_query_count
 from capweb.helpers import reverse, statement_timeout, StatementTimeout
 from config.logging import logger
 
-cite_extracting_regex = "((?:\d\s?)+)\s+([0-9a-zA-Z][\s0-9a-zA-Z.']{0,40})\s+(\d+)"
+cite_extracting_regex = "([1-9]\d*(?: Suppl\.| 1/2)?)\s+([a-zA-Z][\s0-9a-zA-Z.']{0,40})\s+([1-9]\d*)"
 
 def create_zip_filename(case_list):
     ts = slugify(datetime.now().timestamp())

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1083,7 +1083,7 @@ class CaseMetadata(models.Model):
 
     def get_json_from_html(self, html):
         casebody_pq = PyQuery(html)
-        casebody_pq.remove('.page-label,.footnotemark,.bracketnum')  # remove page numbers and references from text/json
+        casebody_pq.remove('.page-label,.footnotemark,.bracketnum,.footnote > a')  # remove page numbers and footnote numbers from text/json
 
         # extract each opinion into a dictionary
         opinions = []

--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -1,35 +1,35 @@
-import re
 import pytest
 
 from django.utils.text import slugify
 
-from capdb.models import CaseMetadata, CaseImage, CaseBodyCache, CaseXML, fetch_relations, Court, EditLog
+from capdb.models import CaseMetadata, CaseImage, fetch_relations, Court, EditLog, CaseBodyCache
 from capdb.tasks import retrieve_images_from_cases
-from scripts.helpers import parse_xml
+from test_data.test_fixtures.helpers import xml_equal
 
 
 ### test our model helpers ###
+
 
 @pytest.mark.django_db
 def test_fetch_relations(case, court, django_assert_num_queries):
     case = CaseMetadata.objects.get(pk=case.pk)
     with django_assert_num_queries(select=2):
-        fetch_relations(case, select_relations=['volume__volume_xml', 'jurisdiction'], prefetch_relations=['citations'])
+        fetch_relations(case, select_relations=['volume__reporter', 'jurisdiction'], prefetch_relations=['citations'])
     with django_assert_num_queries():
-        fetch_relations(case, select_relations=['volume__volume_xml', 'jurisdiction'], prefetch_relations=['citations'])
+        fetch_relations(case, select_relations=['volume__reporter', 'jurisdiction'], prefetch_relations=['citations'])
     with django_assert_num_queries():
         assert case.jurisdiction
     with django_assert_num_queries():
-        assert case.volume.volume_xml
+        assert case.volume.reporter
     with django_assert_num_queries():
         assert len(list(case.citations.all()))
 
     # can prefetch_related on sub-relationships
-    case_xml = CaseXML.objects.get(pk=case.case_xml.pk)
+    body_cache = CaseBodyCache.objects.first()
     with django_assert_num_queries(select=2):
-        fetch_relations(case_xml, prefetch_relations=['metadata__citations'])
+        fetch_relations(body_cache, prefetch_relations=['metadata__citations'])
     with django_assert_num_queries():
-        assert len(list(case_xml.metadata.citations.all()))
+        assert len(list(body_cache.metadata.citations.all()))
 
     # can change items and it fetches relations of sub-items
     case = CaseMetadata.objects.get(pk=case.pk)
@@ -121,7 +121,7 @@ def test_volume_unredact(case_factory):
     volume.refresh_from_db()
     case.body_cache.refresh_from_db()
     assert volume.redacted is False
-    assert case.body_cache.text == 'Text 1\nText 2Text 3\n1\nText 4\n'
+    assert case.body_cache.text == 'Text 1\nText 2Text 3\nText 4\n'
     assert 'src="data:image data"' in case.body_cache.html
 
 
@@ -183,73 +183,71 @@ def test_update_frontend_urls(case_factory, django_assert_num_queries):
     assert case1.frontend_url == "/test/123/456/"
     assert case2.frontend_url == "/test/124/456/"
 
-### CaseXML ###
-
 @pytest.mark.django_db
-def test_reorder_head_matter(case_xml):
-    # To set up test, empty out <casebody> and <div TYPE="blocks"> and replace with new XML.
-    # Do this at a string level to avoid trickiness with namespaces.
-    parsed = case_xml.get_parsed_xml()
-    parsed('casebody|casebody').text("REPLACE_CASEBODY")
-    parsed('mets|div[TYPE="blocks"]').text("REPLACE_BLOCKS")
-    xml = str(parsed)
+def test_sync_case_body_cache(reset_sequences, case):
+    # set up case
+    structure = case.structure
+    page = structure.pages.first()
+    structure.opinions = [
+        {
+            'type': 'head',
+            'paragraphs': [{'class': 'parties', 'block_ids': ['BL_1.1'], 'id': 'b1-1'}],
+        }, {
+            'type': 'majority',
+            'paragraphs': [{'class': 'p', 'block_ids': ['BL_1.2', 'BL_1.3'], 'id': 'b1-2'}],
+            'footnotes': [
+                {
+                    'id': 'footnote_1_1',
+                    'paragraphs': [{'class': 'p', 'block_ids': ['BL_1.4'], 'id': 'b1-4'}],
+                    'label': '1',
+                }
+            ],
+        }
+    ]
+    structure.save()
+    page.blocks = [{"id": "BL_1.%s" % i, "class": "p", "tokens": ["Text %s" % i]} for i in range(1, 5)]
+    page.save()
 
-    # elements to be reordered
-    xml = xml.replace("REPLACE_CASEBODY", """
-        <parties id="a">foo</parties>
-        <empty id="empty1"> </empty>
-        <headnotes id="b">foo</headnotes>
-        <headnotes id="c1">foo</headnotes>
-        <headnotes id="c2">foo</headnotes>
-        <headnotes id="c3">foo</headnotes>
-        <opinion type="majority">
-            <empty id="empty2"> </empty>
-            <p id="d">foo</p>
-            <footnote label="†">
-                <p id="e">foo</p>
-            </footnote>
-        </opinion>
-        <opinion type="dissent">
-            <p id="f">foo</p>
-        </opinion>
-    """)
-
-    # specify new element order
-    pairs = [('b', 'BL_9.9'), ('a', 'BL_9.10'), ('d', 'BL_9.11'), ('c1', 'BL_9.12'), ('e', 'BL_10.9'), ('c2', 'BL_10.10'), ('f', 'BL_10.11'), ('c3', 'BL_10.12'), ('empty1', None), ('empty2', None)]
-    xml = xml.replace("REPLACE_BLOCKS", "".join("""
-        <div TYPE="element">
-            <fptr><area BEGIN="%s" BETYPE="IDREF" FILEID="casebody_0001"/></fptr>
-            <fptr><seq>%s</seq></fptr>
-        </div>""" % (
-            case_id,
-            ('<area BEGIN="%s" BETYPE="IDREF" FILEID="alto_00009_0"/>' % alto_id) if alto_id else ''
-        ) for case_id, alto_id in pairs))
-
-    # reorder xml
-    parsed = parse_xml(xml)
-    case_xml.reorder_head_matter(parsed)
-
-    # strip <casebody> tag and whitespace from result, and verify order
-    result = str(parsed('casebody|casebody'))
-    result = re.sub(r'\s*\n\s*', '', re.sub(r'</?casebody.*?>', '', result), flags=re.S)
-    assert result == re.sub(r'\s*\n\s*', '', """
-        <headnotes id="b">foo</headnotes>
-        <parties id="a">foo</parties>
-        <empty id="empty1"> </empty>
-        <opinion type="majority">
-            <empty id="empty2"> </empty>
-            <p id="d">foo</p>
-            <headnotes id="c1">foo</headnotes>
-            <headnotes id="c2">foo</headnotes>
-            <footnote label="†">
-                <p id="e">foo</p>
-            </footnote>
-        </opinion>
-        <opinion type="dissent">
-            <p id="f">foo</p>
-            <headnotes id="c3">foo</headnotes>
-        </opinion>
-    """, flags=re.S)
+    # verify case contents
+    case.sync_case_body_cache()
+    assert case.body_cache.text == 'Text 1\nText 2Text 3\nText 4\n'
+    assert xml_equal(case.body_cache.html,
+        '<section class="casebody" data-case-id="00000000" data-firstpage="4" data-lastpage="8">\n'
+        '  <section class="head-matter">\n'
+        '    <h4 class="parties" id="b1-1">Text 1</h4>\n'
+        '  </section>\n'
+        '  <article class="opinion" data-type="majority">\n'
+        '    <p id="b1-2">Text 2Text 3</p>\n'
+        '    <aside class="footnote" data-label="1" id="footnote_1_1">\n'
+        '      <a href="#ref_footnote_1_1">1</a>\n'
+        '      <p id="b1-4">Text 4</p>\n'
+        '    </aside>\n'
+        '  </article>\n'
+        '</section>\n')
+    assert case.body_cache.json == {
+        'attorneys': [],
+        'parties': ['Text 1'],
+        'judges': [],
+        'opinions': [
+            {
+                'type': 'majority',
+                'author': None,
+                'text': 'Text 2Text 3\nText 4'
+            }],
+        'head_matter': 'Text 1',
+        'corrections': ''
+    }
+    assert xml_equal(case.body_cache.xml,
+        '<?xml version=\'1.0\' encoding=\'utf-8\'?>\n'
+        '<casebody firstpage="4" lastpage="8" xmlns="http://nrs.harvard.edu/urn-3:HLS.Libr.US_Case_Law.Schema.Case_Body:v1">\n'
+        '  <parties id="b1-1">Text 1</parties>\n'
+        '  <opinion type="majority">\n'
+        '    <p id="b1-2">Text 2Text 3</p>\n'
+        '    <footnote label="1">\n'
+        '      <p id="b1-4">Text 4</p>\n'
+        '    </footnote>\n'
+        '  </opinion>\n'
+        '</casebody>\n')
 
 
 ### EditLog and EditLogTransaction ###
@@ -269,12 +267,11 @@ def test_data_edit(volume_metadata):
 
 @pytest.mark.django_db
 def test_retrieve_and_store_images(case, inline_image_src, django_assert_num_queries):
-    caseimages = CaseImage.objects.all()
-    assert len(caseimages) == 0
+    assert not CaseImage.objects.exists()
 
     # index for first time
-    params = {"html": "<img src='image/png;base64,%s'>" % inline_image_src}
-    CaseBodyCache(metadata=case, **params).save()
+    case.body_cache.html = "<img src='image/png;base64,%s'>" % inline_image_src
+    case.body_cache.save()
     with django_assert_num_queries(select=3, insert=1, update=1):
         retrieve_images_from_cases(case.volume_id)
     assert CaseImage.objects.count() == 1

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -36,7 +36,7 @@ services:
           - 127.0.0.1:9200:9200
     worker:
         build: .
-        image: capstone:0.3.77-dc01083536b78dc3461c88a590cbf2cc
+        image: capstone:0.3.78-88930ddafd43f36cd43b59257279305f
         volumes:
             # NAMED VOLUMES
             # Use a named, persistent volume so that the node_modules directory,
@@ -63,7 +63,7 @@ services:
           - "api.case.test:127.0.0.1"
     web:
         build: .
-        image: capstone:0.3.77-dc01083536b78dc3461c88a590cbf2cc
+        image: capstone:0.3.78-88930ddafd43f36cd43b59257279305f
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/test_data/test_fixtures/helpers.py
+++ b/capstone/test_data/test_fixtures/helpers.py
@@ -1,5 +1,10 @@
+import difflib
 import hashlib
 from pathlib import Path
+
+from lxml import etree
+
+from scripts.helpers import parse_xml
 
 
 def file_hash(path):
@@ -24,3 +29,48 @@ def dir_hash(directory):
             hash.update(file.read_bytes())
 
     return hash.hexdigest()
+
+def elements_equal(e1, e2, ignore={}, ignore_trailing_whitespace=False, tidy_style_attrs=False, exc_class=ValueError):
+    """
+        Recursively compare two lxml Elements.
+        Raise an exception (by default ValueError) if not identical.
+        Optionally, ignore trailing whitespace after block elements.
+        Optionally, munge "style" attributes for easier comparison.
+    """
+    if e1.tag != e2.tag:
+        raise exc_class("e1.tag != e2.tag (%s != %s)" % (e1.tag, e2.tag))
+    if e1.text != e2.text:
+        diff = '\n'.join(difflib.ndiff([e1.text or ''], [e2.text or '']))
+        raise exc_class("e1.text != e2.text:\n%s" % diff)
+    if e1.tail != e2.tail:
+        exc = exc_class("e1.tail != e2.tail (%s != %s)" % (e1.tail, e2.tail))
+        if ignore_trailing_whitespace:
+            if (e1.tail or '').strip() or (e2.tail or '').strip():
+                raise exc
+        else:
+            raise exc
+    ignore_attrs = ignore.get('attrs', set()) | ignore.get('tag_attrs', {}).get(e1.tag.rsplit('}', 1)[-1], set())
+    e1_attrib = {k:v for k,v in e1.attrib.items() if k not in ignore_attrs}
+    e2_attrib = {k:v for k,v in e2.attrib.items() if k not in ignore_attrs}
+    if tidy_style_attrs and e1_attrib.get('style'):
+        # allow easy comparison of sanitized style tags by removing all spaces and final semicolon
+        e1_attrib['style'] = e1_attrib['style'].replace(' ', '').rstrip(';')
+        e2_attrib['style'] = e2_attrib['style'].replace(' ', '').rstrip(';')
+    if e1_attrib != e2_attrib:
+        diff = "\n".join(difflib.Differ().compare(["%s: %s" % i for i in sorted(e1_attrib.items())], ["%s: %s" % i for i in sorted(e2_attrib.items())]))
+        raise exc_class("e1.attrib != e2.attrib:\n%s" % diff)
+    s1 = [i for i in e1 if i.tag.rsplit('}', 1)[-1] not in ignore.get('tags', ())]
+    s2 = [i for i in e2 if i.tag.rsplit('}', 1)[-1] not in ignore.get('tags', ())]
+    if len(s1) != len(s2):
+        diff = "\n".join(difflib.Differ().compare([s.tag for s in s1], [s.tag for s in s2]))
+        raise exc_class("e1 children != e2 children:\n%s" % diff)
+    for c1, c2 in zip(s1, s2):
+        elements_equal(c1, c2, ignore, ignore_trailing_whitespace, tidy_style_attrs, exc_class)
+
+    # If you've gotten this far without an exception, the elements are equal
+    return True
+
+def xml_equal(s1, s2, **kwargs):
+    e1 = parse_xml(s1)[0]
+    e2 = parse_xml(s2)[0]
+    return elements_equal(e1, e2, **kwargs)


### PR DESCRIPTION
Some improvements to citation extraction:

* Don't match citations where volume or page number starts with `0`
* Match citations where volume number ends with `Suppl.` or `1/2`
* Don't extract citations where reporter name starts with a digit (no valid reporter names do)
* Remove footnote numbers from CaseBodyCache.text
* Filter out invalid reporters like `or`
* Translate OCR-error reporters like `la.`
* Update Elasticsearch as we go along, so we don't have to rebuild the search index afterward

Also included:

* prefetch_related citations in update_elasticsearch_for_vol
* drop one-off task `sync_xml_image_case_body_cache_for_vol`
* `case` fixture is now a built-in `CaseFactory` instance; fix tests impacted by that
* add test for `sync_case_body_cache`
* `docker-compose.yml` wanted to be updated for some reason; maybe two mutually-incompatible PRs we brought in recently?