### PR TITLE
Bump redis to 6.0.11

### DIFF
--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         volumes:
           - db_data_11:/var/lib/postgresql/data:delegated
     redis:
-        image: registry.lil.tools/library/redis:6.0.10
+        image: registry.lil.tools/library/redis:6.0.11
     elasticsearch:
         image: docker.elastic.co/elasticsearch/elasticsearch:7.11.2
         environment:


### PR DESCRIPTION
This is a low-urgency point release: https://github.com/redis/redis/blob/6.0/00-RELEASENOTES