### PR TITLE
Docs CSS and template tweaks

### DIFF
--- a/capstone/capweb/templates/docs.html
+++ b/capstone/capweb/templates/docs.html
@@ -1,147 +1,79 @@
-{% load static %} {% load bootstrap4 %} {% load pipeline %}{% load startswith %}{% load capweb_static %}{% load render_bundle from webpack_loader %}{% load capture_tags %}<!DOCTYPE html>
-<html lang="en">
-  <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# article: http://ogp.me/ns/article#">
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    {# title #}
-    {% capture as title_out silent %}{% block title %}{% if title %}{{ title }}{% endif %}{% endblock title %}{% block title_suffix %} | Caselaw Access Project{% endblock title_suffix %}{% endcapture %}
-    <title>{{ title_out }}</title>
-    <meta property="og:title" content="{% if og_title %}{{ og_title }}{% else %}{{ title_out }}{% endif %}">
-    <meta property="twitter:title" content="{% if og_title %}{{ og_title }}{% else %}{{ title_out }}{% endif %}">
-    {# description #}
-    {% capture as meta_description_out silent %}{% block meta_description %}{% if meta_description %}{{ meta_description }}{% else %}Explore American Caselaw{% endif %}{% endblock meta_description %}{% endcapture %}
-    <meta name="description" content="{{ meta_description_out }}">
-    <meta property="og:description" content="{% if og_description %}{{ og_description }}{% else %}{{ meta_description_out }}{% endif %}">
-    <meta name="twitter:description" content="{% if og_description %}{{ og_description }}{% else %}{{ meta_description_out }}{% endif %}">
+{% extends "layouts/wide.html" %}
+{% load pipeline %}
+{% load static %}
+{% load startswith %}
 
-    {# social #}
-    {% capture as page_image_out silent %}{% block page_image %}{% if page_image != None %}{{ page_image }}{% else %}img/og_image/api.jpg{% endif %}{% endblock %}{% endcapture %}
-    {% capture as page_image_out silent %}{% if page_image_out|slice:":4" == 'http' %}{{ page_image_out }}{% else %}{% capweb_static page_image_out %}{% endif %}{% endcapture %}
-    {% if page_image_out %}
-      <meta name="twitter:card" content="summary_large_image">
-      <meta name="twitter:image" content="{{ page_image_out }}">
-      <meta property="og:image"  content="{{ page_image_out }}">
-    {% endif %}
+{% block title %}{{ meta.title }}{% endblock %}
+{% block base_css %}{% stylesheet "unified_docs" %}{% endblock %}
 
-    <meta name="twitter:site" content="@caselawaccess">
-    <meta name="twitter:creator" content="@HarvardLIL">
-
-    {% if page_url %}
-      <meta property="og:url" content="{{ page_url }}">
-    {% else %}
-      {% if request %}<meta property="og:url" content="{{ request.build_absolute_uri }}">{% endif %}
-    {% endif %}
-
-    <meta property="og:type" content="article">
-
-    {# extra meta tags #}
-    {% if meta_tags %}
-      {% for meta_tag in meta_tags %}
-        <meta
-          {% for k, v in meta_tag.items %}
-            {{ k }}="{{ v }}"
-          {% endfor %}
-        >
-      {% endfor %}
-    {% endif %}
-
-    {# favicon #}
-    <link rel="apple-touch-icon" sizes="152x152" href="{% static "img/favicon/apple-touch-icon.png" %}">
-    <link rel="icon" type="image/png" sizes="192x192"  href="{% static "img/favicon/android-chrome-144x144.png" %}">
-    <link rel="icon" type="image/png" sizes="96x96" href="{% static "img/favicon/favicon.ico" %}">
-    <link rel="icon" type="image/png" sizes="32x32" href="{% static "img/favicon/favicon-32x32.png" %}">
-    <link rel="icon" type="image/png" sizes="16x16" href="{% static "img/favicon/favicon-16x16.png" %}">
-    <link rel="mask-icon" href="{% static "img/favicon/safari-pinned-tab.svg" %}" color="#0075FF">
-    <meta name="msapplication-TileColor" content="#2b5797">
-    <meta name="msapplication-TileImage" content="{% static "img/favicon/mstile-150x150.png" %}">
-    <meta name="theme-color" content="#ffffff">
-
-    {# if a stylesheet has to import base.scss, it should override this block instead of going in extra_head to avoid double import #}
-    {% block base_css %}{% stylesheet "unified_docs" %}{% endblock %}
-    {% render_bundle 'chunk-common' %}
-    {% render_bundle 'base' %}
-    {% if extra_head %}{{ extra_head }}{% endif %}
-    {% block extra_head %}{% endblock %}
-  </head>
-
-<body class="hamburger-menu-closed" tabindex="-1">
-
-<div id="container" class="gr_container no-nav">
-    <nav class="site-nav">
-        {% include "includes/nav.html" %}
-    </nav>
+{% block content %}
+  <div id="container" class="gr_container no-nav">
     <nav class="breadcrumb" tabindex="0" onclick="toggle_mobile_nav();">
-        <div class="row">
-            <div class="col-10">
-                {% autoescape off %}
-                    {{ breadcrumb }}
-                {% endautoescape %}
-            </div>
-            <div class="col-2 expand-nav-div">
-                <img id="expand-nav-arrow" height="15" width="30" class="unexpanded" src="{% static 'img/arrows/expand-arrow-blocked-black.svg' %}">
-            </div>
+      <div class="row">
+        <div class="col-10">
+          {% autoescape off %}
+            {{ breadcrumb }}
+          {% endautoescape %}
         </div>
+        <div class="col-2 expand-nav-div">
+          <img id="expand-nav-arrow" height="15" width="30" class="unexpanded"
+               src="{% static 'img/arrows/expand-arrow-blocked-black.svg' %}">
+        </div>
+      </div>
     </nav>
     <nav class="doc-nav show-nav">
-        <div id="docs_toc" class="panel-group w-100 pl-0">
-            {% for item in toc %}
-                <div class="panel-heading">
-                    <div class="panel-title">
-                        <a class="top-level-label" data-toggle="collapse" href="#collapse1_{{ item.url }}" data-target="#collapse1_{{ item.url }}">{{ item.label }}</a>
-                    </div>
-                </div>
+      <div id="docs_toc" class="panel-group w-100 pl-0">
+        {% for item in toc %}
+          <div class="panel-heading">
+            <div class="panel-title">
+              <a class="top-level-label" data-toggle="collapse" href="#collapse1_{{ item.url }}"
+                 data-target="#collapse1_{{ item.url }}">{{ item.label }}</a>
+            </div>
+          </div>
 
-               {% if req_doc_path|startswith:item.url %}
-                    <div id="collapse1_{{ item.url }}" class="panel-collapse show collapse">
-               {% else %}
-                    <div id="collapse1_{{ item.url }}" class="panel-collapse collapse">
-               {% endif %}
-                        <ul class="top-level-item pl-0">
-                            <li class="top-level-structure">
-                                {% include "includes/docs_toc.html" with toc=item.children %}
-                            </li>
-                        </ul>
-                    </div>
-            {% endfor %}
+          {% if req_doc_path|startswith:item.url %}
+            <div id="collapse1_{{ item.url }}" class="panel-collapse show collapse">
+          {% else %}
+            <div id="collapse1_{{ item.url }}" class="panel-collapse collapse">
+          {% endif %}
+        <ul class="top-level-item pl-0">
+          <li class="top-level-structure">
+            {% include "includes/docs_toc.html" with toc=item.children %}
+          </li>
+        </ul>
         </div>
+        {% endfor %}
+      </div>
     </nav>
 
-    <main id="document-contents" class="doc-main">
-
-            {{ content }}
-    </main>
-
+    <div id="document-contents" class="doc-main">
+      {{ content }}
+    </div>
 
     <header class="title"><h1>{{ meta.title }}</h1></header>
     <aside class="explainer">
-
-        <p>
-            {{meta.explainer}}
-        </p>
+      <p>
+        {{ meta.explainer }}
+      </p>
     </aside>
-    <footer class="main-footer">
-        {% include "includes/footer.html" %}
-    </footer>
-</div>
-<script>
-
-    function toggle_mobile_nav(force_hide=false) {
-        let container = document.getElementById("container");
-        let viz_state = container.classList.contains("show-nav") ? ["show-nav", "no-nav"] : ["no-nav", "show-nav"];
-        if (!window.matchMedia('(max-width: 767px)').matches || (force_hide &&  viz_state === container.classList.contains("no-nav"))){
-            return
-        }
-        container.classList.replace(...viz_state);
+  </div>
+  <script>
+    function toggle_mobile_nav(force_hide = false) {
+      let container = document.getElementById("container");
+      let viz_state = container.classList.contains("show-nav") ? ["show-nav", "no-nav"] : ["no-nav", "show-nav"];
+      if (!window.matchMedia('(max-width: 767px)').matches || (force_hide && viz_state === container.classList.contains("no-nav"))) {
+        return
+      }
+      container.classList.replace(...viz_state);
     }
 
     page_toc_items = document.getElementsByClassName("doc-toc-item");
     for (let local_link of page_toc_items) {
-        local_link.addEventListener("click", function () {
-            if (window.matchMedia('(max-width: 767px)').matches) {
-                toggle_mobile_nav(true);
-            }
-        })
+      local_link.addEventListener("click", function () {
+        if (window.matchMedia('(max-width: 767px)').matches) {
+          toggle_mobile_nav(true);
+        }
+      })
     }
 
     breadcrumb = document.getElementsByClassName('breadcrumb')[0]
@@ -150,9 +82,5 @@
         breadcrumb.click();
       }
     });
-
-</script>
-<span id="content-and-footer"></span>
-</body>
-</html>
-
+  </script>
+{% endblock content %}

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -44,21 +44,20 @@ body {
   /* push footer to bottom of screen if insufficient main-content to fill page */
   display: flex;
   flex-direction: column;
+  height: 100vh;
   color: $color-black;
   -webkit-hyphens: auto;
   -moz-hyphens: auto;
   -ms-hyphens: auto;
   hyphens: auto;
-
-  // push footer to bottom on short pages
-  @extend .d-flex;
-  @extend .flex-column;
-  height: 100vh;
 }
 
 #content-and-footer {
   flex: 1 1 auto;
   overflow-y: auto;
+  /* push footer to bottom of screen if insufficient main-content to fill page */
+  display: flex;
+  flex-direction: column;
 }
 
 // BUTTONS & LINKS
@@ -179,14 +178,7 @@ pre {
 }
 
 main {
-  // push footer to bottom on short pages
-  @extend .flex-fill;
-  @extend .d-flex;
-  @extend .flex-column;
-  min-height: 85%;
-  > * {
-    @extend .flex-fill;
-  }
+  flex: 1;
 }
 
 .code-block {

--- a/capstone/static/css/scss/unified_docs.scss
+++ b/capstone/static/css/scss/unified_docs.scss
@@ -27,14 +27,13 @@ h2 {
   display: grid;
   grid-gap: 0;
   grid-template-areas:
-          "pagenav pagenav pagenav"
           "nav breadcrumb breadcrumb"
           "nav title title"
-          "nav content explainer"
-          "footer footer footer";
+          "nav content explainer";
 
-  grid-template-columns: minmax(15rem, 18rem) auto minmax(12rem, 18rem);
-  grid-template-rows: auto auto auto auto auto;
+  grid-template-columns: minmax(15rem, 18rem) minmax(0, 1fr) minmax(12rem, 18rem);
+  grid-template-rows: auto auto 1fr;
+  height: 100%;
 
   .expand-nav-div {
     display: none;
@@ -57,7 +56,7 @@ h2 {
     background-color: $color-black;
   }
 
-  main#document-contents {
+  #document-contents {
     padding: 0rem 3rem 1rem 3rem;
     grid-area: content;
 
@@ -190,6 +189,8 @@ h2 {
     padding-left: 1rem;
     padding-top: .5rem;
     padding-bottom: 2.3rem;
+    position: sticky;
+    top: 0;
   }
 
   aside.explainer {
@@ -221,15 +222,13 @@ h2 {
     }
     display: grid;
     grid-template-areas:
-            "pagenav pagenav pagenav"
             "nav breadcrumb breadcrumb"
             "nav title title"
             "nav explainer ."
-            "nav content ."
-            "footer footer footer";
+            "nav content .";
 
-    grid-template-columns: minmax(12rem, 18rem) auto 3rem;
-    grid-template-rows: auto 3rem minmax(5rem, 10rem) auto auto 5rem;
+    grid-template-columns: minmax(12rem, 18rem) minmax(0, 1fr) 3rem;
+    grid-template-rows: auto auto auto 1fr;
   }
 }
 
@@ -237,7 +236,7 @@ h2 {
   html body.hamburger-menu-closed div.gr_container nav.site-nav nav#site-nav {
     border-bottom: 0;
   }
-  main#document-contents {
+  #document-contents {
     padding: 2rem 1rem 1rem 1rem;
   }
   .gr_container {
@@ -259,18 +258,12 @@ h2 {
     }
 
     grid-template-areas:
-            "pagenav"
             "breadcrumb"
             "title"
             "explainer"
-            "content"
-            "footer";
-    grid-template-columns: 1fr;
-    grid-template-rows: auto
-    minmax(25px, auto)
-    1fr
-    minmax(75px, auto)
-    auto;
+            "content";
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto auto auto 1fr;
   }
   .gr_container.show-nav {
     nav.doc-nav {
@@ -278,20 +271,15 @@ h2 {
       top: 2rem;
     }
 
-    main#document-contents, .explainer, footer, header {
+    #document-contents, .explainer, footer, header {
       display: none !important;
     }
 
     grid-template-areas:
-            "pagenav"
             "breadcrumb"
             "nav";
-    grid-template-columns: 1fr;
-    grid-template-rows: auto /* Header */
-    minmax(25px, auto) /* Nav */
-    1fr /* Content */
-    minmax(75px, auto) /* Sidebar */
-    auto; /* Footer */
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto 1fr;
     #expand-nav-arrow {
       transform: rotate(180deg);
     }
@@ -300,6 +288,11 @@ h2 {
 
 
 nav.doc-nav {
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow: auto;
+  white-space: nowrap;
   .nav {
     padding-left: 2rem;
   }


### PR DESCRIPTION
- Refactor docs.html to inherit from layouts/wide.html instead of duplicating the full html base template
- Add title
- Tweak css that pushes footer to bottom of screen on short pages, so it doesn't also spread out contents of `<main>` tag
- Make docs breadcrumbs and sidebar sticky
- Tweak grid sizes so docs nav doesn't get squished or too wide if main content has wide `<pre>` tags