### PR TITLE
Update Postgres in dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Capstone should now be running at 127.0.0.1:8000.
 
 ### Docker Setup <a id="docker-setup"></a>
 
-We have initial support for local development via `docker compose`. Docker setup looks like this:
+We support local development via `docker compose`. Docker setup looks like this:
 
     $ docker-compose up -d
     $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE capdb;"
@@ -149,6 +149,7 @@ We have initial support for local development via `docker compose`. Docker setup
     $ docker-compose exec db psql --user=postgres -c "CREATE DATABASE cap_user_data;"
     $ docker-compose exec web fab init_dev_db
     $ docker-compose exec web fab ingest_fixtures
+    $ docker-compose exec web fab import_web_volumes
     $ docker-compose exec web fab run
     
 Capstone should now be running at 127.0.0.1:8000.

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -4,11 +4,11 @@ services:
         build:
           context: ../services/docker
           dockerfile: extended-postgres.dockerfile
-        image: capstone-postgres:0.1
+        image: capstone-postgres:0.2
         environment:
             POSTGRES_PASSWORD: password
         volumes:
-          - db_data:/var/lib/postgresql/data:delegated
+          - db_data_11:/var/lib/postgresql/data:delegated
     redis:
         image: registry.lil.tools/library/redis:6.0.9
     elasticsearch:
@@ -23,7 +23,7 @@ services:
             soft: -1
             hard: -1
         volumes:
-          - esdata01:/usr/share/elasticsearch/data
+          - esdata02:/usr/share/elasticsearch/data
         ports:
           - 127.0.0.1:9200:9200
     web:
@@ -55,7 +55,7 @@ services:
             - SYS_PTRACE
 
 volumes:
-    db_data:
+    db_data_11:
     node_modules:
-    esdata01:
+    esdata02:
       driver: local

--- a/services/docker/extended-postgres.dockerfile
+++ b/services/docker/extended-postgres.dockerfile
@@ -1,13 +1,16 @@
-FROM registry.lil.tools/library/postgres:9.6
+FROM registry.lil.tools/library/postgres:11.10
 
 RUN apt-get update && \
-    apt-get install -y libpq-dev && \
-    apt-get install -y postgresql-9.6-plv8
+    apt-get install -y libpq-dev
 
 # install temporal_tables
 RUN apt-get update && \
     apt-get install -y build-essential && \
     apt-get install -y systemtap-sdt-dev && \
-    apt-get install -y postgresql-server-dev-9.6 && \
-    apt-get install -y pgxnclient && \
-    USE_PGXS=1 pgxn install temporal_tables
+    apt-get install -y postgresql-server-dev-11 && \
+    apt-get install -y git && \
+    git clone https://github.com/mlt/temporal_tables.git && \
+    cd temporal_tables && \
+    git checkout 6cc86eb03d618d6b9fc09ae523f1a1e5228d22b5 && \
+    make && \
+    make install


### PR DESCRIPTION
This updates Postgres to 11.10 in our Docker development environment. There are a few points of interest:

To get your environment set up again, run

    docker-compose up -d
    docker-compose exec db psql --user=postgres -c "CREATE DATABASE capdb;"
    docker-compose exec db psql --user=postgres -c "CREATE DATABASE capapi;"
    docker-compose exec db psql --user=postgres -c "CREATE DATABASE cap_user_data;"
    docker-compose exec web fab init_dev_db
    docker-compose exec web fab ingest_fixtures
    docker-compose exec web fab import_web_volumes

In order to make a clean and easy break with the previous setup, this changes the names of both the database and index volumes. You can keep the old ones around for reference, or delete them with

    docker volume rm db_data
    docker volume rm esdata01

Note the new method for installing the deprecated `temporal_tables` extension in `services/docker/extended-postgres.dockerfile`. The pinned commit in the checkout line is the same as checking out
https://github.com/mlt/temporal_tables/tree/mlt -- see https://github.com/mlt/temporal_tables for a recommendation to use
https://github.com/xocolatl/periods instead.

Finally, I had to increase the memory allotted in Docker Desktop's Preferences... Resources to prevent the Elasticsearch container from dying with code 137 -- I set it to 4GB. Your mileage may vary. It's not clear to me whether the added use of memory was inherent in this change, or in inessential excess load I was putting on the index while I was fussing with it.

Closes #1674.