### PR TITLE
Don't match cites that are part of larger words

### DIFF
--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -22,7 +22,7 @@ from capapi.tasks import cache_query_count
 from capweb.helpers import reverse, statement_timeout, StatementTimeout
 from config.logging import logger
 
-cite_extracting_regex = "([1-9]\d*(?: Suppl\.| 1/2)?)\s+([a-zA-Z][\s0-9a-zA-Z.']{0,40})\s+([1-9]\d*)"
+cite_extracting_regex = r"\b([1-9]\d*(?: Suppl\.| 1/2)?)\s+([a-zA-Z][\s0-9a-zA-Z.']{0,40})\s+([1-9]\d*)\b"
 
 def create_zip_filename(case_list):
     ts = slugify(datetime.now().timestamp())

--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -376,8 +376,8 @@ def extract_citations_per_vol(self, volume_id):
         extra_reporters = {'wl'}
         valid_reporters = {normalize_cite(c) for c in list(EDITIONS.keys()) + list(VARIATIONS_ONLY.keys())} | extra_reporters
         invalid_reporters = set(ascii_lowercase) | {'at', 'or', 'p.', 'c.', 'B'}
-        translations = {'la.': 'Ia.'}
-        cases = (CaseMetadata.objects.filter(body_cache__text__regex=cite_extracting_regex, volume_id=volume_id, in_scope=True)
+        translations = {'la.': 'Ia.', 'Yt.': 'Vt.', 'Pae.': 'Pac.'}
+        cases = (CaseMetadata.objects.filter(volume_id=volume_id, in_scope=True)
                  .select_related('body_cache')
                  .only('body_cache__text'))
         # remove all extracted citations in volume before recreating

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -244,8 +244,19 @@ def test_redact_id_numbers(case_factory):
 @pytest.mark.django_db
 def test_extract_citations(case_factory, tmpdir, settings, elasticsearch):
     settings.MISSED_CITATIONS_DIR = str(tmpdir)
-    legitimate_cites = ["225 F.Supp. 552", "125 f supp 152", "2 1/2 Mass. 1", "3 Suppl. Mass. 2"]
-    illegitimate_cites = ["2 Dogs 3", "3 Dogs 4", "1 or 2"]
+    legitimate_cites = [
+        "225 F.Supp. 552",  # correct
+        "125 f supp 152",   # normalized
+        "2 1/2 Mass. 1",    # special volume numbers
+        "3 Suppl. Mass. 2", # special volume numbers
+        "1 F. 2d 2"         # not matched as "1 F. 2"
+    ]
+    illegitimate_cites = [
+        "2 Dogs 3",             # unrecognized reporter
+        "3 Dogs 4",             # duplicate unrecognized reporter
+        "1 or 2",               # not matched as 1 Or. 2
+        "word1 Mass. 2word"     # not matched if part of larger word
+    ]
     case = case_factory(body_cache__text=", some text, ".join(legitimate_cites+illegitimate_cites))
     fabfile.extract_all_citations()
     cites = list(ExtractedCitation.objects.all())


### PR DESCRIPTION
This requires word boundaries around citations, so won't match "word1 Mass. 2word". This reduces false positives, and also means that we correctly detect "123 F. 2d 456" instead of matching it as "123 F. 2".

Also adds translations for two common OCR errors (`'Yt.': 'Vt.', 'Pae.': 'Pac.'`).