### PR TITLE
Match version to docker-compose.override.yml

### DIFF
--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.2'
 services:
     db:
         image: harvardlil/capstone-postgres:0.4-027c54f92cc347a7b1f3bdc52a29e4a3


### PR DESCRIPTION
This should handle `Version mismatch: file ./docker-compose.yml specifies version 2.0 but extension file ./docker-compose.override.yml uses version 2.2`.