### PR TITLE
Always use disambiguated frontend urls in disambiguation page

### DIFF
--- a/capstone/cite/templates/cite/citation_failed.html
+++ b/capstone/cite/templates/cite/citation_failed.html
@@ -42,7 +42,7 @@
           <h4 class="case-name">Multiple cases match:</h4>
           <ul>
             {% for case in resolved.cap %}
-              <li><a href="{{ case.frontend_url }}">{{ case.full_cite }}</a></li>
+              <li><a href="{{ case.case_obj.get_unambiguous_frontend_url }}">{{ case.full_cite }}</a></li>
             {% endfor %}
           </ul>
         {% endif %}

--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -321,6 +321,9 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
                 if len(resolved_by_source['cap']) == 1:
                     resolved_case = resolved_by_source['cap'][0]
                     case = CaseDocument.get(resolved_case['source_id'])
+                else:
+                    for resolved_case in resolved_by_source['cap']:
+                        resolved_case['case_obj'] = CaseMetadata.objects.get(pk=resolved_case['source_id'])
             else:
                 cap_candidates = {
                     c.id: c


### PR DESCRIPTION
This is a partial fix to #1700 and #1791 -- we now always generate a disambiguated link for each case on the disambiguation page instead of using the stored `frontend_url` value for each case. There's an underlying bug where two cases can sometimes end up with the same `frontend_url` value, which I should track down, but in the meantime this should allow both cases to be reached from the disambiguation page.