### PR TITLE
Retry emails if first attempt to send fails.

### DIFF
--- a/capstone/config/wsgi.py
+++ b/capstone/config/wsgi.py
@@ -13,4 +13,17 @@ from django.core.wsgi import get_wsgi_application
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
 
+# patch email sending to retry on error, to work around sporadic connection issues
+from django.core.mail import EmailMessage
+from smtplib import SMTPException
+from time import sleep
+_orig_send = EmailMessage.send
+def retrying_send(message, *args, **kwargs):
+    try:
+        return _orig_send(message, *args, **kwargs)
+    except (SMTPException, TimeoutError):
+        sleep(1)
+        return _orig_send(message, *args, **kwargs)
+EmailMessage.send = retrying_send
+
 application = get_wsgi_application()


### PR DESCRIPTION
@bensteinberg says CAP is experiencing the same sporadic email errors that Perma was, e.g.:
```
Internal Server Error: /user/register/
    
SMTPServerDisconnected at /user/register/
Connection unexpectedly closed
```

I applied this patch in Perma, which simply makes another attempt to send the email a second later, if the first attempt fails. We haven't seen any exceptions since.