### PR TITLE
Stop displaying xml_volume_number in API

### DIFF
--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -327,7 +327,6 @@ class VolumeSerializer(serializers.ModelSerializer):
     reporter = serializers.ReadOnlyField(source='xml_reporter_full_name')
     start_year = serializers.ReadOnlyField(source='spine_start_year')
     end_year = serializers.ReadOnlyField(source='spine_end_year')
-    volume_number = serializers.ReadOnlyField(source='xml_volume_number')
     publisher = serializers.ReadOnlyField(source='xml_publisher')
     pdf_url = serializers.FileField(source='pdf_file')
     frontend_url = serializers.ReadOnlyField(source='get_frontend_url')

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -651,7 +651,7 @@ class VolumeMetadata(models.Model):
     xml_end_year = models.IntegerField(blank=True, null=True)
     xml_publisher = models.CharField(max_length=255, blank=True, null=True)
     xml_publication_city = models.CharField(max_length=1024, blank=True, null=True)
-    xml_volume_number = models.CharField(max_length=64, blank=True, null=True)
+    xml_volume_number = models.CharField(max_length=64, blank=True, null=True)  # this has been copied to volume_number where valid; no longer used
     # just extract this and keep it here for now -- we can use it to check the reporter= field later:
     xml_reporter_short_name = models.CharField(max_length=255, blank=True, null=True)
     xml_reporter_full_name = models.CharField(max_length=255, blank=True, null=True)


### PR DESCRIPTION
Per #1667, xml_volume_number is now fully incorporated into volume_number and should no longer be used.