### PR TITLE
Update circleci cache key to match update_docker_image_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,9 @@ jobs:
       # Docker image building and caching
       # This block shaves a minute or two off of the test runtime by using cached docker images.
       # Otherwise we could omit this step entirely and let `docker-compose run` build what it needs to.
+      # List of files in the cache key should match the ones checked in update_docker_image_version.
       - restore_cache:
-          key: docker-images-{{ checksum "docker-compose.yml" }}
+          key: docker-images-{{ checksum "docker-compose.yml" }}-{{ checksum "Dockerfile" }}-{{ checksum "requirements.txt" }}-{{ checksum "yarn.lock" }}
       - run:
           name: "Build docker images"
           command: |
@@ -40,7 +41,7 @@ jobs:
               docker save -o ~/docker-cache.tar capstone capstone-postgres
             fi
       - save_cache:
-          key: docker-images-{{ checksum "docker-compose.yml" }}
+          key: docker-images-{{ checksum "docker-compose.yml" }}-{{ checksum "Dockerfile" }}-{{ checksum "requirements.txt" }}-{{ checksum "yarn.lock" }}
           paths:
             - "~/docker-cache.tar"
 

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -100,6 +100,7 @@ def update_docker_image_version():
     import re
 
     # get hash of Dockerfile input files
+    # if this list changes, also update .circleci/config.yml
     paths = ['Dockerfile', 'requirements.txt', 'yarn.lock']
     hasher = hashlib.sha256()
     for path in paths:


### PR DESCRIPTION
Tests are failing currently on dev because the circleci cache key assumed that update_docker_image_version had always been called already, which isn't true anymore.

This could be fancier, like ... a shell script that is called by both config.yml and update_docker_image_version to get the file hash. I did it less DRY but with less moving parts for now.