### PR TITLE
Default to not sending the site limit report when resetting site limits

### DIFF
--- a/capstone/capapi/tasks.py
+++ b/capstone/capapi/tasks.py
@@ -19,19 +19,20 @@ def daily_site_limit_reset_and_report():
 
     # send admin email
     users_created_today = CapUser.objects.filter(date_joined__gte=timezone.now()-timedelta(days=1)).values_list('email', flat=True)
-    send_mail(
-        'CAP daily usage: %s registered users, %s blacklisted downloads' % (site_limits.daily_signups, site_limits.daily_downloads),
-        """
+    if settings.SITE_LIMIT_REPORT:
+        send_mail(
+            'CAP daily usage: %s registered users, %s blacklisted downloads' % (site_limits.daily_signups, site_limits.daily_downloads),
+            """
 Blacklist cases downloaded: %s
 User signups: %s
 User emails:
 
 %s
-        """ % (site_limits.daily_downloads, site_limits.daily_signups, "\n".join(users_created_today)),
-        settings.DEFAULT_FROM_EMAIL,
-        [settings.DEFAULT_FROM_EMAIL],
-        fail_silently=False,
-    )
+            """ % (site_limits.daily_downloads, site_limits.daily_signups, "\n".join(users_created_today)),
+            settings.DEFAULT_FROM_EMAIL,
+            [settings.DEFAULT_FROM_EMAIL],
+            fail_silently=False,
+        )
 
     # log status
     print("CAP daily usage report: created %s new users, %s blacklisted cases downloaded" % (site_limits.daily_signups, site_limits.daily_downloads))

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -658,3 +658,4 @@ VALIDATE_EMAIL_SIGNUPS = False
 
 MISSED_CITATIONS_DIR = "/tmp/missed_citations"
 
+SITE_LIMIT_REPORT = False

--- a/capstone/config/settings/settings_pytest.py
+++ b/capstone/config/settings/settings_pytest.py
@@ -8,3 +8,5 @@ SET_CACHE_CONTROL_HEADER = True
 
 # don't waste time on whitenoise for tests
 MIDDLEWARE = [i for i in MIDDLEWARE if not i.startswith('whitenoise.')]
+
+SITE_LIMIT_REPORT = True


### PR DESCRIPTION
I think we want to reset the site limits daily on beta without sending an email about it. This PR conditions the report on a new setting, `SITE_LIMIT_REPORT`, which defaults to `False`. I will make it `True` in production settings.