### PR TITLE
Looser regex to detect a-numbers

### DIFF
--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -70,10 +70,9 @@ def remove_id_number_in_volume(self, volume_id):
     # patterns to replace
     regexes = [
         # a-number
-        r'\bA *[-—] *\d{8,9}\b',
-        r'\bA\d{8,9}\b',
+        r'\bA(?:[ \-—]*\d){8,9}\b',
         # ssn
-        r'\b\d{3} *[-—] *\d{2} *[-—] *\d{4}\b',
+        r'\b\d{3} *[\-—] *\d{2} *[\-—] *\d{4}\b',
         r'\b\d{3} +\d{2} +\d{4}\b',
     ]
 

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -244,6 +244,7 @@ def test_redact_id_numbers(case_factory):
         A123456789  # 9 digit A-number
         A-12345678  # 8 digit A-number with hyphen
         A — 123456789  # 9 digit A-number with mdash and spaces
+        A — 1 -2- 3 45-67  8--9  # just why
     """
     case.body_cache.save()
     fabfile.redact_id_numbers()
@@ -253,6 +254,7 @@ def test_redact_id_numbers(case_factory):
         'A — 123456789': 'A — XXXXXXXXX',
         'A123456789': 'AXXXXXXXXX',
         'A-12345678': 'A-XXXXXXXX',
+        'A — 1 -2- 3 45-67  8--9': 'A — X -X- X XX-XX  X--X',
     }
 
 


### PR DESCRIPTION
We redact "alien registration numbers", AKA A-numbers, which typically look like `A-12345678` or `A123456789`: an "A" followed by an optional hyphen followed by 8 or 9 numbers.

Following a user report, we learned that courts sometimes add additional spaces and hyphens at random. Here is a list of some confirmed patterns for A-numbers in our cases:

```
AXXX XXX XXX
AXX XXX XXX
AXX-XXX-XXX
A XX XXX XXX
A XXX XXX XXX
AXXXXXXXX
AXXX-XXX-XXX
A XX-XXX-XXX
AXXXXX-XXX
AXX-XXXXXX
A-XXXXXXXX
AXXXXXXXXX
A-XX-XXX-XXX
AXXX-XXXXXX
A XXXXXXXX
AXXXXXX-XXX
AXX-XXXX-XXX
A XXX-XXX-XXX
A-XX XXX XXX
A-XXXXXXXXX
AXXXXXX XXX
AXX XXXX XXX
AXXXXX XXX
A XX XX X XXX
AXX-XXX XXX
AX XX XXX XXX
AXX XXX-XXX
AXX-XXX-XXXX
AXX-XXX-X XX
AXXX XXX XX
AXX XXXXXX
A XX XXX XX X
AXX- XXX-XXX
AXXX XX XXX
A XX- XXX-XXX
AXXX-XXX XXX
AXXX- XXX-XXX
A X XX XXX XXX
AXXX XXX-XXX
A XX-XXX- XXX
AXX XXX X XXX
A XX XXXXXX
```

This PR therefore broadens the redaction regex to include an A followed by 8 or 9 digits mixed with any number of spaces and hyphens.

In addition to redacting 15 or 20 thousand A-numbers, the new regex will redact several thousand cases for false positives, such as `AXXXX-XXXXX` and `A-XXXXXX-XX` (lower court docket numbers) and `AXXXX-XXXX` (trial record page ranges). This seems acceptable.

For future reference, to dump potential matches:

`\copy (SELECT metadata_id, regexp_matches(text, '\yA(?:[ \-]*\d){8,9}\y', 'g') from capdb_casebodycache where text ~ '\yA(?:[ \-]*\d){8,9}\y') to '/foo/bar/templates.csv' with csv`

To print counts and samples for each pattern:

```
import csv
from collections import defaultdict
import re
lines = list(csv.reader(open('/foo/bar/templates.csv')))
lines = [[a, b.replace('{','').replace('}','').replace('"', '')] for a, b in lines]
groups = defaultdict(list)
for l in lines:
    groups[re.sub(r'\d', 'X', l[1])].append(l)
groups = sorted(groups.items(), reverse=True, key=lambda i: len(i[1]))
for template, pairs in groups:
    print(template, len(pairs))
    for case_id, anum in pairs[:3]:
        case = CaseMetadata.objects.get(pk=case_id)
        text = case.body_cache.text
        context = re.search(r'.{,30}%s.{,30}' % re.escape(anum), text)
        print(f"\t{case_id}: {case.get_full_frontend_url()} {context[0]}")
```