### PR TITLE
Correctly label chronological order of "cited by" page

### DIFF
--- a/capstone/cite/templates/cite/case_cited_by.html
+++ b/capstone/cite/templates/cite/case_cited_by.html
@@ -23,7 +23,7 @@
       {% if previous %}
         <div class="entries col-6">
           <a href="?{{ previous }}" class="btn btn-sm p-0">
-            &laquo; Newer entries
+            &laquo; Older entries
           </a>
         </div>
       {% endif %}
@@ -31,7 +31,7 @@
       {% if next %}
         <div {% if previous %}class="entries col-6 text-right"{% else %}class="entries col-12 text-right"{% endif %}>
           <a href="?{{ next }}" class="btn btn-sm p-0 ">
-            Older entries &raquo;
+            Newer entries &raquo;
           </a>
         </div>
       {% endif %}
@@ -69,14 +69,14 @@
       {% if previous %}
         <div class="entries col-6">
           <a href="?{{ previous }}" class="btn btn-sm">
-            &laquo; Newer entries
+            &laquo; Older entries
           </a>
         </div>
       {% endif %}
       {% if next %}
         <div {% if previous %}class="entries col-6 text-right"{% else %}class="entries col-12 text-right"{% endif %}>
           <a href="?{{ next }}" class="btn btn-sm">
-            Older entries &raquo;
+            Newer entries &raquo;
           </a>
         </div>
       {% endif %}


### PR DESCRIPTION
If an opinion is cited by more than one page's worth of opinions, they are split across multiple pages and the button to go to the second page is currently labeled "older entries." See [example](https://cite.case.law/cited-by/2292816/). That's backwards, since the citations are listed from oldest to newest. This PR swaps the "older entries" and "newer entries" labels to reflect that.

An alternative fix would be to keep the labels as-is, but reverse the order of cases.