### PR TITLE
Signup tweaks

### DIFF
--- a/capstone/capapi/models.py
+++ b/capstone/capapi/models.py
@@ -141,7 +141,7 @@ class CapUser(PermissionsMixin, AbstractBaseUser):
             self.save(update_fields=['case_allowance_remaining', 'case_allowance_last_updated'])
 
     def authenticate_user(self, activation_nonce):
-        if self.activation_nonce == activation_nonce and self.nonce_expires + timedelta(hours=24) > timezone.now():
+        if self.is_active and self.activation_nonce == activation_nonce and self.nonce_expires + timedelta(days=3) > timezone.now():
             Token.objects.get_or_create(user=self)
             self.activation_nonce = ''
             self.email_verified = True

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -30,7 +30,7 @@ def send_new_signup_email(request, user):
     token_url = reverse('verify-user', kwargs={'user_id':user.pk, 'activation_nonce': user.get_activation_nonce()}, scheme="https")
     send_mail(
         'Caselaw Access Project: Verify your email address',
-        "Please click here to verify your email address: \n\n%s \n\nIf you believe you have received this message in error, please ignore it." % token_url,
+        "Please click here to verify your email address: \n\n%s \n\nIf you received this message in error, please ignore it." % token_url,
         settings.DEFAULT_FROM_EMAIL,
         [user.email],
         fail_silently=False, )

--- a/capstone/capapi/templates/registration/verified.html
+++ b/capstone/capapi/templates/registration/verified.html
@@ -2,25 +2,22 @@
 
 {% block title %}
   {% if error %}
-    Not Verified&mdash;
+    Not Verified
   {% else %}
-    Verified&mdash;
+    Verified
   {% endif %}
 {% endblock %}
 
-
-{% block meta_description %}Caselaw Access Project: Email Verification{% endblock %}
+{% block meta_description %}Email Verification{% endblock %}
 
 {% block main_content %}
   {% if error %}
     <div class="alert alert-warning">{{ error }}</div>
   {% else %}
     <h4>We've verified your email address.</h4>
-    <p>
-      {{ mailing_list_message }}
-    </p>
-    <p>
-      You can now <a href="{% url "login" %}">log in</a>.
-    </p>
+    {% if mailing_list_message %}
+      <p>{{ mailing_list_message }}</p>
+    {% endif %}
+    <p>You can now <a href="{% url "login" %}">log in</a>.</p>
   {% endif %}
 {% endblock %}

--- a/capstone/capapi/views/viz_views.py
+++ b/capstone/capapi/views/viz_views.py
@@ -22,7 +22,6 @@ def details_view(request):
     jurisdictions = OrderedDict(sorted(jurisdictions.items(), key=lambda t: t[1]['name_long']))
     return render(request, 'data/viz-details.html', {
         "hide_footer": True,
-        'page_name': 'jurisdiction_details',
         'jurisdictions': jurisdictions,
     })
 
@@ -48,7 +47,6 @@ def totals_view(request):
     jurs = OrderedDict(sorted(jurs.items(), key=lambda t: t[1]['name_long']))
     return render(request, 'data/viz-totals.html', {
         "hide_footer": True,
-        'page_name': 'totals',
         'jurisdictions': json.dumps(jurs),
         'data': json.dumps(case_count),
     })

--- a/capstone/capweb/templates/index.html
+++ b/capstone/capweb/templates/index.html
@@ -464,31 +464,13 @@
     <!-- START CONTACT --> <!-- (https://1n.pm/igQ7s) -->
 
     <div class="contact-section m-0 p-0 pb-5 pt-5 bg-yellow">
-      <div class="row d-inline d-md-none">
-        <div class="col-6 pl-0 offset-1">
+      <div class="row">
+        <div class="col-md-3 offset-1 pb-2 follow">
           <h2 class="section-title pt-0 mb-3">
             Contact
           </h2>
-        </div>
-      </div>
-      <div class="row">
-        <div class="col-2 offset-1 d-none d-md-block follow">
           Follow our progress, contribute code, or just say hi!
-        </div>
-        <div class="col-8 offset-1 d-block d-md-none pb-4">
-          <form action="https://law.us3.list-manage.com/subscribe/post?u={{ mailchimp_u }}&amp;id={{ mailchimp_id }}"
-                method="post" id="mc-embedded-subscribe-form-small" name="mc-embedded-subscribe-form-small"
-                class="validate" target="_blank" novalidate>
-            <div style="position: absolute; left: -5000px;" aria-hidden="true">
-              <input type="text" name="b_{{ mailchimp_u }}_{{ mailchimp_id }}" tabindex="-1" value="">
-            </div>
-            <input type="email" name="EMAIL" class="form-control" placeholder="email" required="" title="">
-            <div class="add">Add your email to keep in touch</div>
-            <button class="btn-secondary subscribe" value="Subscribe" name="subscribe" id="mc-embedded-subscribe-small" type="submit">Subscribe!</button>
-          </form>
-        </div>
-        <div class="col-11 col-md-2 offset-1 offset-md-0 ">
-          <div class="social-top d-block d-md-flex justify-content-end">
+          <div class="social-top d-block d-md-flex">
             <span class="twitter">
               <a href="https://twitter.com/caselawaccess" target="_blank"
                  title="Caselaw Access Project Twitter"
@@ -507,21 +489,19 @@
             </span>
           </div>
         </div>
-        <div class="d-none d-md-block col-5 col-md-5 col-lg-3 offset-1 offset-sm-0">
-
+        <div class="col-5 col-md-5 col-lg-3 offset-1">
           <form action="https://law.us3.list-manage.com/subscribe/post?u={{ mailchimp_u }}&amp;id={{ mailchimp_id }}"
                 method="post" id="mc-embedded-subscribe-form-large" name="mc-embedded-subscribe-form-large"
                 class="validate" target="_blank" novalidate>
             <div style="position: absolute; left: -5000px;" aria-hidden="true">
               <input type="text" name="b_{{ mailchimp_u }}_{{ mailchimp_id }}" tabindex="-1" value="">
             </div>
-            <input type="email" name="EMAIL" class="form-control" placeholder="mail" required="" title="">
-            <div class="add">Add your email to keep in touch</div>
+            <label class="add" for="email">Subscribe to Lawvocado, our biweekly email list</label>
+            <input type="email" name="EMAIL" class="form-control" placeholder="email" id="email">
             <button class="btn-secondary subscribe" value="Subscribe" name="subscribe" id="mc-embedded-subscribe-large" type="submit">Subscribe!</button>
           </form>
         </div>
         <div class="col-3 promise pl-5 d-none d-lg-block">
-
           We promise won't spam you, though we might invite you to a hackathon.
         </div>
       </div>

--- a/capstone/capweb/views.py
+++ b/capstone/capweb/views.py
@@ -55,7 +55,6 @@ def index(request):
         'state': state,
         'federal': federal,
         'page_image': 'img/og_image/index.png',
-        'page_name': 'home'
     })
 
 


### PR DESCRIPTION
* User visiting email confirmation link with expired code will be asked if they want to resend.
* User visiting email confirmation link after already being confirmed will be told that they are confirmed instead of seeing an error.
* Increase timeout for confirmation link to 3 days.
* Tweak display of Lawvocado signup form on homepage.

Fixes #1369