### PR TITLE
Avoid occasional test failure

### DIFF
--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -164,7 +164,7 @@ def test_case_detail_pdf(transactional_db, client, auth_client, restricted_case,
 def test_csv(transactional_db, client, auth_client, restricted_case, unrestricted_case, elasticsearch):
     """ Test ?format=csv on case detail and list API. """
     content_type = 'text/csv'
-    case_text = "majority"
+    case_text = "Opinion text"
 
     # unauthorized request can't fetch restricted TSV
     response = client.get(api_reverse("cases-detail", args=[restricted_case.id]),


### PR DESCRIPTION
Just a quick tweak -- this test occasionally fails when the word "majority" is used in a randomly generated court or jurisdiction name.