### PR TITLE
Update analysis text types

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -110,7 +110,10 @@ class CaseDocument(DocType):
         }),
     })
 
-    analysis = fields.ObjectField()
+    analysis = fields.ObjectField(properties={
+        'sha256': fields.KeywordField(),
+        'simhash': fields.KeywordField(),
+    })
 
     def prepare_frontend_pdf_url(self, instance):
         return instance.get_pdf_url(with_host=False)


### PR DESCRIPTION
Analysis text fields have to be KeywordField to allow sorting. This will require a full ES index rebuild at some point, but doesn't seem urgent.