### PR TITLE
Add search box and view random case link to top of cite.case.law

### DIFF
--- a/capstone/cite/templates/cite/home.html
+++ b/capstone/cite/templates/cite/home.html
@@ -4,7 +4,19 @@
 {% block meta_description %}Caselaw Access Project cases{% endblock %}
 
 {% block explainer %}
-  Browse the collection of the <a href="{% url 'home' %}">Caselaw Access Project</a>.
+  <p class="mb-4">Browse all volumes of the Caselaw Access Project below.</p>
+  <form id="search" class="form-inline mb-4">
+    <label for="q">Search the collection:</label>
+    <input type="text" class="form-control flex-fill ml-2" id="q">
+    <input type="submit" class="btn btn-primary" value="Search">
+  </form>
+  <script>
+    document.getElementById('search').addEventListener('submit', function(e) {
+      document.location = '{% url "search" %}#/cases?page=1&search=' + encodeURIComponent(document.getElementById('q').value);
+      e.preventDefault();
+    })
+  </script>
+  <p class="mb-0">View a <a href="{% url "random" host "cite" %}">random case</a>.</p>
 {% endblock %}
 
 {% block sidebar_menu_items %}

--- a/capstone/cite/urls.py
+++ b/capstone/cite/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    path('random/', views.random, name='random'),
     path('robots.txt', views.robots, name='robots'),
     path('set-cookie/', views.set_cookie, name='set_cookie'),
     path('cited-by/<int:case_id>/', views.case_cited_by, name='case_cited_by'),

--- a/capstone/static/css/scss/base.scss
+++ b/capstone/static/css/scss/base.scss
@@ -286,8 +286,6 @@ input.form-control[type="text"],
 input[type="text"],
 input[type="email"],
 textarea {
-  width: 100%;
-  margin-bottom: 10px;
   padding: 5px;
   outline: none;
   border-radius: 0;


### PR DESCRIPTION
Add a quick-and-dirty search box, which redirects to the search page, and a get-random-case link to the cite.case.law landing page.

Random cases are drawn from all cases over 1,000 words, not weighted by importance, though I kept a commented-out line in there for how to do that.

![image](https://user-images.githubusercontent.com/376272/101674670-cac4de80-3a26-11eb-98d2-8e85f89658d3.png)
