### PR TITLE
Update Elasticsearch to 7.13.0

### DIFF
--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     redis:
         image: redis:6.0.11
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.12.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.13.0
         environment:
           - node.name=es01
           - bootstrap.memory_lock=true


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.13.0.html

https://www.elastic.co/guide/en/elasticsearch/reference/current/migrating-7.13.html#breaking-changes-7.13