### PR TITLE
Use in_scope for snippet counting; update date snippet

### DIFF
--- a/capstone/scripts/tests/test_snippet_updaters.py
+++ b/capstone/scripts/tests/test_snippet_updaters.py
@@ -16,11 +16,15 @@ def test_map_numbers(case_factory, jurisdiction):
 
 @pytest.mark.django_db(databases=['capdb'])
 def test_cases_by_decision_date(case_factory):
-    cases = [case_factory() for i in range(3)]
+    dates = ["2000", "2000-04", "2000-04", "2000-04-15"]
+    _ = [case_factory(decision_date_original=d) for d in dates]
     update_snippets.cases_by_decision_date_tsv()
     cases_by_decision_date = Snippet.objects.get(label='cases_by_decision_date')
-    for case in cases:
-        assert case.decision_date_original in cases_by_decision_date.contents
+    assert cases_by_decision_date.contents == (
+        '"2000"\t4\t"https://api.case.test:8000/v1/cases/?decision_date__gte=2000&decision_date__lte=2000-12-31"\r\n'
+        '"2000-04"\t3\t"https://api.case.test:8000/v1/cases/?decision_date__gte=2000-04&decision_date__lte=2000-04-31"\r\n'
+        '"2000-04-15"\t1\t"https://api.case.test:8000/v1/cases/?decision_date__gte=2000-04-15&decision_date__lte=2000-04-15"\r\n'
+    )
 
 @pytest.mark.django_db(databases=['capdb'])
 def test_cases_by_jurisdiction(jurisdiction, case_factory):

--- a/capstone/scripts/update_snippets.py
+++ b/capstone/scripts/update_snippets.py
@@ -1,12 +1,14 @@
 import io
 import csv
+from collections import defaultdict
 
 from django.db import connections
-from django.db.models import Count, Case, When, IntegerField
+from django.db.models import Count, Q
 from capdb.models import Reporter, Jurisdiction, CaseMetadata, Snippet, Court
 import json
 from capweb.templatetags.api_url import api_url
 from tqdm import tqdm
+
 
 def update_all():
     update_map_numbers()
@@ -21,25 +23,40 @@ def cases_by_decision_date_tsv():
     """
         count of all cases, grouped by decision date
     """
-    by_date = CaseMetadata.objects.all().values('decision_date').annotate(Count('decision_date')).order_by('decision_date')
+    by_date = (CaseMetadata.objects
+        .in_scope()
+        .values('decision_date_original')
+        .annotate(Count('decision_date_original'))
+        .order_by('decision_date_original'))
     label="cases_by_decision_date"
     snippet_format="text/tab-separated-values"
     output = io.StringIO()
-    writer = csv.writer(output, delimiter='\t',quoting=csv.QUOTE_NONNUMERIC)
+    writer = csv.writer(output, delimiter='\t', quoting=csv.QUOTE_NONNUMERIC)
+
+    # count dates
+    date_counter = defaultdict(int)
     for group in tqdm(by_date):
-        if group['decision_date__count'] == 0:
-            continue
-        writer.writerow(
-            [
-                group['decision_date'],
-                group['decision_date__count'],
-                '{}?decision_date_min={}&decision_date_max={}'.format(
-                    api_url('cases-list'),
-                    group['decision_date'],
-                    group['decision_date']
-                )
-            ]
-        )
+        print(group)
+        date = group['decision_date_original']
+        count = group['decision_date_original__count']
+        # count year
+        date_counter[date[:4]] += count
+        # count year-month
+        if len(date) > 4:
+            date_counter[date[:7]] += count
+        # count year-month-day
+        if len(date) > 7:
+            date_counter[date] += count
+
+    # write dates
+    cases_url = api_url('cases-list')
+    for date, count in date_counter.items():
+        max_date = date + "0000-12-31"[len(date):]
+        writer.writerow([
+            date,
+            count,
+            f"{cases_url}?decision_date__gte={date}&decision_date__lte={max_date}",
+        ])
 
     write_update(label, snippet_format, output.getvalue())
 
@@ -51,7 +68,7 @@ def cases_by_jurisdiction_tsv():
     snippet_format="text/tab-separated-values"
     output = io.StringIO()
     writer = csv.writer(output, delimiter='\t',quoting=csv.QUOTE_NONNUMERIC)
-    for jurisdiction in tqdm(Jurisdiction.objects.order_by('name').annotate(case_count=Count('case_metadatas'))):
+    for jurisdiction in tqdm(Jurisdiction.objects.order_by('name').annotate(case_count=Count('case_metadatas', filter=Q(case_metadatas__in_scope=True)))):
         if jurisdiction.case_count == 0:
             continue
         writer.writerow(
@@ -75,8 +92,7 @@ def cases_by_reporter_tsv():
     snippet_format="text/tab-separated-values"
     output = io.StringIO()
     writer = csv.writer(output, delimiter='\t',quoting=csv.QUOTE_NONNUMERIC)
-    for reporter in tqdm(Reporter.objects.order_by('full_name').annotate(case_count=Count(
-            Case(When(case_metadatas__duplicative=False, then=1), output_field=IntegerField())))):
+    for reporter in tqdm(Reporter.objects.order_by('full_name').annotate(case_count=Count('case_metadatas', filter=Q(case_metadatas__in_scope=True)))):
         if reporter.case_count == 0:
             continue
         writer.writerow(
@@ -106,7 +122,7 @@ def update_map_numbers():
         FROM capdb_jurisdiction j 
           LEFT JOIN capdb_casemetadata c ON j.id=c.jurisdiction_id 
         WHERE
-          c.duplicative IS FALSE
+          c.in_scope IS True
         GROUP BY j.id;
     """)
     # get column names from sql query


### PR DESCRIPTION
A couple of tweaks to the aggregate case count snippets inspired by a support request:

* snippets filter cases to those `in_scope`
* `cases_by_decision_date` snippet changes how it counts dates, so `2000` shows total count of cases from 2000, `2000-04` shows count of cases from April 2000, and `2000-04-15` shows count of cases from April 15, 2000.