### PR TITLE
XML and HTML serialization/deserialization tweaks

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -12,7 +12,6 @@ from model_utils import FieldTracker
 import nacl
 import nacl.encoding
 import nacl.secret
-from pyquery import PyQuery
 from bs4 import BeautifulSoup
 
 from django.conf import settings
@@ -36,7 +35,7 @@ from scripts.extract_images import extract_images
 from scripts.fix_court_tag.fix_court_tag import fix_court_tag
 from scripts.helpers import (special_jurisdiction_cases, jurisdiction_translation, parse_xml,
                              serialize_xml, jurisdiction_translation_long_name,
-                             short_id_from_s3_key, copy_file, normalize_cite)
+                             short_id_from_s3_key, copy_file, normalize_cite, parse_html)
 from scripts.process_metadata import get_case_metadata, parse_decision_date
 
 from elasticsearch.helpers import BulkIndexError
@@ -1278,7 +1277,7 @@ class CaseMetadata(models.Model):
         return analyses
 
     def get_json_from_html(self, html):
-        casebody_pq = PyQuery(html)
+        casebody_pq = parse_html(html)
         casebody_pq.remove(
             '.page-label,.footnotemark,.bracketnum,.footnote > a')  # remove page numbers and footnote numbers from text/json
 

--- a/capstone/scripts/extract_cites.py
+++ b/capstone/scripts/extract_cites.py
@@ -11,10 +11,9 @@ from eyecite.find_citations import get_citations
 from eyecite.models import FullCaseCitation, CaseCitation
 from eyecite.tokenizers import HyperscanTokenizer, EXTRACTORS
 from eyecite.utils import is_balanced_html
-from pyquery import PyQuery
 
 from capweb.helpers import reverse
-from scripts.helpers import serialize_xml, parse_xml, serialize_html, normalize_cite
+from scripts.helpers import serialize_xml, parse_xml, serialize_html, normalize_cite, parse_html
 
 
 ### ENTRY POINTS ###
@@ -38,11 +37,11 @@ def extract_citations(case, html, xml):
     # Annotation is faster if we extract paragraph by paragraph. So first get an index of each paragraph in the
     # html and xml to insert annotations into, and parse a cleaned version of the source html to extract citations
     # from:
-    html_pq = PyQuery(html)
+    html_pq = parse_html(html)
     html_els = {el.attr('id'): el for el in html_pq('[id]').items()}
     xml_pq = parse_xml(xml)
     xml_els = {el.attr('id'): el for el in xml_pq('[id]').items()}
-    clean_html_pq = PyQuery(clean_text(html))
+    clean_html_pq = parse_html(clean_text(html))
     clean_html_pq('.page-label').remove()
 
 

--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -196,28 +196,30 @@ def read_file(path):
 
 
 def parse_xml(xml):
-    """
-        Parse XML with PyQuery.
-    """
+    """Parse trusted XML with PyQuery."""
 
     # lxml requires byte string
     if type(xml) == str:
         xml = xml.encode('utf8')
 
-    return PyQuery(xml, parser='xml', namespaces=nsmap)
+    # use custom parser with huge_tree=True to disable xml bomb protection for very large cases
+    tree = etree.fromstring(xml, parser=etree.XMLParser(huge_tree=True))
+    return PyQuery(tree, parser='xml', namespaces=nsmap)
+
+
+def parse_html(html):
+    """Parse html with PyQuery."""
+    # no custom parser like parse_xml because xml bomb protection doesn't apply to html
+    return PyQuery(html)
 
 
 def serialize_xml(xml):
-    """
-        Write PyQuery object back to utf-8 bytestring.
-    """
+    """Write PyQuery object back to utf-8 bytestring."""
     return b''.join([etree.tostring(e, encoding='utf-8', xml_declaration=True) for e in xml]) + b'\n'
 
 
 def serialize_html(html):
-    """
-        Write PyQuery object back to HTML.
-    """
+    """Write PyQuery object back to HTML."""
     return html.outer_html()
 
 

--- a/capstone/scripts/render_case.py
+++ b/capstone/scripts/render_case.py
@@ -269,7 +269,7 @@ class VolumeRenderer:
             Render <casebody> as HTML
         """
         self.format = 'html'
-        return self.render_markup(case).replace('\xad', '')
+        return self.render_markup(case, method='html').replace('\xad', '')
 
     def render_xml(self, case):
         """
@@ -297,7 +297,7 @@ class VolumeRenderer:
             par['blocks'] = [blocks_by_id[id] for id in par['block_ids']]
         return opinions
 
-    def render_markup(self, case):
+    def render_markup(self, case, method='xml'):
         """
             Core renderer.
         """
@@ -342,7 +342,8 @@ class VolumeRenderer:
                 else:
                     case_el.append(opinion_el)
 
-        return etree.tostring(case_el, encoding=str, pretty_print=self.pretty_print)
+        etree.indent(case_el)
+        return etree.tostring(case_el, encoding=str, pretty_print=self.pretty_print, method=method)
 
     def make_case_el(self, case):
         """ Make <section class='case'>, or <casebody> """

--- a/capstone/test_data/test_fixtures/helpers.py
+++ b/capstone/test_data/test_fixtures/helpers.py
@@ -2,7 +2,7 @@ import difflib
 import hashlib
 from pathlib import Path
 
-from scripts.helpers import parse_xml
+from scripts.helpers import parse_xml, parse_html
 
 
 def file_hash(path):
@@ -68,9 +68,16 @@ def elements_equal(e1, e2, ignore={}, ignore_trailing_whitespace=False, tidy_sty
     # If you've gotten this far without an exception, the elements are equal
     return True
 
+
 def xml_equal(s1, s2, **kwargs):
     e1 = parse_xml(s1)[0]
     e2 = parse_xml(s2)[0]
+    return elements_equal(e1, e2, **kwargs)
+
+
+def html_equal(s1, s2, **kwargs):
+    e1 = parse_html(s1)[0]
+    e2 = parse_html(s2)[0]
     return elements_equal(e1, e2, **kwargs)
 
 


### PR DESCRIPTION
* Use `XMLParser(huge_tree=True)` to read our largest cases.
* Use `etree.indent` and `method='html'` to format our HTML more consistently.