### PR TITLE
Tweak display of second volume parts

### DIFF
--- a/capstone/cite/templates/cite/series.html
+++ b/capstone/cite/templates/cite/series.html
@@ -29,7 +29,9 @@
       <p>
         <strong>Volume number:</strong>
         {% for volume in volumes %}
-          <a href="{% url 'volume' series_slug=reporter.short_name_slug volume_number_slug=volume.volume_number_slug host 'cite' %}">{{ volume.volume_number }}</a>
+          {% ifchanged %}
+            <a href="{% url 'volume' series_slug=reporter.short_name_slug volume_number_slug=volume.volume_number_slug host 'cite' %}">{{ volume.volume_number }}</a>
+          {% endifchanged %}
         {% endfor %}
       </p>
     {% endfor %}

--- a/capstone/cite/templates/cite/volume.html
+++ b/capstone/cite/templates/cite/volume.html
@@ -28,7 +28,10 @@
 
     {% for volume, cases in volumes %}
       {% with volume.reporter as reporter %}
-        <h3 class="subtitle">{{ volume.volume_number }} {{ reporter.short_name }}</h3>
+        <h3 class="subtitle">
+          {{ volume.volume_number }} {{ reporter.short_name }}
+          {% if volume.second_part_of_id %}part 2{% endif %}
+        </h3>
         <p>
           {{ reporter.full_name }}
           ({{ reporter.start_year|default:"" }}-{{ reporter.end_year|default:"" }})


### PR DESCRIPTION
Remove duplicate listings from list of volume numbers on series page, and add "part 2" to title of second volume on volume page.