### PR TITLE
Separate documents for ES reading and writing

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -8,7 +8,7 @@ from django_filters.utils import translate_validation
 from elasticsearch.exceptions import NotFoundError
 from rest_framework.exceptions import ValidationError
 from rest_framework_filters.backends import RestFrameworkFilterBackend
-from capapi.documents import CaseDocument
+from capapi.documents import CaseReaderDocument
 from capdb import models
 from capdb.models import normalize_cite
 from scripts.extract_cites import extract_citations_from_text
@@ -240,7 +240,7 @@ class CaseFilterBackend(FilteringFilterBackend, RestFrameworkFilterBackend):
                 # check if case id is passed in
                 if cite.isdigit():
                     try:
-                        case = CaseDocument.get(id=cite)
+                        case = CaseReaderDocument.get(id=cite)
                         # add all citations relating to case
                         query_params['cites_to']['values'] += [c['normalized_cite'] for c in case.citations]
                     except NotFoundError:

--- a/capstone/capapi/tests/test_serializers.py
+++ b/capstone/capapi/tests/test_serializers.py
@@ -2,14 +2,14 @@ import pytest
 from rest_framework.request import Request
 
 from capapi import serializers
-from capapi.documents import CaseDocument
+from capapi.documents import CaseReaderDocument
 from capapi.resources import api_reverse
 
 
 @pytest.mark.django_db
 def test_CaseDocumentSerializerWithCasebody(api_request_factory, case_factory, elasticsearch):
     cases = [case_factory() for i in range(3)]
-    case_documents = [CaseDocument.get(c.id) for c in cases]
+    case_documents = [CaseReaderDocument.get(c.id) for c in cases]
 
     # can get single case data
     request = api_request_factory.get(api_reverse("cases-list"))

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -12,7 +12,7 @@ from django_elasticsearch_dsl_drf.viewsets import BaseDocumentViewSet as DEDDBas
 from django.http import HttpResponseRedirect, FileResponse, HttpResponseBadRequest
 
 from capapi import serializers, filters, permissions, renderers as capapi_renderers
-from capapi.documents import CaseDocument, RawSearch, ResolveDocument
+from capapi.documents import CaseReaderDocument, RawSearch, ResolveReaderDocument
 from capapi.pagination import CapESCursorPagination
 from capapi.serializers import CaseDocumentSerializer, ResolveDocumentSerializer
 from capapi.middleware import add_cache_header
@@ -84,7 +84,7 @@ class CourtViewSet(BaseViewSet):
 
 class CaseDocumentViewSet(BaseDocumentViewSet):
     """The CaseDocument view."""
-    document = CaseDocument
+    document = CaseReaderDocument
     serializer_class = CaseDocumentSerializer
     filterset_class = filters.CaseFilter
 
@@ -226,7 +226,7 @@ class CaseDocumentViewSet(BaseDocumentViewSet):
 class ResolveDocumentViewSet(BaseDocumentViewSet):
     """The ResolveDocument view."""
 
-    document = ResolveDocument
+    document = ResolveReaderDocument
     serializer_class = ResolveDocumentSerializer
     filterset_class = filters.ResolveFilter
     pagination_class = None

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1078,7 +1078,7 @@ class CaseMetadata(models.Model):
         if not settings.MAINTAIN_ELASTICSEARCH_INDEX:
             return
 
-        from capapi.documents import CaseDocument, ResolveDocument  # avoid circular import
+        from capapi.documents import CaseWriterDocument, ResolveWriterDocument  # avoid circular import
 
         in_scope = []
         out_of_scope = []
@@ -1090,11 +1090,11 @@ class CaseMetadata(models.Model):
 
         # only indexes non-duplicate cases
         if in_scope:
-            CaseDocument().update(in_scope)
-            ResolveDocument().update(in_scope)
+            CaseWriterDocument().update(in_scope)
+            ResolveWriterDocument().update(in_scope)
 
         # for the duplicates, we want to delete them, if necessary
