### PR TITLE
Update Elasticsearch to 7.12.0

### DIFF
--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     redis:
         image: registry.lil.tools/library/redis:6.0.11
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.11.2
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.12.0
         environment:
           - node.name=es01
           - bootstrap.memory_lock=true


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/7.12/release-notes-7.12.0.html

Although the tests pass, and django-elasticsearch-dsl-drf (and the rest of the chain of dependencies) is reputed to work with 7.x, I'm not perfectly confident about this; https://www.elastic.co/guide/en/elasticsearch/reference/7.12/migrating-7.12.html#breaking-changes-7.12 has

> The search APIs fields parameter returns fields inside nested fields grouped together.
> 
> Details
> In earlier versions, fields retrieved via fields in the search API were returned as a flat list. From 7.12 on, fields inside an object that is mapped using the nested field type are grouped together to maintain the independence of each object inside the original nested array.

which struck me as a change that might require updates to one or more of the Python packages in question.