### PR TITLE
Cite extraction tweaks

### DIFF
--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -429,6 +429,7 @@ def extract_citations_per_vol(self, volume_id):
                  .filter(volume_id=volume_id, in_scope=True)
                  .exclude(body_cache=None)
                  .select_related('body_cache')
+                 .prefetch_related('citations')
                  .only('body_cache__text'))
         comparison_fields = ('normalized_cite', 'page_number_original', 'volume_number_original', 'reporter_name_original', 'cited_by_id', 'cite')
 

--- a/capstone/scripts/extract_cites.py
+++ b/capstone/scripts/extract_cites.py
@@ -129,6 +129,9 @@ def extract_citations_from_text(text, max_year=9999, misses=None):
 
 def extract_citations(case):
     misses = defaultdict(lambda: defaultdict(int))
+    # Don't count instances where a case cites to itself. Typically this is listing the parallel cite,
+    # which leads to false matches when the parallel page has more than one case.
+    self_cites = {c.normalized_cite for c in case.citations.all()}
     case_citations = [
         ExtractedCitation(
             cite=cite,
@@ -139,5 +142,6 @@ def extract_citations(case):
             page_number_original=page_num)
         for cite, normalized_cite, vol_num, reporter_str, page_num in
         extract_citations_from_text(case.body_cache.text, case.decision_date.year, misses)
+        if normalized_cite not in self_cites
     ]
     return case_citations, misses


### PR DESCRIPTION
- When extracting cites, we filter out any cites that match one of the citations for the case itself. This avoids weird outcomes when two different cases have the same parallel cite, and we end up deciding the case is citing to the other one instead of just listing its own parallel cites.
- Add pagerank export and re-import to the `export_citation_graph` fab task.
- Tweak pagerank re-import so it doesn't update cases with unchanged pagerank, to avoid changing last_updated unnecessarily. (This might not accomplish much since pagerank is unstable and all the numbers might change every time anyway. 🤷‍♂️)