### PR TITLE
fix - setting min height to main content container so that footer is pushed to bottom of page

### DIFF
--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -183,6 +183,7 @@ main {
   @extend .flex-fill;
   @extend .d-flex;
   @extend .flex-column;
+  min-height: 85%;
   > * {
     @extend .flex-fill;
   }


### PR DESCRIPTION
the flex classes don't handle all cases (see https://case.law/search/)