### PR TITLE
sync_case_body_cache_for_vol tweak

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1224,7 +1224,7 @@ class CaseMetadata(models.Model):
             body_cache = self.body_cache
         except CaseBodyCache.DoesNotExist:
             body_cache = self.body_cache = CaseBodyCache(metadata=self)
-        changed = False
+        changed = bool(cites_to_delete or cites_to_create)
         for k in ['text', 'html', 'xml', 'json']:
             new_val = locals()[k]
             new_val = self.redact_obj(new_val)

--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -41,7 +41,8 @@ def record_task_status_for_volume(task, volume_id):
         Context manager to record in volume.task_statuses whether the given task succeeds or fails.
     """
     try:
-        yield
+        with transaction.atomic(using='capdb'):
+            yield
     except Exception as e:
         volume = VolumeMetadata.objects.get(pk=volume_id)
         volume.task_statuses[task.name] = {
@@ -407,7 +408,6 @@ def retrieve_images_from_all_cases(update_existing=False):
 
 
 @shared_task(bind=True, acks_late=True)  # use acks_late for tasks that can be safely re-run if they fail
-@transaction.atomic(using='capdb')
 def retrieve_images_from_cases(self, volume_id, update_existing=True):
     """
         Create or update case images for each volume


### PR DESCRIPTION
A couple of volumes got out of sync because of a crash during sync_case_body_cache_for_vol. Fixes:

* Make record_task_status_for_volume use a transaction, so any crashes within that block can't result in weird data in the database
* Expand the logic for checking whether a case needs to be saved after sync_case_body_cache, to deal with the data that got out of sync before (html successfully annotated with ExtractedCitations that weren't successfully saved)