### PR TITLE
Analysis sorting

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -24,6 +24,7 @@ def lazy_choices(queryset, id_attr, label_attr):
 jur_choices = lazy_choices(models.Jurisdiction.objects.all(), 'slug', 'name_long')
 court_choices = lazy_choices(models.Court.objects.all(), 'slug', 'name')
 reporter_choices = lazy_choices(models.Reporter.objects.all(), 'id', 'short_name')
+analysis_fields = ['word_count', 'char_count', 'ocr_confidence', 'pagerank.percentile', 'pagerank.raw', 'simhash', 'sha256', 'cardinality']
 
 
 class NoopMixin():
@@ -180,7 +181,7 @@ class CaseFilter(filters.FilterSet):
     cites_to = filters.CharFilter(label='Cases citing to citation (citation or case id)')
     ordering = filters.ChoiceFilter(
         label='Sort order',
-        choices=(
+        choices=[
             ('', 'Relevance, then decision date (default)'),
             ('decision_date', 'Decision date'),
             ('-decision_date', 'Reverse decision date'),
@@ -188,7 +189,8 @@ class CaseFilter(filters.FilterSet):
             ('-name_abbreviation', 'Reverse name abbreviation'),
             ('id', 'id'),
             ('-id', 'Reverse id'),
-        ),
+            ('', '--- Analysis fields ---')
+        ]+[choice for field in analysis_fields for choice in [[f'analysis.{field}', field], [f'-analysis.{field}', f'Reverse {field}']]],
     )
     page_size = filters.NumberFilter(label='Results per page (1 to 10,000; default 100)')
     last_updated__gte = filters.CharFilter(label='last_updated greater than or equal to this prefix')

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -14,7 +14,7 @@ from django.http import HttpResponseRedirect, FileResponse, HttpResponseBadReque
 from capapi import serializers, filters, permissions, renderers as capapi_renderers
 from capapi.documents import CaseDocument, RawSearch
 from capapi.filters import CAPOrderingFilterBackend, CaseFilterBackend, MultiFieldFTSFilter, \
-    NameFTSFilter, NameAbbreviationFTSFilter, DocketNumberFTSFilter
+    NameFTSFilter, NameAbbreviationFTSFilter, DocketNumberFTSFilter, analysis_fields
 from capapi.pagination import CapESCursorPagination
 from capapi.serializers import CaseDocumentSerializer
 from capapi.middleware import add_cache_header
@@ -101,7 +101,7 @@ class CaseDocumentViewSet(BaseDocumentViewSet):
         'cites_to': 'extractedcitations.normalized_cite',
         'decision_date': 'decision_date_original',
         'last_updated': 'last_updated',
-        **{'analysis.'+k: 'analysis.'+k for k in ['word_count', 'char_count', 'ocr_confidence', 'pagerank.percentile', 'pagerank.raw', 'simhash', 'sha256', 'cardinality']},
+        **{'analysis.'+k: 'analysis.'+k for k in analysis_fields},
         # legacy fields:
         'decision_date_min': {'field': 'decision_date_original', 'default_lookup': 'gte'},
         'decision_date_max': {'field': 'decision_date_original', 'default_lookup': 'lte'},
@@ -111,9 +111,11 @@ class CaseDocumentViewSet(BaseDocumentViewSet):
     # Define ordering fields
     ordering_fields = {
         'relevance': '_score',
-        'decision_date': 'decision_date',
+        'decision_date': 'decision_date_original',
         'name_abbreviation': 'name_abbreviation.raw',
         'id': 'id',
+        'last_updated': 'last_updated',
+        **{'analysis.' + k: 'analysis.' + k for k in analysis_fields},
     }
     # Specify default ordering. Relevance is a synonym for score, so we reverse it. It's reversed in the user-specified
     # ordering backend.

--- a/capstone/capweb/templates/changelog.md
+++ b/capstone/capweb/templates/changelog.md
@@ -8,6 +8,13 @@ explainer: If our data or user-facing research features change in significant wa
 top_section_style: bg-black
 row_style: bg-tan
 
+# August 28, 2020
+
+**API:**
+
+* Cases Endpoint:
+    * Allow `ordering` by analysis fields.
+
 # August 2020
 
 **API:**

--- a/capstone/capweb/templates/index.html
+++ b/capstone/capweb/templates/index.html
@@ -63,7 +63,8 @@
           <img alt="" aria-hidden="true" src='{% static "img/magenta-arrow-right.svg" %}'>
         </div>
         <div class="col-8 col-md-3 col-sm-10 offset-1 offset-lg-0">
-          <h2 class="section-title p-0 pt-4 pt-md-3 pt-xl-0 mb-0 mb-md-2">
+          {# "section-dive-in" is the target for the map skiplink -- update skiplink if changing id or order #}
+          <h2 id="section-dive-in" class="section-title p-0 pt-4 pt-md-3 pt-xl-0 mb-0 mb-md-2">
             Dive in!
           </h2>
           <div class="section-subtitle d-none d-md-block">

--- a/capstone/capweb/templates/main_base.html
+++ b/capstone/capweb/templates/main_base.html
@@ -69,7 +69,7 @@
   <body class="hamburger-menu-closed" tabindex="-1">
 
     {% include "includes/nav.html" %}
-    <div id="content-and-footer">
+    <div id="content-and-footer" tabindex="-1">
       <main class="all-content flex-xl-nowrap {% block all_content_style %}{% endblock %}" id="main">
         {% block content %}{% endblock content %}
       </main>


### PR DESCRIPTION
Allow sorting of API results by analysis fields. E.g. sort by case length with `ordering=analysis.word_count`.

Also in this PR -- HTML tweak to fix a bug where page couldn't be scrolled with arrow keys, and to fix skiplink on homepage.