### PR TITLE
Set cache maxage so it won't be overridden by cloudflare

### DIFF
--- a/capstone/capapi/middleware.py
+++ b/capstone/capapi/middleware.py
@@ -20,12 +20,17 @@ _capuser_cache_safe_attributes = {
     'is_anonymous', 'is_authenticated', '__class__',
 }
 
-def add_cache_header(response, s_maxage=settings.CACHE_CONTROL_DEFAULT_MAX_AGE):
-    patch_cache_control(response, s_maxage=s_maxage)
+def add_cache_header(response):
+    patch_cache_control(response, s_maxage=settings.CDN_CACHE_LENGTH, max_age=settings.BROWSER_CACHE_LENGTH)
+
+
+def add_no_cache_header(response):
+    patch_cache_control(response, s_maxage=0, max_age=0)
+
 
 def cache_header_middleware(get_response):
     """
-        Set an outgoing "Cache-Control: s-maxage=<settings.CACHE_CONTROL_DEFAULT_MAX_AGE>" header on all requests
+        Set an outgoing "Cache-Control: s-maxage=<settings.CDN_CACHE_LENGTH>, max-age=<settings.BROWSER_CACHE_LENGTH>" header on all requests
         that are detected to be cacheable.
 
         See test_cache.py for examples of when we set or don't set cache headers.
@@ -83,7 +88,7 @@ def cache_header_middleware(get_response):
         if cache_response:
             add_cache_header(response)
         else:
-            add_cache_header(response, s_maxage=0)
+            add_no_cache_header(response)
 
         return response
 

--- a/capstone/capapi/tests/helpers.py
+++ b/capstone/capapi/tests/helpers.py
@@ -43,4 +43,4 @@ def check_response(response, status_code=200, content_type=None, content_include
 
 def is_cached(response):
     cache_header = response['cache-control'] if response.has_header('cache-control') else ''
-    return 's-maxage=%d' % settings.CACHE_CONTROL_DEFAULT_MAX_AGE in cache_header
+    return f's-maxage={settings.CDN_CACHE_LENGTH}' in cache_header

--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -579,7 +579,8 @@ SIMPLE_HISTORY_FILEFIELD_TO_CHARFIELD = True
 
 # cache headers
 SET_CACHE_CONTROL_HEADER = False  # whether to set a cache-control header on all cacheable views
-CACHE_CONTROL_DEFAULT_MAX_AGE = 60*60*24  # length of time to cache pages by default, in seconds
+CDN_CACHE_LENGTH = 60*60*24  # for cacheable responses, how long to cache on CDN (Cloudflare)
+BROWSER_CACHE_LENGTH = 60*60  # for cacheable responses, how long to cache in browser
 
 # settings for scripts/compress_volumes.py
 COMPRESS_VOLUMES_THREAD_COUNT = 20   # if < 2, no thread pool will be used


### PR DESCRIPTION
We're seeing cached 302 redirects on prod, which I think is because when Cloudflare sees a cache-control header without a max-age like `Cache-Control: s-maxage=0`, it adds a default max-age according to this setting

![image](https://user-images.githubusercontent.com/376272/101826345-e0a4d300-3afc-11eb-9f79-2a4d80aed56a.png)

so the header comes through as `cache-control: max-age=14400, s-maxage=0`.

This ensures that we set max-age as well as s-maxage.