### PR TITLE
Only compress static assets in settings_prod

### DIFF
--- a/capstone/config/settings/settings_base.py
+++ b/capstone/config/settings/settings_base.py
@@ -238,7 +238,7 @@ STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
 ]
 
-STATICFILES_STORAGE = 'capdb.storages.WhitenoisePipelineStorage'
+STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'
 
 PIPELINE = {
     'COMPILERS': (

--- a/capstone/config/settings/settings_prod.py
+++ b/capstone/config/settings/settings_prod.py
@@ -109,3 +109,7 @@ VALIDATE_EMAIL_SIGNUPS = True
 
 RESOLVE_API_PREFIX = 'https://api.case.law/v1/cases/'
 RESOLVE_FRONTEND_PREFIX = 'https://cite.case.law'
+
+# for production, compress static files and add hashes to file names for permanent caching.
+# this takes about 8x as long as plain pipeline.storage.PipelineStorage
+STATICFILES_STORAGE = 'capdb.storages.WhitenoisePipelineStorage'


### PR DESCRIPTION
This shaves about two minutes off of each CI run. The downside is if we upgrade `django`, `django-pipeline`, or `whitenoise`, we should really make sure it successfully deploys to stage before going to production. I think that should be true anyway, though.