### PR TITLE
Update Elasticsearch to version 7

### DIFF
--- a/capstone/capapi/pagination.py
+++ b/capstone/capapi/pagination.py
@@ -120,7 +120,7 @@ class ESPaginatorMixin:
         :return:
         """
         __data = [
-            ('count', self.count),
+            ('count', self.count['value']),
             ('next', self.get_next_link()),
             ('previous', self.get_previous_link()),
         ]

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     redis:
         image: redis:4
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:6.8.11
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.8.1
         environment:
           - node.name=es01
           - bootstrap.memory_lock=true
@@ -28,7 +28,7 @@ services:
           - 127.0.0.1:9200:9200
     web:
         build: .
-        image: capstone:0.3.99-021adf544e37bdb4b5923e54886ef700
+        image: capstone:0.3.100-0b5f618351abdc3543b1e8f19bb50b13
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -82,7 +82,7 @@ celery[redis,sqs]==4.3.0 \
 certifi==2018.11.29 \
     --hash=sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7 \
     --hash=sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033 \
-    # via requests
+    # via elasticsearch, requests
 cffi==1.11.5 \
     --hash=sha256:151b7eefd035c56b2b2e1eb9963c90c6302dc15fbd8c1c0a83a163ff2c7d7743 \
     --hash=sha256:1553d1e99f035ace1c0544050622b7bc963374a00c467edafac50ad7bd276aef \
@@ -253,12 +253,12 @@ django-compressor==2.2 \
     # via django-libsass
 django-db-file-storage==0.5.3 \
     --hash=sha256:67bc53a789fbec24eb92fd35797f0b2cf3674d2e036bdf7c3ebeb2b34b87424f
-django-elasticsearch-dsl-drf==0.20.3 \
-    --hash=sha256:293e8b26239a14b49de419d3cd2df5ec7b472278477afed93e16c5df81f7e812 \
-    --hash=sha256:d28ef4ac1171c2d0d59dbcdabb30eb41c1536d1dbf274c8915e203538a6206f4
-django-elasticsearch-dsl==6.4.2 \
-    --hash=sha256:ba043005eca1647d3f48b9e60d760c2b4daf886cbaa9312e658592b59ab57be2 \
-    --hash=sha256:e0aa448efd751909a40dfebad67d0206d37a15777ee455bbde63630f1eaa636a
+django-elasticsearch-dsl-drf==0.20.8 \
+    --hash=sha256:90bf300fb96ebac5cb0b3fa21601e37f1b1231a57aac4b5a001a11c52db59d74 \
+    --hash=sha256:9effbd541bb25becb39454b694de20d0f5a2c9e5bf7b629fcd8f9c9505b9320a
+django-elasticsearch-dsl==7.1.4 \
+    --hash=sha256:5bbd49a9acb51c08fbbb7fba9beee7c9ce73b481af718cc57e4c8ac3d561888f \
+    --hash=sha256:e733ccfd0e8b83ad6896d812a2c15ccbd563caf4ebf30fd31640538ad2de8e26
 django-extensions==2.1.4 \
     --hash=sha256:8317a3fe479b1ba3e3a04ecf33fb8d6ccf09bb18f30eab64e34c40a593741d26 \
     --hash=sha256:a76a61566f1c8d96acc7bcf765080b8e91367a25a2c6f8c5bddd574493839180
@@ -273,9 +273,9 @@ django-libsass==0.7 \
     --hash=sha256:49db3334b87e1f7955c4f9fb9945bc296f8bfd27a14d6d89706e4b0e5dc5de1c
 https://github.com/jcushman/django-model-utils/archive/f2e97e41418788c81ee8e5ab1cec37ecff65a003.zip#egg=django-model-utils \
     --hash=sha256:e52b087de48c8ca8406304fd26a79de3fd2cb94d7b30f92cb3d0542dd579cc03
-django-nine==0.2.2 \
-    --hash=sha256:6364ae029da6b801fe7dcf9cdbdffb714a9bf0b95c8594f827032f19f99db198 \
-    --hash=sha256:a58fda1d24781086025018d1c85d7a1a8e2ae99aa6a8a7e0f4fe16a582f13480 \
+django-nine==0.2.3 \
+    --hash=sha256:394c043668f820f50d1f7b27009b4957f9f480a7ecf74f55a6699b80ac6e1f69 \
+    --hash=sha256:f09fa5870ea2b0d86c03249c9c574c9b14c7e81b05dd860e9ef9c656740892cc \
     # via django-elasticsearch-dsl-drf
 django-pipeline==1.6.14 \
     --hash=sha256:b56f2cfdb113dc1cb05257d8eb8d145fc0ade6f0d1236fb425df15bd059dce15 \
@@ -323,12 +323,12 @@ ecdsa==0.13.3 \
     --hash=sha256:163c80b064a763ea733870feb96f9dd9b92216cfcacd374837af18e4e8ec3d4d \
     --hash=sha256:9814e700890991abeceeb2242586024d4758c8fc18445b194a49bd62d85861db \
     # via python-jose, sshpubkeys
-elasticsearch-dsl==6.4.0 \
-    --hash=sha256:26416f4dd46ceca43d62ef74970d9de4bdd6f4b0f163316f0b432c9e61a08bec \
-    --hash=sha256:f60aea7fd756ac1fbe7ce114bbf4949aefbf495dfe8896640e787c67344f12f6
-elasticsearch==6.3.1 \
-    --hash=sha256:7546cc08e3899716e12fe67d12d7cfe9a64647014d1134b014c3c392b63cad42 \
-    --hash=sha256:aada5cfdc4a543c47098eb3aca6663848ef5d04b4324935ced441debc11ec98b \
+elasticsearch-dsl==7.2.1 \
+    --hash=sha256:1e345535164cb684de4b825e1d0daf81b75554b30d3905446584a9e4af0cc3e7 \
+    --hash=sha256:593c01822a03e3e84b87753c78edb833f4b2bfafcd52089841bd8f99b7e74ccd
+elasticsearch==7.8.1 \
+    --hash=sha256:2ffbd746fc7d2db08e5ede29c822483705f29c4bf43b0875c238637d5d843d44 \
+    --hash=sha256:92b534931865a186906873f75ae0b91808ff5036b0f2b9269eb5f6dc09644b55 \
     # via django-elasticsearch-dsl-drf, elasticsearch-dsl
 https://github.com/jcushman/email-normalize/archive/6b5088bd05de247a9a33ad4e5c7911b676d6daf2.zip#egg=email-normalize \
     --hash=sha256:366bdd6870b59aee8bf7aed1e22533eb0ceb78d008513a7add9098311cc2a97a
@@ -766,9 +766,9 @@ pytest-xdist==1.32.0 \
 pytest==6.0.1 \
     --hash=sha256:85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4 \
     --hash=sha256:8b6007800c53fdacd5a5c192203f4e531eb2a1540ad9c752e052ec0f7143dbad
-python-dateutil==2.7.5 \
-    --hash=sha256:063df5763652e21de43de7d9e00ccf239f953a832941e37be541614732cdfc93 \
-    --hash=sha256:88f9287c0174266bb0d8cedd395cfba9c58e87e5ad86b2ce58859bc11be3cf02 \
+python-dateutil==2.8.1 \
+    --hash=sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c \
+    --hash=sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a \
     # via botocore, elasticsearch-dsl, faker, moto
 python-jose==2.0.2 \
     --hash=sha256:391f860dbe274223d73dd87de25e4117bf09e8fe5f93a417663b1f2d7b591165 \
@@ -899,10 +899,10 @@ s3transfer==0.3.3 \
     --hash=sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13 \
     --hash=sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db \
     # via boto3
-six==1.12.0 \
-    --hash=sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c \
-    --hash=sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73 \
-    # via aws-sam-translator, bcrypt, cfn-lint, cryptography, django-elasticsearch-dsl-drf, django-extensions, docker, docker-pycreds, drf-yasg, elasticsearch-dsl, fabric3, faker, jsonschema, libsass, mock, more-itertools, moto, packaging, pathlib2, pip-tools, pynacl, pyrsistent, pytest-xdist, python-dateutil, python-jose, reporters-db, responses, swagger-spec-validator, websocket-client
+six==1.15.0 \
+    --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
+    --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced \
+    # via aws-sam-translator, bcrypt, cfn-lint, cryptography, django-elasticsearch-dsl, django-elasticsearch-dsl-drf, django-extensions, docker, docker-pycreds, drf-yasg, elasticsearch-dsl, fabric3, faker, jsonschema, libsass, mock, more-itertools, moto, packaging, pathlib2, pip-tools, pynacl, pyrsistent, pytest-xdist, python-dateutil, python-jose, reporters-db, responses, swagger-spec-validator, websocket-client
 soupsieve==1.7.3 \
     --hash=sha256:466910df7561796a60748826781ebe9a888f7a1668a636ae86783f44d10aae73 \
     --hash=sha256:87db12ae79194f0ff9808d2b1641c4f031ae39ffa3cab6b907ea7c1e5e5ed445 \


### PR DESCRIPTION
Note: this code is not compatible with ES6, so for production it requires doing a `fab rebuild_search_index` against ES7.

Marking as draft until Ben is ready to do that.