### PR TITLE
Handle example-search clicks on trend searches with wildcards

### DIFF
--- a/capstone/static/js/trends/main.vue
+++ b/capstone/static/js/trends/main.vue
@@ -898,9 +898,10 @@
                   maxYear = year;
                 years[year] = yearData;
               }
+              const params = {...result.params, jurisdiction: jurName, q: gram};
               results[(jurName === "total" ? "" : this.jurisdictionLookup[jurName] + ": ") + gram] = {
                 data: years,
-                params: result.params,
+                params: params,
               };
             }
           }

--- a/capstone/static/js/trends/search-results.vue
+++ b/capstone/static/js/trends/search-results.vue
@@ -67,7 +67,7 @@
           decision_date_max: `${endYear}-12-31`,
           page_size: 5,
         };
-        if (params.jurisdiction)
+        if (params.jurisdiction && params.jurisdiction !== "total")
           searchParams.jurisdiction = params.jurisdiction;
         this.showLoading = true;
         Vue.nextTick().then(() => { this.$refs.loadingMessage.focus() });


### PR DESCRIPTION
This handles wildcard substitution so when you click on a Trends search result for a query like `ride a *` or `*: library` the search matches the particular line you clicked on. Note that assets need to be rebuilt by CI on the develop branch before deployment.

Fixes #1084 
Fixes #1498