### PR TITLE
Re-index once for case body updates and metadata updates & minor case editor change

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1147,7 +1147,7 @@ class CaseMetadata(models.Model):
         return renderer.hydrate_opinions(structure.opinions, blocks_by_id)
 
     def sync_case_body_cache(self, blocks_by_id=None, fonts_by_id=None, labels_by_block_id=None, rerender=True,
-                             save=True):
+                             save=True, reindex=True):
         """
             Update self.body_cache with new values based on the current value of self.structure.
             blocks_by_id and fonts_by_id can be provided for efficiency if updating a bunch of cases from the same volume.
@@ -1192,8 +1192,8 @@ class CaseMetadata(models.Model):
             setattr(body_cache, k, v)
         if save:
             body_cache.save()
-
-        self.reindex()
+        if reindex:
+            self.reindex()
 
     def get_json_from_html(self, html):
         casebody_pq = PyQuery(html)

--- a/capstone/cite/templates/cite/case_editor.html
+++ b/capstone/cite/templates/cite/case_editor.html
@@ -6,7 +6,7 @@
 {% load capweb_static %}
 
 {% block title %}Editing {{ citation_full }}{% endblock %}
-{% block content_title %}{{ citation_full }}{% endblock %}
+{% block content_title %}<a href="{{ case.get_full_frontend_url }}">{{ citation_full }}</a>{% endblock %}
 {% block base_css %}{% stylesheet 'case_editor' %}{% endblock %}
 {% block meta_description %}Editing {{ citation_full|striptags }} from the Caselaw Access Project.{% endblock %}
 {% block main_content_style %}col-12{% endblock %}

--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -211,11 +211,16 @@ def case_editor(request, case_id):
 
         if case_to_save or pages_to_save:
             with EditLog(description='Case %s edited by user %s: %s metadata fields, %s words' % (case.id, request.user.id, metadata_count, word_count)).record():
+                reindex_flag = False
                 if case_to_save:
                     case.save()
+                    reindex_flag = True
                 if pages_to_save:
                     PageStructure.objects.bulk_update(pages_to_save, ['blocks'])
-                    case.sync_case_body_cache(blocks_by_id=PageStructure.blocks_by_id(pages))
+                    case.sync_case_body_cache(blocks_by_id=PageStructure.blocks_by_id(pages), reindex=False)
+                    reindex_flag = True
+                if reindex_flag:
+                    case.reindex()
 
         return HttpResponse('OK')
 


### PR DESCRIPTION
We now re-index Elasticsearch once if we update the case body, metadata, or both. Also made the case editor title a link back to the case viewer.