-        for Document in (CaseDocument, ResolveDocument):
+        for Document in (CaseWriterDocument, ResolveWriterDocument):
             try:
                 if out_of_scope:
                     Document().update(out_of_scope, action="delete")

--- a/capstone/capdb/tests/test_postgres.py
+++ b/capstone/capdb/tests/test_postgres.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 import pytest
 from django.db import transaction
 
-from capapi.documents import CaseDocument
+from capapi.documents import CaseReaderDocument
 from capdb.models import CaseMetadata
 from capdb.tasks import update_elasticsearch_from_queue
 from scripts.helpers import parse_xml, serialize_xml
@@ -111,8 +111,8 @@ def test_last_updated(case, extracted_citation_factory, elasticsearch):
 
     # case gets removed when in_scope changes
     update_elasticsearch_from_queue()
-    CaseDocument.get(case.pk)
+    CaseReaderDocument.get(case.pk)
     case.duplicative = True
     case.save()
     update_elasticsearch_from_queue()
-    CaseDocument.get(case.pk)
+    CaseReaderDocument.get(case.pk)

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -13,7 +13,7 @@ from reporters_db import EDITIONS, VARIATIONS_ONLY
 from django.core.files.storage import FileSystemStorage
 from django.db import connections, utils
 
-from capapi.documents import CaseDocument
+from capapi.documents import CaseReaderDocument
 from capdb.models import CaseMetadata, Court, Reporter, Citation, ExtractedCitation, CaseBodyCache, normalize_cite
 from capdb.tasks import get_case_count_for_jur, get_court_count_for_jur, \
     get_reporter_count_for_jur, update_elasticsearch_for_vol, sync_case_body_cache_for_vol, \
@@ -297,8 +297,8 @@ def test_extract_citations(case_factory, tmpdir, settings, elasticsearch):
     assert cite_set == set(legitimate_cites)
     assert normalized_cite_set == legitimate_cites_normalized
     assert all(c.cited_by_id == case.pk for c in cites)
-    assert set(c['cite'] for c in CaseDocument.get(id=case.pk).extractedcitations) == cite_set
-    assert set(c['normalized_cite'] for c in CaseDocument.get(id=case.pk).extractedcitations) == normalized_cite_set
+    assert set(c['cite'] for c in CaseReaderDocument.get(id=case.pk).extractedcitations) == cite_set
+    assert set(c['normalized_cite'] for c in CaseReaderDocument.get(id=case.pk).extractedcitations) == normalized_cite_set
 
     # remove a cite and add a cite --
     # make sure IDs of unchanged cites are still the same

