### PR TITLE
Update cite export

### DIFF
--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -32,7 +32,7 @@ def run_task_for_volumes(task, volumes=None, last_run_before=None, synchronous=F
         the task has not succeeded after that time.
     """
     if volumes is None:
-        volumes = VolumeMetadata.objects.filter(out_of_scope=False)
+        volumes = VolumeMetadata.objects.filter(out_of_scope=False, duplicate=False)
     if last_run_before:
         # find volumes where task has never run, or had an error, or had a success before last_run_before date
         volumes = volumes.filter(

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -298,60 +298,58 @@ def test_sync_case_body_cache_for_vol(volume_metadata, case_factory, django_asse
 
 
 @pytest.mark.django_db
-def test_export_citation_graph(case_factory, tmpdir, settings, elasticsearch, extracted_citation_factory, citation_factory):
-    output_folder = str(tmpdir)
-    file_name = "citations"
-    file_path = os.path.join(output_folder, file_name + ".csv.gz")
+def test_export_citation_graph(case_factory, tmpdir, elasticsearch, extracted_citation_factory, citation_factory):
+    output_folder = Path(str(tmpdir))
     cite_from = "225 F.Supp. 552"
     cite_to = "73 Ill. 561"
+    cite_to_aka = "123 Reg. 456"
     another_cite_to = "43 Ill. 112"
     cite_not_in_cap = "23 Some. Cite. 456"
+    duplicate_citation = "36 R.I. 316"
+    future_cite = "123 Fut. 456"
 
-    case_from = case_factory(body_cache__text=", some text, " + cite_to, citations__cite=cite_from, citations__type='official')
-    case_to = case_factory(body_cache__text=", some other text, ", citations__cite=cite_to, citations__type='official')
-    another_case_to = case_factory(body_cache__text=", some other text, ", citations__cite=another_cite_to, citations__type='official')
+    # source case
+    case_from = case_factory(citations__cite=cite_from, decision_date=datetime(2000, 1, 1))
+    extracted_citation_factory(cite=cite_from, cited_by_id=case_from.id)  # cite to self is ignored
 
-    # extract citation and attach it to our case_from
+    # dest case should appear
+    case_to = case_factory(citations__cite=cite_to, decision_date=datetime(1990, 1, 1))
     extracted_citation_factory(cite=cite_to, cited_by_id=case_from.id)
+    citation_factory(cite=cite_to_aka, case=case_to)
+    extracted_citation_factory(cite=cite_to_aka, cited_by_id=case_from.id)  # we should only include this parallel cite once
+
+    # second dest case should appear
+    another_case_to = case_factory(citations__cite=another_cite_to, decision_date=datetime(1990, 1, 1))
     extracted_citation_factory(cite=another_cite_to, cited_by_id=case_from.id)
 
-    # the following cases should not show up (we should only be extracting citations that are found in CAP)
-    extracted_citation_factory(cite=cite_not_in_cap, cited_by_id=case_from.id)
-    fabfile.export_citation_graph(output_folder=output_folder)
-    results = []
-    with gzip.open(file_path, 'rt') as f:
-        csv_r = csv.reader(f)
-        for row in csv_r:
-            results.append(row)
-    assert len(results) == 1
-    case_citations = results[0]
-    assert case_citations[0] == str(case_from.id)
-    assert str(case_to.id) in case_citations and str(another_case_to.id) in case_citations
-    assert len(case_citations) == 3
-
-    ### verify that we're ignoring all duplicate citations
-    old_case_citations = case_citations
-    duplicate_citation = "36 R.I. 316"
-
-    # create several cases with the same citation
-    case_dups = [case_factory(body_cache__text=", some text, ", citations__cite=duplicate_citation,
-                              citations__type='official') for case_dup in range(3)]
-
-    # make sure we've extracted this citation
+    # multiple cases with same cite should be filtered out
+    [case_factory(citations__cite=duplicate_citation) for _ in range(3)]
     extracted_citation_factory(cite=duplicate_citation, cited_by_id=case_from.id)
 
-    fabfile.export_citation_graph(output_folder=output_folder)
-    results = []
-    with gzip.open(file_path, 'rt') as f:
-        csv_r = csv.reader(f)
-        for row in csv_r:
-            results.append(row)
-    assert len(results) == 1
-    case_citations = results[0]
-    assert case_citations[0] == str(case_from.id)
+    # cites matching zero cases should be filtered out
+    extracted_citation_factory(cite=cite_not_in_cap, cited_by_id=case_from.id)
 
-    # only one duplicate citation found
-    assert str(case_dups[0].id) not in case_citations[1]
-    assert str(case_dups[1].id) not in case_citations[1]
-    assert len(case_citations) == 3
-    assert case_citations == old_case_citations
+    # citations to future cases should be filtered out
+    case_factory(citations__cite=future_cite, decision_date=datetime(2010, 1, 1))
+    extracted_citation_factory(cite=future_cite, cited_by_id=case_from.id)
+
+    # perform export
+    fabfile.export_citation_graph(output_folder=str(output_folder))
+
+    # check citations.csv.gz
+    with gzip.open(str(output_folder / "citations.csv.gz"), 'rt') as f:
+        results = list(csv.reader(f))
+    assert len(results) == 1
+    assert results[0][0] == str(case_from.id)
+    assert set(results[0][1:]) == {str(case_to.id), str(another_case_to.id)}
+
+    # check README.md
+    results = output_folder.joinpath("README.md").read_text()
+    assert results.endswith("\nNodes: 3\nEdges: 2\n")
+
+    # check metadata.csv.gz
+    with gzip.open(str(output_folder / "metadata.csv.gz"), 'rt') as f:
+        results = list(csv.DictReader(f))
+    assert set(int(r['id']) for r in results) == {case_from.id, case_to.id, another_case_to.id}
+    for r in results:  # check 'cites' column
+        assert set(c.cite for c in Citation.objects.filter(case_id=r['id'])) == set(r['cites'].split('; '))

--- a/capstone/config/settings/settings_prod.py
+++ b/capstone/config/settings/settings_prod.py
@@ -2,7 +2,7 @@ from .settings_base import *  # noqa
 
 DEBUG = False
 
-STORAGES = {
+STORAGES.update({
     'ingest_storage': {
         'class': 'CapS3Storage',
         'kwargs': {
@@ -69,7 +69,7 @@ STORAGES = {
             'location': os.path.join(BASE_DIR, 'downloads'),
         }
     }
-}
+})
 
 INVENTORY = {
     # prefix to strip from paths in manifest.json

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -2,7 +2,6 @@ import csv
 import gzip
 import hashlib
 import os
-import pathlib
 import signal
 import subprocess
 import sys
@@ -113,7 +112,7 @@ def update_docker_image_version():
         docker_compose = docker_compose.replace(current_version, new_version)
         docker_compose_path.write_text(docker_compose)
         print("%s updated to version %s" % (docker_compose_path, new_version))
-        
+
     else:
         print("%s is already up to date" % docker_compose_path)
 
@@ -698,7 +697,7 @@ def url_to_js_string(target_url="http://case.test:8000/maintenance/?no_toolbar",
         # replace case.test:8000 with case.law
         data = data.replace(urlparse(target_url).netloc, new_domain)
     data = escapejs(data)           # encode for storage in javascript
-    pathlib.Path(out_path).write_text(data)
+    Path(out_path).write_text(data)
 
 
 @task
@@ -1070,7 +1069,6 @@ def download_pdfs(jurisdiction=None):
         as we're using a read-only overlay to expose the files.
     """
     from capdb.storages import pdf_storage, writeable_download_files_storage
-    from pathlib import Path
     import re
 
     # find each PDF by checking TarFile, since we have a 1-to-1 mapping between tar files and PDFs
@@ -1153,16 +1151,16 @@ def populate_case_page_order():
     """
     cursor = django.db.connections['capdb'].cursor()
     cursor.execute("""
-        UPDATE capdb_casemetadata m 
-        SET first_page_order=j.first_page_order, last_page_order=j.last_page_order 
-        FROM 
-            capdb_casestructure c, 
+        UPDATE capdb_casemetadata m
+        SET first_page_order=j.first_page_order, last_page_order=j.last_page_order
+        FROM
+            capdb_casestructure c,
             (
-                SELECT min(p.order) as first_page_order, max(p.order) as last_page_order, cp.casestructure_id 
-                FROM capdb_pagestructure p, capdb_casestructure_pages cp 
-                WHERE p.id=cp.pagestructure_id 
+                SELECT min(p.order) as first_page_order, max(p.order) as last_page_order, cp.casestructure_id
+                FROM capdb_pagestructure p, capdb_casestructure_pages cp
+                WHERE p.id=cp.pagestructure_id
                 GROUP BY cp.casestructure_id
-            ) j 
+            ) j
         WHERE c.metadata_id=m.id and c.id=j.casestructure_id
     """)
 
@@ -1174,51 +1172,88 @@ def extract_all_citations(last_run_before=None):
 
 
 @task
-def export_citation_graph(chunk_size=10000, file_name="citations", output_folder="graph"):
+def export_citation_graph(output_folder="graph"):
     """writes cited from and citing to to file"""
-    full_filepath = os.path.join(output_folder, '%s.csv.gz' % file_name)
+    from django.utils import timezone
+    from django.contrib.postgres.aggregates import ArrayAgg
 
     # create path if doesn't exist
-    pathlib.Path(output_folder).mkdir(parents=True, exist_ok=True)
+    output_folder = Path(output_folder)
+    output_folder.mkdir(parents=True, exist_ok=True)
+    citations_path = output_folder / 'citations.csv.gz'
+    citations_path.touch(mode=0o644)  # check that we have write access
 
-    cursor_name = 'cite_cursor'
-    with gzip.open(full_filepath, "wt") as f:
+    # write citations.csv.gz
+    nodes = set()
+    edge_count = 0
+    chunk_size = 10000
+    query = """
+        DECLARE cite_cursor CURSOR for
+        select
+            from_id, array_agg(distinct to_id)
+        from (
+            select
+                cite_from.id as from_id, min(cite_to.id) as to_id
+            from capdb_casemetadata cite_from
+            inner join
+                capdb_extractedcitation ec on cite_from.id = ec.cited_by_id
+            inner join
+                capdb_citation cite on cite.normalized_cite = ec.normalized_cite
+            inner join
+                capdb_casemetadata cite_to on cite.case_id = cite_to.id
+            where cite_from.in_scope is true
+                and cite_from.decision_date_original >= cite_to.decision_date_original
+                and cite_to.id != cite_from.id
+            group by cite_from.id, ec.normalized_cite
+            having count(*) = 1
+        ) as c group by from_id;
+    """
+    print("Running citations query")
+    with transaction.atomic(using='capdb'), \
+            connections['capdb'].cursor() as cursor, \
+            gzip.open(str(citations_path), "wt") as f, \
+            tqdm() as pbar:
         csv_w = csv.writer(f)
-        query = """
-                DECLARE %s CURSOR for
-                select
-                from_id, array_agg(to_id)
-                from (
-                    select
-                    cite_from.id as from_id, array_agg(cite_to.case_id) as to_id
-                    from capdb_casemetadata cite_from
-    
-                    inner join 
-                        capdb_extractedcitation ec on cite_from.id = ec.cited_by_id
-                    inner join 
-                        capdb_citation cite_to on cite_to.normalized_cite = ec.normalized_cite
-                    where cite_from.in_scope is true
-                    group by cite_from.id, ec.normalized_cite
-                    having count(*) = 1
-                ) as c group by from_id;
-               """ % cursor_name
-        
-        with transaction.atomic(using='capdb'), connections['capdb'].cursor() as cursor:
-            cursor.execute(query)
-            while True:
-                cursor.execute("FETCH %s FROM %s" % (str(chunk_size), cursor_name))
-                chunk = cursor.fetchall()
-                if not chunk:
-                    cursor.execute("CLOSE %s;" % cursor_name)
-                    break
-                for row in chunk:
-                    cite_tos = [cite_to[0] for cite_to in row[1]]
-                    csv_w.writerow([row[0]] + cite_tos)
+        cursor.execute(query)
+        while True:
+            cursor.execute("FETCH %s FROM cite_cursor" % chunk_size)
+            chunk = cursor.fetchall()
+            pbar.update()
+            if not chunk:
+                break
+            for row in chunk:
+                out = [row[0]] + row[1]
+                csv_w.writerow(out)
+                nodes.update(out)
+                edge_count += len(out) - 1
+
+    # write README.txt
+    output_folder.joinpath('README.md').write_text(
+        "Citation graph exported %s\n"
+        "Nodes: %s\n"
+        "Edges: %s\n" % (timezone.now(), len(nodes), edge_count)
+    )
+
+    # write metadata.csv.gz
+    fields = [
+        'id', 'frontend_url', 'jurisdiction__name', 'jurisdiction_id', 'court__name_abbreviation', 'court_id',
+        'reporter__short_name', 'reporter_id', 'name_abbreviation', 'decision_date_original', 'cites'
+    ]
+    nodes = list(nodes)
+    print("Writing metadata")
+    with gzip.open(str(output_folder / 'metadata.csv.gz'), "wt") as f:
+        csv_w = csv.writer(f)
+        csv_w.writerow(fields)
+        query = CaseMetadata.objects.annotate(cites=ArrayAgg('citations__cite')).values_list(*fields)
+        for i in tqdm(range(0, len(nodes), chunk_size)):
+            for row in query.filter(id__in=nodes[i:i+chunk_size]):
+                row = row[:-1] + ("; ".join(row[-1]),)  # combine citations
+                csv_w.writerow(row)
+
 
 @task
 def report_missed_citations():
     """ Summarize files written by extract_all_citations. Writes csv to stdout. """
-    from pathlib import Path
     import random
     counts = {}
     for f in Path(settings.MISSED_CITATIONS_DIR).glob('*.csv'):
@@ -1245,7 +1280,6 @@ def filter_limerick_lines(stopwords_path):
         such as https://www.freewebheaders.com/download/files/full-list-of-bad-words_text-file_2018_07_30.zip
         or https://www.cs.cmu.edu/~biglou/resources/bad-words.txt
     """
-    from pathlib import Path
     import re
     stopwords_set = set(s.lower() for s in Path(stopwords_path).read_text().splitlines(keepends=False))
     limerick_text = Path('static/js/limerick_lines.js').read_text()


### PR DESCRIPTION
Some improvements to our exported cite graph, mostly based on discussions with Momin:

* Exclude volumes marked duplicate (currently not any)
* Exclude duplicate edges, which are caused by parallel cites
* Exclude citations forward in time, which are caused by data errors
* Exclude citations from a case to itself
* Add a README.md that says how many nodes and edges are in the exported graph
* Add a metadata.csv.gz that lists the ID, url, jurisdiction, reporter, court, short name, date, and citations for each node
