### PR TITLE
Block Quote Update, headmatter footnote link nudge

### DIFF
--- a/capstone/static/css/scss/case.scss
+++ b/capstone/static/css/scss/case.scss
@@ -107,8 +107,11 @@ section.casebody {
 
 blockquote {
   font-family: $font-serif;
-  padding: 0 1em;
-  background-color: $color-light-gray;
+  padding: .5rem 1rem .5rem 1rem;
+  border-left: .5rem solid $color-gray;
+  color: $color-medium-dark-blue;
+  font-size: $font-size-sm;
+  line-height: $line-height-sm;
 }
 
 p.small-text {
@@ -308,8 +311,7 @@ mark {
   // footnote number
   > a {
     position: absolute;
-    left: 0;
-    transform: translateX(30%);
+    left: .5rem;
     border-bottom: 0;
     font-weight: $font-weight-bold;
     color: $color-magenta;


### PR DESCRIPTION
Two minor changes. Block quote styling:
<img width="789" alt="Screen Shot 2021-01-21 at 8 40 41 PM" src="https://user-images.githubusercontent.com/1882536/105434371-70c05700-5c29-11eb-8771-848616fa03e3.png">

Head matter footnote link placement:
<img width="432" alt="Screen Shot 2021-01-21 at 8 41 04 PM" src="https://user-images.githubusercontent.com/1882536/105434374-70c05700-5c29-11eb-9ddc-dbb0ada3c8b2.png">