--- a/capstone/capweb/helpers.py
+++ b/capstone/capweb/helpers.py
@@ -275,7 +275,7 @@ safe_domains = [(h['subdomain']+"." if h['subdomain'] else "") + settings.PARENT
 
 def get_toc_by_url():
     from elasticsearch.exceptions import NotFoundError #TODO figure out how to fix this import problem
-    from capapi.documents import CaseDocument
+    from capapi.documents import CaseReaderDocument
     app_absolute_path = os.path.abspath(os.path.dirname(__file__))
     base_path = Path(app_absolute_path, settings.DOCS_RELATIVE_DIR)
     toc_by_url = {
@@ -295,10 +295,10 @@ def get_toc_by_url():
     context['contributors']= sorted_contributors
     context['news']= get_data_from_lil_site(section="news")
     try:
-        case = CaseDocument.get(id=settings.API_DOCS_CASE_ID)
+        case = CaseReaderDocument.get(id=settings.API_DOCS_CASE_ID)
     except NotFoundError:
         try:
-            case = CaseDocument.search().execute()[0]
+            case = CaseReaderDocument.search().execute()[0]
         except NotFoundError:
             case = None
     context['case_id'] = case.id if case else 1

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -649,6 +649,9 @@ MAINTAIN_ELASTICSEARCH_INDEX = True  # whether to update index when changing cas
 ELASTICSEARCH_INDEXES={
     'cases_endpoint': 'cases',
     'resolve_endpoint': 'resolve',
+    # these can be set on prod if they're different:
+    # 'cases_reader_endpoint': 'cases_ro',
+    # 'resolve_reader_endpoint': 'resolve_ro',
 }
 MAX_PAGE_SIZE = 10000
 

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -28,7 +28,7 @@ services:
           - 127.0.0.1:9200:9200
     web:
         build: .
-        image: capstone:0.3.109-bf5bb65e58e2f46f4bea2e5a64d63b65
+        image: capstone:0.3.110-02aa104a0bffb5e9f0188a2d0890603c
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/scripts/export.py
+++ b/capstone/scripts/export.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.template.loader import render_to_string
 from django.utils import timezone
 
-from capapi.documents import CaseDocument
+from capapi.documents import CaseReaderDocument
 from capapi.serializers import NoLoginCaseDocumentSerializer, CaseDocumentSerializer
 from capdb.models import Jurisdiction, Reporter
 from capdb.storages import download_files_storage
@@ -61,7 +61,7 @@ def export_cases_by_jurisdiction(version_string, id):
         Write a .jsonl.gz file with all cases for jurisdiction.
     """
     jurisdiction = Jurisdiction.objects.get(pk=id)
-    cases = CaseDocument.raw_search().filter("term", jurisdiction__id=id)
+    cases = CaseReaderDocument.raw_search().filter("term", jurisdiction__id=id)
     if cases.count() == 0:
         print("WARNING: Jurisdiction '{}' contains NO CASES.".format(jurisdiction.name))
         return
@@ -81,7 +81,7 @@ def export_cases_by_reporter(version_string, id):
         Write a .jsonl.gz file with all cases for reporter.
     """
     reporter = Reporter.objects.get(pk=id)
-    cases = CaseDocument.raw_search().filter("term", reporter__id=id)
+    cases = CaseReaderDocument.raw_search().filter("term", reporter__id=id)
     if cases.count() == 0:
         print("WARNING: Reporter '{}' contains NO CASES.".format(reporter.full_name))
         return

--- a/capstone/scripts/ingest_courtlistener.py
+++ b/capstone/scripts/ingest_courtlistener.py
@@ -10,7 +10,7 @@ from tempfile import TemporaryDirectory
 from tqdm import tqdm
 
 from capdb.models import normalize_cite
-from capapi.documents import ResolveDocument
+from capapi.documents import ResolveWriterDocument
 from scripts.simhash import get_simhash
 
 
@@ -116,7 +116,7 @@ def ingest_courtlistener(download_dir='/tmp', start_from=None):
             run(f"tar -xOf {clusters_file} {jurisdiction_file} | tar -C {clusters_dir} -zxf -", shell=True)
             run(f"tar -xOf {opinions_file} {jurisdiction_file} | tar -C {opinions_dir} -zxf -", shell=True)
             documents = pool.imap_unordered(load_cluster, ((cluster_member, opinions_dir) for cluster_member in clusters_dir.glob("*.json")))
-            ResolveDocument().update(tqdm(d for d in documents if d), parallel=True)
+            ResolveWriterDocument().update(tqdm(d for d in documents if d), parallel=True)
 
 
 def make_test_files(input_dir='.', output_dir='test_data/courtlistener'):


### PR DESCRIPTION
This allows the Elasticsearch reading and writing to be separated, so the index can be rebuilt while the site is still serving results from the old index. The process would look something like this:

* set indexes read only
* use ES clone API to make _ro copies
* set original indexes back to read-write
* point Django to the _ro copies:
```
ELASTICSEARCH_INDEXES={
    'cases_endpoint': 'cases',
    'resolve_endpoint': 'resolve',
    # these can be set on prod if they're different:
    'cases_reader_endpoint': 'cases_ro',
    'resolve_reader_endpoint': 'resolve_ro',
}
```
* run `fab rebuild_search_index`. This will delete `cases` and `resolve` endpoints, but we'll keep serving results from the clones.
* once reindexing is done, point Django back to the originals and delete the _ro indexes.