### PR TITLE
Update services

### DIFF
--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -33,7 +33,7 @@ RUN echo "--modules-folder /node_modules" > /.yarnrc
 COPY package.json /app
 COPY yarn.lock /app
 # pin node version -- see https://github.com/nodesource/distributions/issues/33
-RUN curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_14.15.1-1nodesource1_amd64.deb \
+RUN curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_14.16.0-1nodesource1_amd64.deb \
     && dpkg -i ./nodejs.deb \
     && rm nodejs.deb \
     && npm install -g yarn@1.22.5 \

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         volumes:
           - db_data_11:/var/lib/postgresql/data:delegated
     redis:
-        image: registry.lil.tools/library/redis:6.0.9
+        image: registry.lil.tools/library/redis:6.0.10
     elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.11.1
         environment:

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -4,7 +4,7 @@ services:
         build:
           context: ../services/docker
           dockerfile: extended-postgres.dockerfile
-        image: capstone-postgres:0.2
+        image: capstone-postgres:0.3
         environment:
             POSTGRES_PASSWORD: password
         volumes:

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -28,7 +28,7 @@ services:
           - 127.0.0.1:9200:9200
     web:
         build: .
-        image: capstone:0.3.118-15853d8a47d8ab0482387fca1d0aa7b8
+        image: capstone:0.3.119-b8c52fc5bf34e0c225eeb4965205a712
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     redis:
         image: registry.lil.tools/library/redis:6.0.9
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.2
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.11.1
         environment:
           - node.name=es01
           - bootstrap.memory_lock=true

--- a/services/docker/extended-postgres.dockerfile
+++ b/services/docker/extended-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM registry.lil.tools/library/postgres:11.10
+FROM registry.lil.tools/library/postgres:11.11
 
 RUN apt-get update && \
     apt-get install -y libpq-dev


### PR DESCRIPTION
This PR updates Elasticsearch, Redis, Postgres, and node, to match the versions that a Debian package upgrade wants to install. If that seems like too much all at once, I can break this into separate PRs. These are all minor version upgrades, except for redis, which is a point version upgrade.

https://www.elastic.co/guide/en/elasticsearch/reference/7.11/release-notes-7.11.1.html
https://www.elastic.co/guide/en/elasticsearch/reference/7.11/migrating-7.11.html#breaking-changes-7.11 from which I think the only possibly relevant thing is
> REST APIs that do not use a request body now return an error if a body is provided.

https://github.com/redis/redis/blob/6.0/00-RELEASENOTES

https://www.postgresql.org/docs/11/release-11-11.html from which
> A dump/restore is not required for those running 11.X.
> 
> However, see the second changelog item below, which describes cases in which reindexing indexes after the upgrade may be advisable.
> ...
> Fix CREATE INDEX CONCURRENTLY to wait for concurrent prepared transactions (Andrey Borodin)
> 
> At the point where CREATE INDEX CONCURRENTLY waits for all concurrent transactions to complete so that it can see rows they inserted, it must also wait for all prepared transactions to complete, for the same reason. Its failure to do so meant that rows inserted by prepared transactions might be omitted from the new index, causing queries relying on the index to miss such rows. In installations that have enabled prepared transactions (max_prepared_transactions > 0), it's recommended to reindex any concurrently-built indexes in case this problem occurred when they were built.


https://nodejs.org/en/blog/release/v14.16.0/