### PR TITLE
unredact_out_of_copyright_volumes task -- fix save(), better warnings

### DIFF
--- a/capstone/capdb/storages.py
+++ b/capstone/capdb/storages.py
@@ -221,7 +221,7 @@ class DownloadOverlayStorage(Storage):
             setattr(self, method_name, types.MethodType(method, self))
 
         # functions that go directly to underlay storage
-        for method_name in ('url', 'mkdir', 'symlink', 'rmtree'):
+        for method_name in ('url', 'mkdir', 'symlink', 'rmtree', 'save'):
             setattr(self, method_name, getattr(underlay_storage, method_name))
 
 


### PR DESCRIPTION
Tweaks to the `fab unredact_out_of_copyright_volumes` task based on this year's run. This is already run, no need to run again.