### PR TITLE
Add view to admin to summarize volume task outcomes

### DIFF
--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -19,7 +19,7 @@ from capdb.models import *
 
 ### HELPERS ###
 
-def run_task_for_volumes(task, volumes=None, last_run_before=None, synchronous=False, **kwargs):
+def run_task_for_volumes(task, volumes=None, last_run_before=None, **kwargs):
     """
         Run the given celery task for the given queryset of volumes, or all volumes if not specified.
         If last_run_before is provided as an ISO timestamp, volumes will only be run if volume.task_statuses indicates that

--- a/capstone/capdb/templates/admin/capdb/volumemetadata/change_list.html
+++ b/capstone/capdb/templates/admin/capdb/volumemetadata/change_list.html
@@ -1,0 +1,7 @@
+{% extends "admin/change_list.html" %} {% load i18n %}
+{% block object-tools-items %}
+    <li>
+        <a class="historylink" href="task_statuses/">Task statuses</a>
+    </li>
+    {{ block.super }}
+{% endblock %}

--- a/capstone/capdb/templates/admin/capdb/volumemetadata/task_statuses.html
+++ b/capstone/capdb/templates/admin/capdb/volumemetadata/task_statuses.html
@@ -1,0 +1,24 @@
+{% extends "admin/base_site.html" %}
+{% block content %}
+  <h1></h1>
+  <ul>
+    {% for task, status in statuses %}
+      <li>
+        {{ task }}
+        <ul>
+          {% if status.success %}
+            <li>successes: {{ status.success }}, most recent {{ status.last_success }}</li>
+          {% endif %}
+          {% if status.error %}
+            <li>
+              errors: {{ status.error }}, most recent {{ status.last_error }}
+              <ul>
+                <li>{{ status.error_message }}</li>
+              </ul>
+            </li>
+          {% endif %}
+        </ul>
+      </li>
+    {% endfor %}
+  </ul>
+{% endblock %}


### PR DESCRIPTION
Add a button under the Volumes admin screen to see a summary of the outcomes for all per-volume background tasks that have been run.

![image](https://user-images.githubusercontent.com/376272/89904606-24231b00-dbb7-11ea-9f45-a7f937142571.png)

![image](https://user-images.githubusercontent.com/376272/89904609-25544800-dbb7-11ea-9430-a6954bd55ce6.png)
