### PR TITLE
Fix date fields

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -50,7 +50,7 @@ class CaseDocument(DocType):
     decision_date_original = fields.KeywordField()
     docket_numbers = fields.TextField(multi=True)
     docket_number = fields.TextField()
-    last_updated = fields.DateField()
+    last_updated = fields.KeywordField()
 
     volume = fields.ObjectField(properties={
         "barcode": fields.KeywordField(),

--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -164,8 +164,8 @@ class CaseFilter(filters.FilterSet):
     name = filters.CharFilter(label='Full Name (contains)')
     jurisdiction = filters.ChoiceFilter(choices=jur_choices)
     reporter = filters.ChoiceFilter(choices=reporter_choices, label='Reporter Series')
-    decision_date_min = filters.CharFilter(label='Earliest Decision Date (Format YYYY-MM-DD)')
-    decision_date_max = filters.CharFilter(label='Latest Decision Date (Format YYYY-MM-DD)')
+    decision_date__gte = filters.CharFilter(label='Earliest Decision Date (Format YYYY-MM-DD)')
+    decision_date__lte = filters.CharFilter(label='Latest Decision Date (Format YYYY-MM-DD)')
     docket_number = filters.CharFilter(label='Docket Number (contains)')
     court = filters.ChoiceFilter(choices=court_choices)
     court_id = filters.NumberFilter(label='Court ID')
@@ -191,8 +191,8 @@ class CaseFilter(filters.FilterSet):
         ),
     )
     page_size = filters.NumberFilter(label='Results per page (1 to 10,000; default 100)')
-    last_updated_min = filters.CharFilter(label='last_updated greater than or equal to this prefix')
-    last_updated_max = filters.CharFilter(label='last_updated less than or equal to this prefix')
+    last_updated__gte = filters.CharFilter(label='last_updated greater than or equal to this prefix')
+    last_updated__lte = filters.CharFilter(label='last_updated less than or equal to this prefix')
 
 
 class CaseFilterBackend(FilteringFilterBackend, RestFrameworkFilterBackend):


### PR DESCRIPTION
* For the API viewer, use `decision_date__lte`, `decision_date__gte`, `last_updated__lte`, `last_updated__gte` instead of the deprecated `_min` and `_max` suffixes
* For the Elasticsearch index, change the type of `last_updated` from Date to Keyword so prefix searches will work as expected.

The latter requires a rebuild as opposed to populate, so maybe that means cutting over to beta?