### PR TITLE
Remove unused citations API endpoint

### DIFF
--- a/capstone/capapi/api_urls.py
+++ b/capstone/capapi/api_urls.py
@@ -16,7 +16,6 @@ router.register('reporters', api_views.ReporterViewSet)
 router.register('bulk', api_views.CaseExportViewSet)
 router.register('ngrams', api_views.NgramViewSet, basename='ngrams')
 router.register('user_history', api_views.UserHistoryViewSet)
-router.register('citations', api_views.ExtractedCitationViewSet)
 
 unstable_router = routers.DefaultRouter()
 unstable_router.register('resolve', api_views.ResolveDocumentViewSet, basename="resolve")

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -64,14 +64,6 @@ class CitationWithCaseSerializer(CitationSerializer):
         fields = CitationSerializer.Meta.fields + ('case_id', 'case_url')
 
 
-class ExtractedCitationSerializer(serializers.ModelSerializer):
-    cited_by = serializers.HyperlinkedRelatedField(view_name='cases-detail', read_only=True, lookup_field='id')
-
-    class Meta:
-        model = models.ExtractedCitation
-        fields = ('id', 'cite', 'cited_by')
-
-
 class JurisdictionSerializer(serializers.ModelSerializer):
     url = serializers.HyperlinkedIdentityField(
         view_name="jurisdiction-detail",

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -36,7 +36,6 @@ def test_flow(client, unrestricted_case, elasticsearch):
     ("reporter", "pk", "full_name"),
     ("volume_metadata", "pk", "title"),
     ("case_export", "pk", "file_name"),
-    ("extracted_citation", "pk", "cite"),
 ])
 def test_model_endpoint(request, client, fixture_name, detail_attr, comparison_attr):
     """ Generic test to kick the tires on -list and -detail for model endpoints. """

--- a/capstone/capapi/tests/test_serializers.py
+++ b/capstone/capapi/tests/test_serializers.py
@@ -24,14 +24,3 @@ def test_CaseDocumentSerializerWithCasebody(api_request_factory, case_factory, e
     assert len(serialized.data) == 3
     for case in serialized.data:
         assert 'casebody' in case
-
-
-@pytest.mark.django_db
-def test_ExtractedCitationSerializer(api_request_factory, extracted_citation_factory):
-    extractedcitation = extracted_citation_factory()
-    request = api_request_factory.get(api_reverse("extractedcitation-list"))
-    serializer_context = {'request': Request(request)}
-
-    serialized = serializers.ExtractedCitationSerializer(extractedcitation, context=serializer_context)
-    assert 'cite' in serialized.data
-    assert serialized.data.get('cite') == extractedcitation.cite

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -320,11 +320,6 @@ class CaseExportViewSet(BaseViewSet):
         return response
 
 
-class ExtractedCitationViewSet(BaseViewSet):
-    serializer_class = serializers.ExtractedCitationSerializer
-    queryset = models.ExtractedCitation.objects.order_by('pk')
-
-
 class NgramViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     http_method_names = ['get']
     filterset_class = filters.NgramFilter

--- a/capstone/capweb/templates/docs/02_site_features/03_api.md
+++ b/capstone/capweb/templates/docs/02_site_features/03_api.md
@@ -395,19 +395,3 @@ Under `cal`, there is an array of objects, each containing the counts for a spec
 results from 1984, that's the only year listed. Under `count`, there's `40, 4589927`, meaning *4,589,927* terms were 
 indexed for California in 1984, and 40 of those are *raisins*. Under `doc_count` there's `1, 1237`, meaning *1,237* 
 cases were indexed for California in 1984, and *raisins* shows up in *1* of those cases.
-    
-{# ==============> Citations <============== #}
-## Citations {: id="endpoint-citations" }
-
-[{% api_url "extractedcitation-list" %}]({% api_url "extractedcitation-list" %})
-{: class="endpoint-link" }
-
-Return a list of citations that cases have cited to.
-      
-### Endpoint Parameters
-
-* `cursor` 
-{: add_list_class="parameter-list" }
-    * __data type:__    string
-    * __description:__  A value provided by a previous search result to go to the next page of results
-

--- a/capstone/capweb/templates/docs/03_learning_tracks/01_APIs/02_api_tutorial.md
+++ b/capstone/capweb/templates/docs/03_learning_tracks/01_APIs/02_api_tutorial.md
@@ -26,8 +26,7 @@ In a separate tab, navigate to <{% api_url "api-root" %}>
         "volumes": "{% api_url "volumemetadata-list" %}",
         "reporters": "{% api_url "reporter-list" %}",
         "ngrams": "{% api_url "ngrams-list" %}",
-        "user_history": "{% api_url "api-root" %}user_history/",
-        "citations": "{% api_url "extractedcitation-list" %}"
+        "user_history": "{% api_url "api-root" %}user_history/"
     }
 
 Congratulations! You just executed your first query to the CAP API! While the results might not be incredibly exciting, 
@@ -235,7 +234,7 @@ save it to a file. Help to install curl on your system is a quick google search 
 macOS, have curl preinstalled.
 
     $ curl {% api_url "api-root" %}
-    {"cases":"{% api_url "api-root" %}","jurisdictions":"{% api_url "jurisdiction-list" %}","courts":"{% api_url "court-list" %}","volumes":"{% api_url "volumemetadata-list" %}","reporters":"{% api_url "reporter-list" %}","ngrams":"{% api_url "ngrams-list" %}","user_history":"{% api_url "api-root" %}user_history/","citations":"{% api_url "extractedcitation-list" %}"}
+    {"cases":"{% api_url "api-root" %}","jurisdictions":"{% api_url "jurisdiction-list" %}","courts":"{% api_url "court-list" %}","volumes":"{% api_url "volumemetadata-list" %}","reporters":"{% api_url "reporter-list" %}","ngrams":"{% api_url "ngrams-list" %}","user_history":"{% api_url "api-root" %}user_history/"}
 
 <small>[Browsable API Link]({% api_url "api-root" %})</small>
 
@@ -248,7 +247,6 @@ Hmm... that's not very readable. On macOS and Linux, we can format the output us
        "jurisdictions" : "{% api_url "jurisdiction-list" %}",
        "ngrams" : "{% api_url "ngrams-list" %}",
        "user_history" : "{% api_url "api-root" %}user_history/",
-       "citations" : "{% api_url "extractedcitation-list" %}",
        "volumes" : "{% api_url "volumemetadata-list" %}",
        "cases" : "{% api_url "cases-list" %}"
     }
@@ -275,8 +273,7 @@ Let's take a look at the output of our example command:
         "volumes": "{% api_url "volumemetadata-list" %}",
         "reporters": "{% api_url "reporter-list" %}",
         "ngrams": "{% api_url "ngrams-list" %}",
-        "user_history": "{% api_url "api-root" %}user_history/",
-        "citations": "{% api_url "extractedcitation-list" %}"
+        "user_history": "{% api_url "api-root" %}user_history/"
     }
 <small>[Browsable API Link]({% api_url "api-root" %})</small>
 


### PR DESCRIPTION
This removes the /v1/citations API endpoint. We currently don't have any usecases for that endpoint, it doesn't offer any features, it's barely documented, and it doesn't have anything behind it like an Elasticsearch index that it would need to support searching 100 million entries. It's also generating some janky sql queries at the moment. We can make a new endpoint if we figure out a usecase for it ... but possibly everything it might want to do is better handled by the cases endpoint, resolve endpoint, or bulk data exports.