### PR TITLE
New download overlay system; handle symlinks in download folder; add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,7 +22,9 @@ capstone/test_data/bulk-data/
 capstone/test_data/ngrams/
 capstone/test_data/case-images/
 capstone/test_data/GeoLite2-City.mmdb
-capstone/downloads/PDFs/*/*/*/*.pdf
+capstone/test_data/downloads/
+!capstone/test_data/downloads/fake_volume.pdf
+!capstone/test_data/downloads/README.md
 *.ipynb*
 *.lprof
 

--- a/capstone/capapi/tests/helpers.py
+++ b/capstone/capapi/tests/helpers.py
@@ -22,7 +22,11 @@ def check_response(response, status_code=200, content_type=None, content_include
         if content_type == 'application/pdf':
             content = "\n".join(page.getText() for page in fitz.open(stream=response.content, filetype="pdf"))
         else:
-            content = response.content.decode()
+            try:
+                content = response.content.decode()
+            except AttributeError:
+                # FileResponse
+                content = b''.join(response.streaming_content).decode()
 
         if content_includes:
             if isinstance(content_includes, str):

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -24,8 +24,7 @@ from django.utils.text import slugify
 from django.utils.encoding import force_bytes, force_str
 from django.core.files.base import ContentFile
 
-from capdb.storages import bulk_export_storage, case_image_storage, download_files_storage, \
-    writeable_download_files_storage, pdf_storage
+from capdb.storages import bulk_export_storage, case_image_storage, download_files_storage, pdf_storage
 from capdb.versioning import TemporalHistoricalRecords, TemporalQuerySet
 from capweb.helpers import reverse, transaction_safe_exceptions
 from scripts import render_case
@@ -741,7 +740,7 @@ class VolumeMetadata(models.Model):
         # replace PDF
         if self.pdf_file:
             copy_file("unredacted/%s.pdf" % self.pk, self.pdf_file, from_storage=pdf_storage,
-                      to_storage=writeable_download_files_storage)
+                      to_storage=download_files_storage)
 
         # update flag
         self.redacted = False

--- a/capstone/capdb/storages.py
+++ b/capstone/capdb/storages.py
@@ -2,6 +2,7 @@ import csv
 import gzip
 import hashlib
 import traceback
+import types
 from contextlib import contextmanager
 
 import msgpack
@@ -21,6 +22,7 @@ from storages.backends.s3boto3 import S3Boto3Storage
 
 
 class CapStorageMixin(object):
+
     def relpath(self, path):
         return os.path.relpath(path, self.location)
 
@@ -127,7 +129,10 @@ class CapFileStorage(CapStorageMixin, FileSystemStorage):
         if partial_path:
             search_path, prefix = os.path.split(search_path)
 
-        directories, files = self.listdir(search_path)
+        try:
+            directories, files = self.listdir(search_path)
+        except FileNotFoundError:
+            return
         for file_name in itertools.chain(directories, files):
             if partial_path and not file_name.startswith(prefix):
                 continue
@@ -136,7 +141,7 @@ class CapFileStorage(CapStorageMixin, FileSystemStorage):
                 continue
             yield os.path.join(search_path, file_name)
 
-    def iter_files_recursive(self, path="", with_md5=False):
+    def iter_files_recursive(self, path="", with_md5=False, with_dirs=False):
         """
             Yield each file in path or subdirectories.
             Order is not specified.
@@ -151,6 +156,13 @@ class CapFileStorage(CapStorageMixin, FileSystemStorage):
                     yield rel_path, hashlib.md5(self.contents(rel_path, 'rb')).hexdigest()
                 else:
                     yield rel_path
+            if with_dirs:
+                for file_name in dirs:
+                    # skip hidden files starting with .
+                    if file_name.startswith('.'):
+                        continue
+                    rel_path = self.relpath(os.path.join(root, file_name)).lstrip('/')
+                    yield rel_path
 
     def tag_file(self, path, key, value):
         """ For file storage, tags don't work. """
@@ -161,6 +173,40 @@ class CapFileStorage(CapStorageMixin, FileSystemStorage):
 
     def isfile(self, path):
         return os.path.isfile(self.path(path))
+
+    def islink(self, path):
+        return os.path.islink(self.path(path))
+
+    def realpath(self, path):
+        return self.relpath(self.path(os.path.realpath(self.path(path))))
+
+    def stat(self, path, *args, **kwargs):
+        return os.stat(self.path(path), *args, **kwargs)
+
+
+class DownloadOverlayStorage(CapFileStorage):
+    """
+        Storage that shows the files in BASE_DIR/downloads/ as an overlay over the files in the underlying storage.
+        Files in overlay will cached; restart Django to reload.
+    """
+    def __init__(self, *args, **kwargs):
+        self.overlay_storage = CapFileStorage(location=os.path.join(settings.BASE_DIR, 'downloads'))
+        super().__init__(*args, **kwargs)
+
+        # functions that check for existence of the file in the overlay, and otherwise return the result for the underlying storage
+        overlay_paths = set(self.overlay_storage.iter_files_recursive(with_dirs=True))
+        for method_name in ('isdir', 'isfile', 'islink', 'relpath', 'realpath', 'path', 'open', 'size', 'get_modified_time', 'stat'):
+            def method(self, path, *args, overlay_method=getattr(self.overlay_storage, method_name), underlay_method=getattr(super(), method_name), **kwargs):
+                if path in overlay_paths:
+                    return overlay_method(path, *args, **kwargs)
+                return underlay_method(path, *args, **kwargs)
+            setattr(self, method_name, types.MethodType(method, self))
+
+        # functions that return chained results for both storages
+        for method_name in ('iter_files', 'iter_files_recursive'):
+            def method(self, *args, overlay_method=getattr(self.overlay_storage, method_name), underlay_method=getattr(super(), method_name), **kwargs):
+                return set(itertools.chain(overlay_method(*args, **kwargs), underlay_method(*args, **kwargs)))
+            setattr(self, method_name, types.MethodType(method, self))
 
 
 class CaptarFile(File):

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -44,7 +44,7 @@ def test_export_cases(case_factory, tmp_path, django_assert_num_queries, elastic
     version = date.today().strftime('%Y%m%d')
     case1 = case_factory(jurisdiction__slug="aaa", volume__reporter__short_name="aaa", jurisdiction__whitelisted=False)
     case2 = case_factory(jurisdiction__slug="bbb", volume__reporter__short_name="bbb", jurisdiction__whitelisted=True)
-    monkeypatch.setattr("scripts.export.writeable_download_files_storage", FileSystemStorage(location=str(tmp_path)))
+    monkeypatch.setattr("scripts.export.download_files_storage", FileSystemStorage(location=str(tmp_path)))
     changelog = "changelogtext"
     fabfile.export_cases(changelog)
     written_files = sorted(str(i.relative_to(tmp_path)) for i in tmp_path.rglob('*'))

--- a/capstone/capweb/tests/test_views.py
+++ b/capstone/capweb/tests/test_views.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+
+import pytest
+from django.conf import settings
+
+from capapi.tests.helpers import check_response, is_cached
+from capdb.storages import DownloadOverlayStorage
+from capweb.helpers import reverse
+
+
+@pytest.mark.django_db
+def test_download_area(client, unlimited_auth_client, tmp_path, monkeypatch):
+    overlay_path = Path(settings.BASE_DIR, 'downloads')
+    underlay_path = tmp_path
+    monkeypatch.setattr("capweb.views.download_files_storage", DownloadOverlayStorage(location=str(underlay_path)))
+
+    # listing should include files from BASE_DIR/downloads as well as from donload_files_storage location
+    underlay_path.joinpath('underlay.txt').write_text("contents")
+    response = client.get(reverse('download-files', args=['']))
+    check_response(response, content_type="application/json")
+    response_json = response.json()
+    assert set(f['name'] for f in response_json['files']) == (set(p.name for p in overlay_path.glob('*')) | {'underlay.txt'}) - {'README.md', '.DS_Store'}
+
+    # can fetch contents from both overlay and underlay, with or without auth
+    for c in (client, unlimited_auth_client):
+        for read_from, path, content_type in ((overlay_path, 'README.md', 'text/markdown'), (underlay_path, 'underlay.txt', 'text/plain')):
+            response = c.get(reverse('download-files', args=[path]))
+            check_response(response, content_type=content_type, content_includes=read_from.joinpath(path).read_text())
+            assert is_cached(response)
+
+    # restricted folder
+    underlay_path.joinpath('restricted').mkdir()
+    underlay_path.joinpath('restricted/file.txt').write_text('contents')
+    for c, allow_downloads in ((client, False), (unlimited_auth_client, True)):
+        # restricted directory
+        response = c.get(reverse('download-files', args=['restricted/']))
+        check_response(response, content_type="application/json")
+        assert is_cached(response) is not allow_downloads
+        response_json = response.json()
+        assert response_json['allow_downloads'] == allow_downloads
+        assert set(f['name'] for f in response_json['files']) == {'file.txt'}
+
+        # restricted file
+        response = c.get(reverse('download-files', args=['restricted/file.txt']))
+        assert not is_cached(response)
+        if allow_downloads:
+            check_response(response, content_type="text/plain", content_includes="contents")
+        else:
+            check_response(response, content_type="application/json", status_code=403)
+
+    # symlinks
+    underlay_path.joinpath('folder_link').symlink_to('restricted')
+    underlay_path.joinpath('file_link.txt').symlink_to('restricted/file.txt')
+    for p1, p2 in (('folder_link/', 'restricted/'), ('folder_link/file.txt', 'restricted/file.txt'), ('file_link.txt', 'restricted/file.txt')):
+        response = c.get(reverse('download-files', args=[p1]))
+        check_response(response, status_code=302)
+        assert response.url == reverse('download-files', args=[p2])

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -429,18 +429,12 @@ STORAGES = {
         }
     },
     'download_files_storage': {
-        'class': 'CapFileStorage',
+        'class': 'DownloadOverlayStorage',
         'kwargs': {
-            'location': os.path.join(BASE_DIR, 'downloads'),
+            'location': os.path.join(BASE_DIR, 'test_data/downloads'),
             'base_url': 'http://case.test:8000/download/',
         }
     },
-    'writeable_download_files_storage': {
-        'class': 'CapFileStorage',
-        'kwargs': {
-            'location': os.path.join(BASE_DIR, 'downloads'),
-        }
-    }
 }
 
 INVENTORY = {

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -58,16 +58,7 @@ STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 MAINTAIN_ELASTICSEARCH_INDEX = False
 
 import sys
-if 'pytest' in sys.modules:
-    ## settings only for tests
-    MAINTAIN_ELASTICSEARCH_INDEX = False  # tests must opt in
-    ELASTICSEARCH_INDEXES['cases_endpoint'] = 'cases_test'
-    STORAGES['download_files_storage']['kwargs']['location'] = os.path.join(BASE_DIR, 'test_data/downloads')
-
-    # don't waste time on whitenoise for tests
-    MIDDLEWARE = [i for i in MIDDLEWARE if not i.startswith('whitenoise.')]
-
-else:
+if 'pytest' not in sys.modules:
     ## settings not for tests
     ELASTICSEARCH_INDEXES['cases_endpoint'] = 'cases'
 

--- a/capstone/config/settings/settings_prod.py
+++ b/capstone/config/settings/settings_prod.py
@@ -56,19 +56,6 @@ STORAGES.update({
             'location': os.path.join(BASE_DIR, 'ngrams'),
         },
     },
-    'download_files_storage': {
-        'class': 'CapFileStorage',
-        'kwargs': {
-            'location': os.path.join(BASE_DIR, 'downloads'),
-            'base_url': 'https://case.law/download/',
-        }
-    },
-    'writeable_download_files_storage': {
-        'class': 'CapFileStorage',
-        'kwargs': {
-            'location': os.path.join(BASE_DIR, 'downloads'),
-        }
-    }
 })
 
 INVENTORY = {

--- a/capstone/config/settings/settings_pytest.py
+++ b/capstone/config/settings/settings_pytest.py
@@ -1,0 +1,10 @@
+from .settings_dev import *  # noqa
+
+
+MAINTAIN_ELASTICSEARCH_INDEX = False  # tests must opt in
+ELASTICSEARCH_INDEXES['cases_endpoint'] = 'cases_test'
+STORAGES['download_files_storage']['kwargs']['location'] = os.path.join(BASE_DIR, 'test_data/downloads')
+SET_CACHE_CONTROL_HEADER = True
+
+# don't waste time on whitenoise for tests
+MIDDLEWARE = [i for i in MIDDLEWARE if not i.startswith('whitenoise.')]

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -36,7 +36,7 @@ services:
           - 127.0.0.1:9200:9200
     worker:
         build: .
-        image: capstone:0.3.86-9844ed3c02d8abd7ebe1a947fcca7325
+        image: capstone:0.3.89-575ae187733e9d3ad714682c2de036ec
         volumes:
             # NAMED VOLUMES
             # Use a named, persistent volume so that the node_modules directory,
@@ -63,7 +63,7 @@ services:
           - "api.case.test:127.0.0.1"
     web:
         build: .
-        image: capstone:0.3.86-9844ed3c02d8abd7ebe1a947fcca7325
+        image: capstone:0.3.89-575ae187733e9d3ad714682c2de036ec
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/downloads/PDFs/README.md
+++ b/capstone/downloads/PDFs/README.md
@@ -3,4 +3,4 @@ PDFs of each volume scanned for CAP, with selectable text created by OCR.
 Subdirectories:
 
 * [open](open/): Volumes downloadable without a researcher account.
-* restricted: Volumes downloadable only with a researcher account. **This directory is not yet published.**
+* [restricted](restricted/): Volumes downloadable only with a researcher account.

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -65,17 +65,6 @@ def test():
 
 @task(alias='pip-compile')
 def pip_compile(args=''):
-    """
-        We want to run `pip-compile --generate-hashes` so hash values of packages are locked.
-        This breaks packages installed from source; pip currently refuses to install source packages alongside hashed packages:
-            https://github.com/pypa/pip/issues/4995
-        pip will install packages from github in gz form, but those are currently rejected by pip-compile:
-            https://github.com/jazzband/pip-tools/issues/700
-        So we need to keep package requirements in requirements.in that look like this:
-            -e git+git://github.com/jcushman/email-normalize.git@6b5088bd05de247a9a33ad4e5c7911b676d6daf2#egg=email-normalize
-        and convert them to https form with hashes once they're written to requirements.txt:
-            https://github.com/jcushman/email-normalize/archive/6b5088bd05de247a9a33ad4e5c7911b676d6daf2.tar.gz#egg=email-normalize --hash=sha256:530851e150781c5208f0b60a278a902a3e5c6b98cd31d21f86eba54335134766
-    """
     import subprocess
 
     # run pip-compile
@@ -1061,11 +1050,11 @@ def check_existing_emails():
 @task
 def download_pdfs(jurisdiction=None):
     """
-        Download all PDFs, or all for a jurisdiction, to writeable_download_files_storage.
+        Download all PDFs, or all for a jurisdiction, to download_files_storage.
         Locally, this is the same as download_files_storage, but will differ in production,
         as we're using a read-only overlay to expose the files.
     """
-    from capdb.storages import pdf_storage, writeable_download_files_storage
+    from capdb.storages import pdf_storage, download_files_storage
     import re
 
     # find each PDF by checking TarFile, since we have a 1-to-1 mapping between tar files and PDFs
@@ -1095,7 +1084,7 @@ def download_pdfs(jurisdiction=None):
             new_name = new_name_prefix + (' %s' % chr(97+i) if i else '') + '.pdf'
             new_name = new_name.replace('..', '.')  # avoid double period in '1 Mass..pdf'
             new_path = Path('PDFs', open_or_restricted, jurisdiction.name_long, reporter.short_name, new_name)
-            if not writeable_download_files_storage.exists(str(new_path)):
+            if not download_files_storage.exists(str(new_path)):
                 break
         else:
             raise Exception("Failed to find a non-existent path for %s" % new_path)
@@ -1103,7 +1092,7 @@ def download_pdfs(jurisdiction=None):
         try:
             # copy file
             try:
-                copy_file(source_path, new_path, from_storage=pdf_storage, to_storage=writeable_download_files_storage)
+                copy_file(source_path, new_path, from_storage=pdf_storage, to_storage=download_files_storage)
             except IOError:
                 print("  - ERROR: source file not found")
                 continue
@@ -1114,7 +1103,7 @@ def download_pdfs(jurisdiction=None):
             print("  - Downloaded to %s" % new_path)
         except:
             # clean up partial downloads if process is killed
-            writeable_download_files_storage.delete(str(new_path))
+            download_files_storage.delete(str(new_path))
             raise
 
 
@@ -1411,6 +1400,22 @@ def filter_limerick_lines(stopwords_path):
                     if blocked_any:
                         c[word] = fixed
     Path('static/js/limerick_lines_fixed.js').write_text(assignment + " = " + json.dumps(limericks))
+
+
+@task
+def write_manifest_files():
+    """ Update manifest.csv in /download/ """
+    from capdb.storages import download_files_storage
+    with download_files_storage.open('manifest.csv', 'w') as out:
+        writer = csv.writer(out)
+        writer.writerow(["path", "size", "last_modified"])
+        for path in tqdm(sorted(download_files_storage.iter_files_recursive())):
+            stat = download_files_storage.stat(path)
+            writer.writerow([
+                path,
+                stat.st_size,
+                download_files_storage._datetime_from_timestamp(stat.st_mtime),
+            ])
 
 
 if __name__ == "__main__":

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -83,7 +83,6 @@ img2pdf
 Pillow
 diff-match-patch
 Markdown
-python-magic
 PyMuPDF
 
 # maintenance page

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -747,9 +747,6 @@ python-jose==2.0.2 \
     --hash=sha256:391f860dbe274223d73dd87de25e4117bf09e8fe5f93a417663b1f2d7b591165 \
     --hash=sha256:3b35cdb0e55a88581ff6d3f12de753aa459e940b50fe7ca5aa25149bc94cb37b \
     # via moto
-python-magic==0.4.15 \
-    --hash=sha256:f2674dcfad52ae6c49d4803fa027809540b130db1dec928cfbb9240316831375 \
-    --hash=sha256:f3765c0f582d2dfc72c15f3b5a82aecfae9498bd29ca840d72f37d7bd38bfcd5
 python-redis-lock==3.3.1 \
     --hash=sha256:5316d473ce6ce86a774b9f9c110d84c3a9bd1a2abfda5d99e9c0c8a872a8e6d6 \
     --hash=sha256:f0649c49341fa943f19b8fbe93c3457df8a0a85006c88134465a16401fd1e553

--- a/capstone/scripts/export.py
+++ b/capstone/scripts/export.py
@@ -15,7 +15,7 @@ from django.utils import timezone
 from capapi.documents import CaseDocument
 from capapi.serializers import NoLoginCaseDocumentSerializer, CaseDocumentSerializer
 from capdb.models import Jurisdiction, Reporter
-from capdb.storages import writeable_download_files_storage
+from capdb.storages import download_files_storage
 from scripts.helpers import HashingFile
 
 
@@ -24,7 +24,7 @@ def init_export(changelog):
     version_string = date.today().strftime('%Y%m%d')
     template_dir = Path(settings.BASE_DIR, 'capdb/templates/bulk_export')
     output_path = Path('bulk_exports', version_string)
-    if writeable_download_files_storage.exists(str(output_path / 'README.md')):
+    if download_files_storage.exists(str(output_path / 'README.md')):
         print("Cannot init export; %s already exists" % output_path)
         return
 
@@ -38,7 +38,7 @@ def init_export(changelog):
             'changes': changelog,
             'export_date': date.today(),
         })
-        writeable_download_files_storage.save('bulk_exports/%s/%s' % (version_string, path), StringIO(contents))
+        download_files_storage.save('bulk_exports/%s/%s' % (version_string, path), StringIO(contents))
 
     # run export
     export_all(version_string)
@@ -136,7 +136,7 @@ def export_case_documents(cases, zip_path, filter_item, public=False):
             # set up paths for zip file output
             subfolder = 'case_metadata' if format_name == 'metadata' else 'case_text_open' if public else 'case_text_restricted'
             vars['out_path'] = str(zip_path).format(subfolder=subfolder, case_format=format_name)
-            if writeable_download_files_storage.exists(vars['out_path']):
+            if download_files_storage.exists(vars['out_path']):
                 print("File %s already exists; skipping." % vars['out_path'])
                 del formats[format_name]
                 continue
@@ -191,7 +191,7 @@ def export_case_documents(cases, zip_path, filter_item, public=False):
 
             # copy temp file to permanent storage
             vars['out_spool'].seek(0)
-            writeable_download_files_storage.save(vars['out_path'], vars['out_spool'])
+            download_files_storage.save(vars['out_path'], vars['out_spool'])
             vars['out_spool'].close()
 
     finally:

--- a/capstone/setup.cfg
+++ b/capstone/setup.cfg
@@ -1,6 +1,6 @@
 ## http://pytest.org/latest/customize.html#adding-default-options
 [tool:pytest]
-DJANGO_SETTINGS_MODULE = config.settings
+DJANGO_SETTINGS_MODULE = config.settings.settings_pytest
 redis_exec = redis-server
 norecursedirs = node_modules test_data templates fixtures migrations
 testpaths = capapi capdb capweb cite scripts


### PR DESCRIPTION
Some changes to the downloads section:

- Symlinks now work, including folder or file symlinks.
- Move the "overlay" idea into code instead of using an overlay mount. Downloads section will show whatever is in capstone/downloads/, on top of wherever `download_files_storage` points to. This will require new config on beta/prod and a new deploy mechanism, but it makes for easier renaming/deleting of files.
- Generating manifest.json and manifest.csv on the fly was much too slow. Switch to a fab task that generates manifest.csv as a simple file, and drop manifest.json as redundant.