### PR TITLE
Turn chronolawgic on, new lab settings setup

### DIFF
--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -695,5 +695,5 @@ RESOLVE_FRONTEND_PREFIX = 'http://cite.case.test:8000'
 
 PYTHON_BINARY = sys.executable
 
-# show labs features
-LABS = False
+# a list of labs projects to hide
+LABS_HIDDEN = []

--- a/capstone/config/settings/settings_dev.py
+++ b/capstone/config/settings/settings_dev.py
@@ -88,5 +88,5 @@ ADMINS = [('John', 'john@example.com'), ('Mary', 'mary@example.com')]
 # Reveal 'draft' markdown documents
 DOCS_SHOW_DRAFTS = True
 
-# show labs features
-LABS = True
+# a list of labs projects to hide
+LABS_HIDDEN = []

--- a/capstone/config/settings/settings_pytest.py
+++ b/capstone/config/settings/settings_pytest.py
@@ -18,4 +18,3 @@ PASSWORD_HASHERS = [
     'django.contrib.auth.hashers.UnsaltedMD5PasswordHasher',
 ] + PASSWORD_HASHERS
 
-LABS = True

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -1618,8 +1618,6 @@ def print_harvard_ip_ranges():
 
 @task
 def ingest_labs_fixtures():
-    if not settings.LABS:
-        return
     fixtures = [
         ('default', 'labs', ('timeline', )),
     ]

--- a/capstone/labs/urls.py
+++ b/capstone/labs/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
 
 # Project URLs- make discreet groups of URLs for each project
 
-if 'chronolawgic' in settings.LABS_HIDDEN:
+if 'chronolawgic' not in settings.LABS_HIDDEN:
     # # # # chronolawgic # # # #
     urlpatterns += [
         path('chronolawgic/', LabMarkdownView.as_view(template_name='lab/chronolawgic/about-chronolawgic.md'),

--- a/capstone/labs/urls.py
+++ b/capstone/labs/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
 
 # Project URLs- make discreet groups of URLs for each project
 
-if settings.LABS:
+if 'chronolawgic' in settings.LABS_HIDDEN:
     # # # # chronolawgic # # # #
     urlpatterns += [
         path('chronolawgic/', LabMarkdownView.as_view(template_name='lab/chronolawgic/about-chronolawgic.md'),


### PR DESCRIPTION
The LABS boolean setting is now the LABS_HIDDEN list. In the labs urls.py, add a check to see if the project name is in the LABS_HIDDEN list. If we want to retire something or it needs to be taken out of production because it's problematic for some reason, just add it to the list in the base settings.