### PR TITLE
Update body cache when saving case with changed redactions

### DIFF
--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -141,18 +141,19 @@ def api_reverse(viewname, args=None, kwargs=None, request=None, format=None, **e
 
 def apply_replacements(item, replacements, prefix="[ ", suffix=" ]"):
     """ filters out terms in 'item' with the {'original_text': and 'replacement_text' }
-    >>> apply_replacements("Hello, what's your name?", {'name': 'game', 'Hello': 'Wow'})
+    >>> apply_replacements("Hello, what's your name?", (('name', 'game'), ('Hello', 'Wow')))
     "[ Wow ], what's your [ game ]?"
 
-    >>> apply_replacements({"test": "Hello, what's your name?" }, {'name': 'game', 'Hello': 'Wow'})
+    >>> apply_replacements({"test": "Hello, what's your name?" }, (('name', 'game'), ('Hello', 'Wow')))
     {'test': "[ Wow ], what's your [ game ]?"}
     """
 
     if not replacements:
         return item
+    replacements = list(replacements)
 
     if isinstance(item, str):
-        for replacement in replacements.items():
+        for replacement in replacements:
             item = item.replace(replacement[0], prefix + replacement[1] + suffix)
     elif isinstance(item, list):
         item = [apply_replacements(inner_item, replacements) for inner_item in item]

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1014,6 +1014,8 @@ class CaseMetadata(models.Model):
             self.decision_date = parse_decision_date(self.decision_date_original)
         if self.in_scope != self.get_in_scope():
             self.in_scope = not self.in_scope
+        if self.tracker.has_changed('no_index_redacted'):
+            self.sync_case_body_cache()
         super().save(*args, **kwargs)
 
     def full_cite(self):
@@ -1196,6 +1198,7 @@ class CaseMetadata(models.Model):
         changed = False
         for k in ['text', 'html', 'xml', 'json']:
             new_val = locals()[k]
+            new_val = self.redact_obj(new_val)
             old_val = getattr(body_cache, k)
             if new_val != old_val:
                 setattr(body_cache, k, new_val)
@@ -1427,14 +1430,16 @@ class CaseMetadata(models.Model):
     def redact_obj(self, text):
         if not self.no_index_redacted:
             return text
-        return apply_replacements(text, self.no_index_redacted)
+        replacements = sorted(self.no_index_redacted.items(), reverse=True, key=lambda i: len(i[0]))
+        return apply_replacements(text, replacements)
 
     def elide_obj(self, text):
         text = self.redact_obj(text)
         if not self.no_index_elided:
             return text
         elision_span = "<span class='elided-text' role='button' tabindex='0' data-hidden-text='%s'>%s</span>"
-        return mark_safe(apply_replacements(text, {k: elision_span % (k, v) for k, v in self.no_index_elided.items()}, "", ""))
+        replacements = sorted(self.no_index_elided.items(), reverse=True, key=lambda i: len(i[0]))
+        return mark_safe(apply_replacements(text, [(k, elision_span % (k, v)) for k, v in replacements], "", ""))
 
     def extract_citations(self):
         # avoid this import until needed, to avoid loading reporters db

--- a/capstone/capdb/tests/test_models.py
+++ b/capstone/capdb/tests/test_models.py
@@ -171,6 +171,15 @@ def test_withdraw_case(case_factory):
     assert 'This case was withdrawn and replaced' in withdrawn.body_cache.html
     assert 'This case was withdrawn and replaced' in withdrawn.body_cache.xml
 
+
+@pytest.mark.django_db
+def test_redact_case(case_factory):
+    case = case_factory(body_cache__text="foo bar baz boo")
+    case.no_index_redacted = {"Case text": "bar", "Case text 0": "foo"}
+    case.save()
+    assert case.body_cache.text.replace('\n', '') == '[ foo ][ bar ] 1[ bar ] 2[ bar ] 3'
+
+
 @pytest.mark.django_db
 def test_update_frontend_urls(case_factory, django_assert_num_queries):
     case1 = case_factory(citations__cite="123 Test 456", volume__volume_number="123", citations__type="official")

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -219,7 +219,6 @@ def test_update_case_frontend_url_bad_cite(case):
     assert case.frontend_url == "/%s/%s/%s/%s/" % (case.reporter.short_name_slug, case.volume.volume_number, case.first_page, citation.case_id)
 
 
-
 @pytest.mark.django_db
 def test_redact_id_numbers(case_factory):
     # redact some numbers
@@ -238,15 +237,15 @@ def test_redact_id_numbers(case_factory):
     assert case.no_index_redacted == {'123 — 45 — 6789': 'XXX — XX — XXXX', '123-45-6789': 'XXX-XX-XXXX', 'foo': 'bar'}
 
     # test A-numbers
+    case.no_index_redacted = {}
+    case.save()
     case.body_cache.text="""
         A12345678  # 8 digit A-number
         A123456789  # 9 digit A-number
         A-12345678  # 8 digit A-number with hyphen
         A — 123456789  # 9 digit A-number with mdash and spaces
     """
-    case.no_index_redacted = {}
     case.body_cache.save()
-    case.save()
     fabfile.redact_id_numbers()
     case.refresh_from_db()
     assert case.no_index_redacted == {


### PR DESCRIPTION
When saving a case where no_index_redacted has changed, update body_cache text to match the new redactions.

Also apply redactions and elisions from longest to shortest to correctly handle redactions where one target is a substring of another.