### PR TITLE
Store canonical cite in ExtractedCitation.normalized_cite; resolve reporters by year

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -110,7 +110,7 @@ class CaseDocument(DocType):
 
     def prepare_docket_numbers(self, instance):
         if not hasattr(instance, 'docket_numbers'):
-            return { 'docket_numbers': None }
+            return {'docket_numbers': None}
         return instance.docket_numbers
 
     def prepare_last_updated(self, instance):

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1389,6 +1389,11 @@ class CaseMetadata(models.Model):
         elision_span = "<span class='elided-text' role='button' tabindex='0' data-hidden-text='%s'>%s</span>"
         return mark_safe(apply_replacements(text, {k: elision_span % (k, v) for k, v in self.no_index_elided.items()}, "", ""))
 
+    def extract_citations(self):
+        # avoid this import until needed, to avoid loading reporters db
+        from scripts.extract_cites import extract_citations
+        return extract_citations(self)
+
 
 class CaseXML(BaseXMLModel):
     metadata = models.OneToOneField(CaseMetadata, blank=True, null=True, related_name='case_xml',

--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -36,7 +36,6 @@ from capdb.models import Reporter, VolumeMetadata, CaseMetadata, Citation, CaseF
 from capweb.helpers import reverse, is_google_bot
 from cite.helpers import geolocate
 from config.logging import logger
-from scripts.extract_cites import extract_citations
 
 
 def safe_redirect(request):
@@ -219,7 +218,7 @@ def case_editor(request, case_id):
 
                     # re-extract citations
                     existing_cites = {c.cite: c for c in ExtractedCitation.objects.filter(cited_by=case)}
-                    new_cites = {c.cite: c for c in extract_citations(case)[0]}
+                    new_cites = {c.cite: c for c in case.extract_citations()[0]}
                     ExtractedCitation.objects.filter(id__in=[v.id for k, v in existing_cites.items() if k not in new_cites]).delete()
                     ExtractedCitation.objects.bulk_create([v for k, v in new_cites.items() if k not in existing_cites])
                 case.save()

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -28,7 +28,7 @@ services:
           - 127.0.0.1:9200:9200
     web:
         build: .
-        image: capstone:0.3.95-9e39db1b3686baafa7ddc9c3e33b2ad1
+        image: capstone:0.3.96-2ad05f9c2ce76cb50220da15cb217cfb
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -98,10 +98,8 @@ elasticsearch-dsl
 django-elasticsearch-dsl
 django-elasticsearch-dsl-drf
 
-
 # Citation extraction
-# reporters_db
-https://github.com/freelawproject/reporters-db/archive/33eb9a405a55a5a3d5619cdd2a47214a6e59460b.zip#egg=reporters_db  # can be dropped after version > 2.0.0 is on pypi
+reporters_db
 
 # Citation pagerank
 networkx

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -827,8 +827,8 @@ regex==2020.7.14 \
     --hash=sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341 \
     --hash=sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7 \
     # via nltk
-https://github.com/freelawproject/reporters-db/archive/33eb9a405a55a5a3d5619cdd2a47214a6e59460b.zip#egg=reporters_db \
-    --hash=sha256:47ae3f524075abb9cdf29bf75bf6227778b05221ff87b1ceb6f76c1d4c5c249d
+reporters-db==2.0.4 \
+    --hash=sha256:22c1986f046266aa9f81f4322de69e32dbaf51eda8207cd6581892924f47a5b2
 reportlab==3.5.13 \
     --hash=sha256:069f684cd0aaa518a27dc9124aed29cee8998e21ddf19604e53214ec8462bdd7 \
     --hash=sha256:09b68ec01d86b4b120456b3f3202570ec96f57624e3a4fc36f3829323391daa4 \
@@ -902,7 +902,7 @@ s3transfer==0.3.3 \
 six==1.12.0 \
     --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
     --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
-    # via aws-sam-translator, bcrypt, cfn-lint, cryptography, django-elasticsearch-dsl-drf, django-extensions, docker, docker-pycreds, drf-yasg, elasticsearch-dsl, fabric3, faker, jsonschema, libsass, mock, more-itertools, moto, packaging, pathlib2, pip-tools, pynacl, pyrsistent, pytest-xdist, python-dateutil, python-jose, responses, swagger-spec-validator, websocket-client
+    # via aws-sam-translator, bcrypt, cfn-lint, cryptography, django-elasticsearch-dsl-drf, django-extensions, docker, docker-pycreds, drf-yasg, elasticsearch-dsl, fabric3, faker, jsonschema, libsass, mock, more-itertools, moto, packaging, pathlib2, pip-tools, pynacl, pyrsistent, pytest-xdist, python-dateutil, python-jose, reporters-db, responses, swagger-spec-validator, websocket-client
 soupsieve==1.7.3 \
     --hash=sha256:466910df7561796a60748826781ebe9a888f7a1668a636ae86783f44d10aae73 \
     --hash=sha256:87db12ae79194f0ff9808d2b1641c4f031ae39ffa3cab6b907ea7c1e5e5ed445 \

--- a/capstone/scripts/extract_cites.py
+++ b/capstone/scripts/extract_cites.py
@@ -1,43 +1,131 @@
 import re
+from collections import defaultdict
+from datetime import datetime
 from string import ascii_lowercase
-
-from reporters_db import EDITIONS, VARIATIONS_ONLY
 
 from capapi.resources import cite_extracting_regex
 from capdb.models import ExtractedCitation, normalize_cite
 
 
-extra_reporters = {'wl'}
-valid_reporters = {normalize_cite(c) for c in list(EDITIONS.keys()) + list(VARIATIONS_ONLY.keys())} | extra_reporters
-invalid_reporters = set(ascii_lowercase) | {'at', 'or', 'p.', 'c.', 'B'}
-translations = {'la.': 'Ia.', 'Yt.': 'Vt.', 'Pae.': 'Pac.'}
+def get_editions(REPORTERS=None):
+    """
+        Process REPORTERS into a lookup dict from reporter string or normalized reporter string to edition data.
+
+        Given:
+        >>> REPORTERS = {
+        ...     'Foo': [
+        ...         {
+        ...             'editions': {
+        ...                 'Foo': {"start": datetime(1900, 1, 1), "end": datetime(1910, 1, 1)},
+        ...                 'Foo 2d.': {"start": datetime(1910, 1, 1), "end": None},
+        ...             },
+        ...             'variations': {
+        ...                 'foo': 'Foo',
+        ...                 'Food': 'Foo',
+        ...             }
+        ...         },
+        ...         {
+        ...             'editions': {
+        ...                 'Foo': {"start": datetime(1800, 1, 1), "end": datetime(1810, 1, 1)},
+        ...             },
+        ...             'variations': {
+        ...                 'foo': 'Foo',
+        ...                 'Fool': 'Foo',
+        ...             }
+        ...         },
+        ...     ]
+        ... }
+
+        Each reporter string maps to its possible resolutions, sorted in reverse-end-date order:
+        >>> editions = get_editions(REPORTERS)
+        >>> foo1 = {'reporter': 'Foo', 'start_year': 1900, 'end': datetime(1910, 1, 1)}
+        >>> foo2d = {'reporter': 'Foo 2d.', 'start_year': 1910, 'end': datetime(9999, 1, 1)}
+        >>> foo2 = {'reporter': 'Foo', 'start_year': 1800, 'end': datetime(1810, 1, 1)}
+        >>> assert editions == {
+        ...     'Foo': [foo1, foo2],
+        ...     'foo': [foo1, foo2],
+        ...     'Foo 2d.': [foo2d],
+        ...     'foo2d': [foo2d],
+        ...     'Food': [foo1],
+        ...     'food': [foo1],
+        ...     'Fool': [foo2],
+        ...     'fool': [foo2],
+        ... }
+    """
+    if REPORTERS is None:
+        from reporters_db import REPORTERS
+    editions = defaultdict(list)
+    not_ended_date = datetime(9999, 1, 1)
+    unknown_start_date = datetime(1750, 1, 1)
+
+    def append(k, v):
+        for key in (k, normalize_cite(k)):
+            if v not in editions[key]:
+                editions[key].append(v)
+
+    for reporter_cluster in REPORTERS.values():
+        for reporter in reporter_cluster:
+            local_editions = {}
+            for k, v in reporter["editions"].items():
+                local_editions[k] = edition = {
+                    'reporter': k,
+                    'start_year': 0 if v['start'] == unknown_start_date else v['start'].year,
+                    'end': v['end'] or not_ended_date,
+                }
+                append(k, edition)
+            for k, v in reporter["variations"].items():
+                append(k, local_editions[v])
+
+    # sort candidates for each string: first prefer exact matches, then editions that ended more recently
+    for edition_key, candidates in editions.items():
+        candidates.sort(reverse=True, key=lambda c: (c['reporter'] == edition_key, c['end']))
+
+    return editions
+
+
+# set up reporter lookup tables
+EDITIONS = get_editions()
+INVALID_REPORTERS = set(ascii_lowercase) | {'at', 'or', 'p.', 'c.', 'B'}
+TRANSLATIONS = {'la.': 'Ia.', 'Yt.': 'Vt.', 'Pae.': 'Pac.'}
 
 
 def extract_citations(case):
-    misses = []
+    misses = defaultdict(lambda: defaultdict(int))
     case_citations = []
+    case_year = case.decision_date.year
     for match in set(re.findall(cite_extracting_regex, case.body_cache.text)):
         vol_num, reporter_str, page_num = match
 
         # fix known OCR errors
-        if reporter_str in translations:
-            reporter_str = translations[reporter_str]
+        if reporter_str in TRANSLATIONS:
+            reporter_str = TRANSLATIONS[reporter_str]
 
         # skip strings like 'or' that are known non-citations
-        if reporter_str in invalid_reporters:
-            misses.append(reporter_str)
+        if reporter_str in INVALID_REPORTERS:
+            misses['blocked'][reporter_str] += 1
             continue
 
         # Look for found reporter string in the official and nominative REPORTER dicts
-        if normalize_cite(reporter_str) not in valid_reporters:
+        # Try exact match, then normalized match
+        candidates = EDITIONS.get(reporter_str) or EDITIONS.get(normalize_cite(reporter_str))
+        if not candidates:
             # reporter not found, removing cite and adding to misses list
-            misses.append(reporter_str)
+            misses['not_found'][reporter_str] += 1
+            continue
+
+        # Find a candidate reporter that was in operation prior to this case being published.
+        # Reporters are sorted by end date, so this will prefer newer reporters.
+        best_candidate = next((c for c in candidates if c['start_year'] <= case_year), None)
+        if not best_candidate:
+            misses['invalid_date'][reporter_str] += 1
             continue
 
         cite = " ".join(match)
+        normalized_cite = "%s %s %s" % (vol_num, best_candidate['reporter'], page_num)
+
         case_citations.append(ExtractedCitation(
             cite=cite,
-            normalized_cite=normalize_cite(cite),
+            normalized_cite=normalize_cite(normalized_cite),
             cited_by=case,
             reporter_name_original=reporter_str,
             volume_number_original=vol_num,


### PR DESCRIPTION
This uses some additional information from reporters_db to make better matches between cases and the cases they cite. Reporters_db looks something like this:

```
    "A.": [
        {
            "editions": {
                "A.": {
                    "end": "1938-12-31T00:00:00",
                    "start": "1885-01-01T00:00:00"
                },
                "A.2d": {
                    "end": "2010-12-31T00:00:00",
                    "start": "1938-01-01T00:00:00"
                },
                "A.3d": {
                    "end": null,
                    "start": "2010-01-01T00:00:00"
                }
            },
            ...
            "variations": {
                "A. 2d": "A.2d",
                "A. 3d": "A.3d",
                "A.R.": "A.",
                "A.Rep.": "A.",
                "At.": "A.",
                "Atl.": "A.",
                "Atl.2d": "A.2d",
                "Atl.R.": "A.",
                "Atl. Rep.": "A."
            }
        }
...
```

In this PR, when we see something like "123 Atl.R. 456" when extracting citations, we store normalized cite as `123a456`, so we can match it correctly to a case we have stored under `123 A. 456`. And, we only consider reporter candidates to be valid if their `"start"` date is before the decision_date of the case the cite is being extracted from.