### PR TITLE
[chrono] basic clobber stopper and test

### DIFF
--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -12,7 +12,9 @@ geoip2              # local IP geolocation
 numpy               # simhash calculation
 requests
 
+# chronolawgic
 shortuuid           # for chronolawgic timeline uuids
+dictdiffer          # supports a hack to avoid clobbering timelines with outdated data
 
 # celery
 celery[redis,sqs]   # task queue

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -266,6 +266,10 @@ decorator==4.4.1 \
     #   ipython
     #   networkx
     #   retry
+dictdiffer==0.8.1 \
+    --hash=sha256:1adec0d67cdf6166bda96ae2934ddb5e54433998ceab63c984574d187cc563d2 \
+    --hash=sha256:d79d9a39e459fe33497c858470ca0d2e93cb96621751de06d631856adfd9c390
+    # via -r requirements.in
 diff-match-patch==20181111 \
     --hash=sha256:a809a996d0f09b9bbd59e9bbd0b71eed8c807922512910e05cbd3f9480712ddb
     # via -r requirements.in


### PR DESCRIPTION
Was going to split up all of the timeline operations into separate API endpoints, but since the whole point is to avoid clobbering the existing timeline if the site gets out-of-sync, this seems to do just as good of a job. It calculates the delta between the new and old timeline and makes sure there aren't more changes in one request than can be changed in the interface. If it does, then the API 500s and the user gets a red flash error in the interface.