### PR TITLE
Don't run docker-compose up again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,6 @@ jobs:
           name: "Deploy"
           command: |
             if [[ "$CIRCLE_PULL_REQUEST" == "" && "$CIRCLE_BRANCH" == "develop" ]] ; then
-                docker-compose up -d
                 docker-compose exec web yarn build
                 if [[ `git status static/dist/ webpack-stats.json --porcelain` ]] ; then
                     docker-compose exec web fab update_docker_image_version


### PR DESCRIPTION
This is an attempt to deal with a new problem, `PermissionError: [Errno 13] Permission denied: '/home/circleci/project/capstone/requirements.txt'`, in the deploy step.