### PR TITLE
User logins aren't case sensitive

### DIFF
--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -37,6 +37,14 @@ class CapUserManager(BaseUserManager):
 
         return self.create_user(email=email, password=password, **kwargs)
 
+    def get_by_natural_key(self, username):
+        """
+            Make user logins case-insensitive, which works because you can't sign up
+            with the same email with different capitalization anyway.
+        """
+        return self.get(email__iexact=username)
+
+
 # This is a temporary workaround for the problem described in
 # https://github.com/jazzband/django-model-utils/issues/331#issuecomment-478994563
 # where django-model-utils FieldTracker breaks the setter for overridden attributes on abstract base classes


### PR DESCRIPTION
Our user account flow is confusing -- the login form is case sensitive, but the password reset form is not. So if you sign up with a capitalized email and try to log in with a lowercase one, you think your password is wrong, then you successfully reset it, then you still think it's wrong.

This harmonizes the two by making the login form case insensitive as well. That's a little controversial because email addresses are technically allowed to be case sensitive. But we forbid signups with identically-lower-cased emails anyway, so this seems fine.