### PR TITLE
Package updates

### DIFF
--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -70,6 +70,7 @@ flaky              # retry flaky tests
 retry              # re-run blocks of code until the ES index updates, but fail if they don't end up working
 pathlib2           # to keep --require-hashes happy; from pytest
 beautifulsoup4
+mock
 
 # SCSS
 libsasscompiler     # for compiling scss in pipeline

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -26,13 +26,6 @@ attrs==18.2.0 \
     # via
     #   jsonschema
     #   pytest
-aws-sam-translator==1.13.1 \
-    --hash=sha256:9b7b40ba50a2befe255e48549d8a4bb6c63490cf4c0b1f3f2e6a6f25b5723483
-    # via cfn-lint
-aws-xray-sdk==0.95 \
-    --hash=sha256:72791618feb22eaff2e628462b0d58f398ce8c1bacfa989b7679817ab1fad60c \
-    --hash=sha256:9e7ba8dd08fd2939376c21423376206bff01d0deaea7d7721c6b35921fed1943
-    # via moto
 babel==2.6.0 \
     --hash=sha256:6778d85147d5d85345c14a26aada5e478ab04e39b078b0745ee6870c2b5cf669 \
     --hash=sha256:8cba50f48c529ca3fa18cf81fa9403be176d374ac4d60738b839122dfaaa3d23
@@ -75,20 +68,15 @@ beautifulsoup4==4.9.3 \
 billiard==3.6.0.0 \
     --hash=sha256:756bf323f250db8bf88462cd042c992ba60d8f5e07fc5636c24ba7d6f4261d84
     # via celery
-boto3==1.14.32 \
-    --hash=sha256:3cf7c9ce187bcd3c4961c6a51eeb472b75649ef00b67d876dd94735bf64fec34 \
-    --hash=sha256:d494a23295b2db9920e85391dc8106dc08d91dd40eeba5c05002771fe10f8853
+boto3==1.17.86 \
+    --hash=sha256:4f15867701b28ca78eb56cfc4ff5f0e5ee7db42558dbc445f1a7395e467ac3e9 \
+    --hash=sha256:85c1875ab17c36ffb3ad1b0f4b52e3418e0fd1ef7d167ff4e545fb052b7cc1f8
     # via
-    #   aws-sam-translator
     #   celery
     #   moto
-boto==2.49.0 \
-    --hash=sha256:147758d41ae7240dc989f0039f27da8ca0d53734be0eb869ef16e3adcfa462e8 \
-    --hash=sha256:ea0d3b40a2d852767be77ca343b58a9e3a4b00d9db440efb8da74b4e58025e5a
-    # via moto
-botocore==1.17.32 \
-    --hash=sha256:52a80cb721160b687179bd7077e63d775130455a678bf4280fb37c524c2bd67d \
-    --hash=sha256:980c71b91d48ee3378a5f00c4530fdf2213a956e3924ca37859f6b3193f779b0
+botocore==1.20.86 \
+    --hash=sha256:2a48154fd7d61a67d861b0781e204918508aa8af094391f03ad4047c979dc9c7 \
+    --hash=sha256:bbdfd2adedb0cc9117cf411ef51cbd8fc19798e21e414f831ad9781e507ff1da
     # via
     #   boto3
     #   moto
@@ -181,10 +169,6 @@ cffi==1.14.5 \
     #   bcrypt
     #   cryptography
     #   pynacl
-cfn-lint==0.23.2 \
-    --hash=sha256:1a52cfb391ade08287c3f1a1f7c61715826e4b6ab2cdabe4e54676d2812778ff \
-    --hash=sha256:c8db39b43e50012dc53a7cd23e3e541cc34d0e4274f524072a10846f185e07e8
-    # via moto
 chardet==3.0.4 \
     --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
     --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
@@ -258,7 +242,6 @@ cryptography==3.4.6 \
     # via
     #   moto
     #   paramiko
-    #   sshpubkeys
 cssselect==1.0.3 \
     --hash=sha256:066d8bc5229af09617e24b3ca4d52f1f9092d9e061931f4184cd572885c23204 \
     --hash=sha256:3b5103e8789da9e936a68d993b70df732d06b8bb9a337a05ed4eb52c17ef7206
@@ -299,10 +282,6 @@ cython==0.29.16 \
     --hash=sha256:f516d11179627f95471cc0674afe8710d4dc5de764297db7f5bdb34bd92caff9 \
     --hash=sha256:fd6496b41eb529349d58f3f6a09a64cceb156c9720f79cebdf975ea4fafc05f0
     # via -r requirements.in
-datetime==4.3 \
-    --hash=sha256:371dba07417b929a4fa685c2f7a3eaa6a62d60c02947831f97d4df9a9e70dfd0 \
-    --hash=sha256:5cef605bab8259ff61281762cdf3290e459fbf0b4719951d5fab967d5f2ea0ea
-    # via moto
 decorator==4.4.1 \
     --hash=sha256:54c38050039232e1db4ad7375cfce6748d7b41c29e95a081c8a6d2c30364a2ce \
     --hash=sha256:5d19b92a3c8f7f101c8dd86afd86b0f061a8ce4540ab8cd401fa2542756bce6d
@@ -405,29 +384,10 @@ dnspython==1.16.0 \
     --hash=sha256:36c5e8e38d4369a08b6780b7f27d790a292b2b08eea01607865bf0936c558e01 \
     --hash=sha256:f69c21288a962f4da86e56c4905b49d11aba7938d3d740e80d9e366ee4f1632d
     # via email-normalize
-docker-pycreds==0.4.0 \
-    --hash=sha256:6ce3270bcaf404cc4c3e27e4b6c70d3521deae82fb508767870fdbf772d584d4 \
-    --hash=sha256:7266112468627868005106ec19cd0d722702d2b7d5912a28e19b826c3d37af49
-    # via docker
-docker==3.7.0 \
-    --hash=sha256:2840ffb9dc3ef6d00876bde476690278ab13fa1f8ba9127ef855ac33d00c3152 \
-    --hash=sha256:5831256da3477723362bc71a8df07b8cd8493e4a4a60cebd45580483edbe48ae
-    # via moto
-docutils==0.14 \
-    --hash=sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6 \
-    --hash=sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274 \
-    --hash=sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6
-    # via botocore
 drf-yasg==1.20.0 \
     --hash=sha256:8b72e5b1875931a8d11af407be3a9a5ba8776541492947a0df5bafda6b7f8267 \
     --hash=sha256:d50f197c7f02545d0b736df88c6d5cf874f8fea2507ad85ad7de6ae5bf2d9e5a
     # via -r requirements.in
-ecdsa==0.13.3 \
-    --hash=sha256:163c80b064a763ea733870feb96f9dd9b92216cfcacd374837af18e4e8ec3d4d \
-    --hash=sha256:9814e700890991abeceeb2242586024d4758c8fc18445b194a49bd62d85861db
-    # via
-    #   python-jose
-    #   sshpubkeys
 elasticsearch-dsl==7.3.0 \
     --hash=sha256:0ed75f6ff037e36b2397a8e92cae0ddde79b83adc70a154b8946064cb62f7301 \
     --hash=sha256:9390d8e5cf82ebad3505e7f656e407259cf703f5a4035f211cef454127672572
@@ -478,9 +438,6 @@ flatten-json==0.1.7 \
 flower==0.9.2 \
     --hash=sha256:a7a828c2dbea7e9cff1c86d63626f0eeb047b1b1e9a0ee5daad30771fb51e6d0
     # via -r requirements.in
-future==0.17.1 \
-    --hash=sha256:67045236dcfd6816dc439556d009594abf643e5eb48992e36beac09c2ca659b8
-    # via python-jose
 geoip2==3.0.0 \
     --hash=sha256:5869e987bc54c0d707264fec4710661332cc38d2dca5a7f9bb5362d0308e2ce0 \
     --hash=sha256:99ec12d2f1271a73a0a4a2b663fe6ce25fd02289c0a6bef05c0a1c3b30ee95a4
@@ -495,9 +452,7 @@ hyperscan==0.2.0 \
 idna==2.8 \
     --hash=sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407 \
     --hash=sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c
-    # via
-    #   moto
-    #   requests
+    # via requests
 img2pdf==0.3.3 \
     --hash=sha256:9d77c17ee65a736abe92ef8cba9cca009c064ea4ed74492c01aea596e41856cf
     # via -r requirements.in
@@ -548,28 +503,10 @@ joblib==0.16.0 \
     --hash=sha256:8f52bf24c64b608bf0b2563e0e47d6fcf516abc8cfafe10cfd98ad66d94f92d6 \
     --hash=sha256:d348c5d4ae31496b2aa060d6d9b787864dd204f9480baaa52d18850cb43e9f49
     # via nltk
-jsondiff==1.1.2 \
-    --hash=sha256:7e18138aecaa4a8f3b7ac7525b8466234e6378dd6cae702b982c9ed851d2ae21
-    # via moto
-jsonpatch==1.24 \
-    --hash=sha256:83f29a2978c13da29bfdf89da9d65542d62576479caf215df19632d7dc04c6e6 \
-    --hash=sha256:cbb72f8bf35260628aea6b508a107245f757d1ec839a19c34349985e2c05645a
-    # via cfn-lint
-jsonpickle==1.1 \
-    --hash=sha256:0231d6f7ebc4723169310141352d9c9b7bbbd6f3be110cf634575d2bf2af91f0 \
-    --hash=sha256:625098cc8e5854b8c23b587aec33bc8e33e0e597636bfaca76152249c78fe5c1
-    # via aws-xray-sdk
-jsonpointer==2.0 \
-    --hash=sha256:c192ba86648e05fdae4f08a17ec25180a9aef5008d973407b581798a83975362 \
-    --hash=sha256:ff379fa021d1b81ab539f5ec467c7745beb1a5671463f9dcc2b2d458bd361c1e
-    # via jsonpatch
 jsonschema==3.0.2 \
     --hash=sha256:5f9c0a719ca2ce14c5de2fd350a64fd2d13e8539db29836a86adc990bb1a068f \
     --hash=sha256:8d4a2b7b6c2237e0199c8ea1a6d3e05bf118e289ae2b9d7ba444182a2959560d
-    # via
-    #   aws-sam-translator
-    #   cfn-lint
-    #   swagger-spec-validator
+    # via swagger-spec-validator
 kombu==4.5.0 \
     --hash=sha256:389ba09e03b15b55b1a7371a441c894fd8121d174f5583bbbca032b9ea8c9edd \
     --hash=sha256:7b92303af381ef02fad6899fd5f5a9a96031d781356cd8e505fa54ae5ddee181
@@ -673,7 +610,9 @@ markupsafe==1.1.0 \
     --hash=sha256:f137c02498f8b935892d5c0172560d7ab54bc45039de8805075e19079c639a9c \
     --hash=sha256:f82e347a72f955b7017a39708a3667f106e6ad4d10b25f237396a7115d8ed5fd \
     --hash=sha256:fb7c206e01ad85ce57feeaaa0bf784b97fa3cad0d4a5737bc5295785f5c613a1
-    # via jinja2
+    # via
+    #   jinja2
+    #   moto
 maxminddb==1.5.2 \
     --hash=sha256:d0ce131d901eb11669996b49a59f410efd3da2c6dbe2c0094fe2fef8d85b6336
     # via geoip2
@@ -690,17 +629,20 @@ mirakuru==1.1.0 \
     --hash=sha256:4d6eede7ac4bf7e9742163f0c9f9e234eeb5838fb9f4646774433316dee93113 \
     --hash=sha256:7c535bf2aba41d8ad0f45731a7412cf0b18670c30a43d02e5246fd62f425c221
     # via pytest-redis
-mock==2.0.0 \
-    --hash=sha256:5ce3c71c5545b472da17b72268978914d0252980348636840bd34a00b5cc96c1 \
-    --hash=sha256:b158b6df76edd239b8208d481dc46b6afd45a846b7812ff0ce58971cf5bc8bba
-    # via moto
+mock==4.0.3 \
+    --hash=sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62 \
+    --hash=sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc
+    # via -r requirements.in
 more-itertools==5.0.0 \
     --hash=sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4 \
     --hash=sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc \
     --hash=sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9
-    # via pytest
-moto==1.3.13 \
-    --hash=sha256:95d48d8ebaad47fb5bb4233854cf1cf8523ec5307d50eb1e4017ce10f1960b66
+    # via
+    #   moto
+    #   pytest
+moto==2.0.8 \
+    --hash=sha256:812dcfdb460e6d43236f2c0f7774ede038716daef6db8a09dc5c16ea7e4de931 \
+    --hash=sha256:b5b4c596d6f44fe1f658429d0313a649d0861d7df91b2dbdb5cc20d1bb8daf39
     # via -r requirements.in
 msgpack==0.6.1 \
     --hash=sha256:26cb40116111c232bc235ce131cc3b4e76549088cb154e66a2eb8ff6fcc907ec \
@@ -808,10 +750,6 @@ pathlib2==2.3.5 \
 pathtools==0.1.2 \
     --hash=sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0
     # via watchdog
-pbr==5.1.1 \
-    --hash=sha256:f59d71442f9ece3dffc17bc36575768e1ee9967756e6b6535f0ee1f0054c3d68 \
-    --hash=sha256:f6d5b23f226a2ba58e14e49aa3b1bfaf814d0199144b95d78458212444de1387
-    # via mock
 pep517==0.10.0 \
     --hash=sha256:ac59f3f6b9726a49e15a649474539442cf76e0697e39df4869d25e68e880931b \
     --hash=sha256:eba39d201ef937584ad3343df3581069085bacc95454c80188291d5b3ac7a249
@@ -930,36 +868,6 @@ pycodestyle==2.6.0 \
 pycparser==2.19 \
     --hash=sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3
     # via cffi
-pycryptodome==3.7.3 \
-    --hash=sha256:06b779be9736710c109234f28ebef90ff6615c70c335e782d4f6d983c0c66b57 \
-    --hash=sha256:0cfa2a1d9ec697b8924729e86443d2b8fd8dbad0ca4cd322e9507d8b77fb71a0 \
-    --hash=sha256:0d6613ccd561eb6ef7029d59a47f58e63d840dcee0ed2eda19dafceaffe1e544 \
-    --hash=sha256:0f37f03864dc05b70ce11c023dea78f6af4f19adb48651976d512ba4d7210942 \
-    --hash=sha256:16f38a3d9735054cefaa0a5e272395aab585e7eb585cb1609cbea78e69a8da61 \
-    --hash=sha256:1a222250e43f3c659b4ebd5df3e11c2f112aab6aef58e38af55ef5678b9f0636 \
-    --hash=sha256:23df2d665c7f52ddf467d405de355b1ffbd08944442677bb072b33599748e09d \
-    --hash=sha256:624de350bc8f346da0f536b1dee6bd19b40c99fb783ba1ed09caceb783904fca \
-    --hash=sha256:733729141cf2e0706188f905fec9b27d40dd5a8e5ec232f95b82437e15c9ebf3 \
-    --hash=sha256:737248b34df3231ba77fad50897a267cc0718a3ecd71b1eb9d92605a2d12d32e \
-    --hash=sha256:825af2416abf8be0441c2b632d4a0825ce96033cab36b0ea008a71afc7e6ca17 \
-    --hash=sha256:8403b5adaabcaf7594331ce99a5eb834d0de5ce8f29d174db3f420b0fc450b77 \
-    --hash=sha256:861442e3bc8680b47c7c9bfcd34fd9a3683cd179e3e4eaaba13c60af2ce3a8d6 \
-    --hash=sha256:97e2fa022e2e92afbac4d9bc3c7263f7e6813b01b88398d7eb48dd000cfc81cb \
-    --hash=sha256:9f9b9dbabf286e35a6c4a3724fe48fe977acb0005aa6f08318960ac287108c1c \
-    --hash=sha256:a94ccb190cf8b1e0352d2b5f8984a44b3da0dfffdce21c4f3a6b8dc84d95e17a \
-    --hash=sha256:b9671b3ee8104deabee682f40540d65faf098bccb4d65bdd70eeccd87346856d \
-    --hash=sha256:be2403e4b65272516d7b3eeed73de0dbddf9802487c6faf2b202679def520c54 \
-    --hash=sha256:c02ad68c49d959f724f26a4861deefc4aad25a5e970e40dedeeaf0627140605d \
-    --hash=sha256:ca78f78dde52ccd1b4654d8911d9b33015bf3cf54385a664f248a11af7896d44 \
-    --hash=sha256:ce889584b07174047b554c17df9c48357134c48b517ef7008599e5677919e8d0 \
-    --hash=sha256:d0d41c7338753e9e12bf685c7b5c0c8d2df070c6af8b7e7dc8fa0ccab20a4c05 \
-    --hash=sha256:da05447b79754f703e53dae7b381d82234e062b5ca03cb96e64adc887d508dfd \
-    --hash=sha256:db53ea88fb38e3e054c2cb7d765b5dc4cea411b19be336e748b9b29f1b696ee5 \
-    --hash=sha256:e7eb9ffaf5757f76c25761fc6fce2aaecbbaf145c0743bd146d86ba038899bf1 \
-    --hash=sha256:ee5a6bba5a7517676a6afdf98ae4f65440132ed4a736c7c1fe762b464365a900 \
-    --hash=sha256:f162644a8618c85cc29a3b998cea76c790220677461c9b6fffcb8fc7b0ae4335 \
-    --hash=sha256:f6ab3c50b360160c38cb833f8855a42b9aa05ca30366a99bece8f161fa0c622b
-    # via python-jose
 pycurl==7.43.0.5 \
     --hash=sha256:1957c867e2a341f5526c107c7bbc5014d6e75fdc2a14294fcb8a47663fbd2e15 \
     --hash=sha256:50aee0469511a9708a1f1a50d510b5ec2013fc6f5e720c32bbcb3b9c7b0f45b1 \
@@ -1080,10 +988,6 @@ python-dateutil==2.8.1 \
     #   faker
     #   moto
     #   pandas
-python-jose==2.0.2 \
-    --hash=sha256:391f860dbe274223d73dd87de25e4117bf09e8fe5f93a417663b1f2d7b591165 \
-    --hash=sha256:3b35cdb0e55a88581ff6d3f12de753aa459e940b50fe7ca5aa25149bc94cb37b
-    # via moto
 python-redis-lock==3.3.1 \
     --hash=sha256:5316d473ce6ce86a774b9f9c110d84c3a9bd1a2abfda5d99e9c0c8a872a8e6d6 \
     --hash=sha256:f0649c49341fa943f19b8fbe93c3457df8a0a85006c88134465a16401fd1e553
@@ -1097,7 +1001,6 @@ pytz==2018.9 \
     # via
     #   babel
     #   celery
-    #   datetime
     #   django
     #   flower
     #   moto
@@ -1132,10 +1035,7 @@ pyyaml==5.4.1 \
     --hash=sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247 \
     --hash=sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6 \
     --hash=sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0
-    # via
-    #   cfn-lint
-    #   moto
-    #   swagger-spec-validator
+    # via swagger-spec-validator
 redis==3.2.1 \
     --hash=sha256:6946b5dca72e86103edc8033019cc3814c031232d339d5f4533b02ea85685175 \
     --hash=sha256:8ca418d2ddca1b1a850afa1680a7d2fd1f3322739271de4b704e0d4668449273
@@ -1204,15 +1104,12 @@ reportlab==3.5.13 \
     --hash=sha256:f3463f2cb40a1b515ac0133ba859eca58f53b56760da9abb27ed684c565f853c \
     --hash=sha256:facc3c9748ab1525fb8401a1223bce4f24f0d6aa1a9db86c55db75777ccf40f9
     # via -r requirements.in
-requests==2.22.0 \
-    --hash=sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4 \
-    --hash=sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31
+requests==2.25.1 \
+    --hash=sha256:27973dd4a904a4f13b263a19c866c13b92a39ed1c964655f025f3f8d3d75b804 \
+    --hash=sha256:c210084e36a42ae6b9219e00e48287def368a26d03a048ddad7bfee44f75871e
     # via
     #   -r requirements.in
-    #   aws-xray-sdk
-    #   cfn-lint
     #   coreapi
-    #   docker
     #   geoip2
     #   mailchimp3
     #   moto
@@ -1249,9 +1146,9 @@ ruamel.yaml==0.15.87 \
     --hash=sha256:fbd301680a3563e84d667042dac1c5d50ef402ecf1f4b1763507a6877b8181ad \
     --hash=sha256:fc67e79e2f5083be6fd1000c4646e13a891585772a503f56f51f845b547fe621
     # via drf-yasg
-s3transfer==0.3.3 \
-    --hash=sha256:2482b4259524933a022d59da830f51bd746db62f047d6eb213f2f8855dcb8a13 \
-    --hash=sha256:921a37e2aefc64145e7b73d50c71bb4f26f46e4c9f414dc648c6245ff92cf7db
+s3transfer==0.4.2 \
+    --hash=sha256:9b3752887a2880690ce628bc263d6d13a3864083aeacff4890c1c9839a5eb0bc \
+    --hash=sha256:cb022f4b16551edebbb31a377d3f09600dbada7363d8c5db7976e7f47732e1b2
     # via boto3
 shortuuid==1.0.1 \
     --hash=sha256:3c11d2007b915c43bee3e10625f068d8a349e04f0d81f08f5fa08507427ebf1f \
@@ -1261,20 +1158,15 @@ six==1.15.0 \
     --hash=sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259 \
     --hash=sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced
     # via
-    #   aws-sam-translator
     #   bcrypt
-    #   cfn-lint
     #   courts-db
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
-    #   docker
-    #   docker-pycreds
     #   elasticsearch-dsl
     #   fabric3
     #   faker
     #   jsonschema
     #   libsass
-    #   mock
     #   more-itertools
     #   moto
     #   packaging
@@ -1283,11 +1175,9 @@ six==1.15.0 \
     #   pyrsistent
     #   pytest-xdist
     #   python-dateutil
-    #   python-jose
     #   reporters-db
     #   responses
     #   swagger-spec-validator
-    #   websocket-client
 soupsieve==1.7.3 \
     --hash=sha256:466910df7561796a60748826781ebe9a888f7a1668a636ae86783f44d10aae73 \
     --hash=sha256:87db12ae79194f0ff9808d2b1641c4f031ae39ffa3cab6b907ea7c1e5e5ed445
@@ -1296,10 +1186,6 @@ sqlparse==0.3.0 \
     --hash=sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177 \
     --hash=sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873
     # via django
-sshpubkeys==3.1.0 \
-    --hash=sha256:9f73d51c2ef1e68cd7bde0825df29b3c6ec89f4ce24ebca3bf9eaa4a23a284db \
-    --hash=sha256:b388399caeeccdc145f06fd0d2665eeecc545385c60b55c282a15a022215af80
-    # via moto
 swagger-spec-validator==2.4.3 \
     --hash=sha256:57e29feb3aa921a9fb98bd70af148746b27c77d3207266f5571cebcce211e685 \
     --hash=sha256:62ef22eca3f429d93fddda5d793d2a1a9057d3732e7a14606e641805326ae4a6
@@ -1345,9 +1231,9 @@ uritemplate==3.0.0 \
     # via
     #   coreapi
     #   drf-yasg
-urllib3==1.25.8 \
-    --hash=sha256:2f3db8b19923a873b3e5256dc9c2dedfa883e33d87c690d9c7913e1f40673cdc \
-    --hash=sha256:87716c2d2a7121198ebcb7ce7cccf6ce5e9ba539041cfbaeecfb641dc0bf6acc
+urllib3==1.26.5 \
+    --hash=sha256:753a0374df26658f99d826cfe40394a686d05985786d946fbe4165b5148f5a7c \
+    --hash=sha256:a7acd0977125325f516bda9735fa7142b909a8d01e8b2e4c8108d0984e6e0098
     # via
     #   botocore
     #   elasticsearch
@@ -1369,10 +1255,6 @@ wcwidth==0.2.5 \
 webpage2html==0.3.6 \
     --hash=sha256:d32e660682e778967aa3211f3eef3e0d26266e8802aaa1e741558b2fbf4ab884
     # via -r requirements.in
-websocket-client==0.54.0 \
-    --hash=sha256:8c8bf2d4f800c3ed952df206b18c28f7070d9e3dcbd6ca6291127574f57ee786 \
-    --hash=sha256:e51562c91ddb8148e791f0155fdb01325d99bb52c4cdbb291aee7a3563fd0849
-    # via docker
 werkzeug==0.15.5 \
     --hash=sha256:87ae4e5b5366da2347eb3116c0e6c681a0e939a33b2805e2c0cbd282664932c4 \
     --hash=sha256:a13b74dd3c45f758d4ebdb224be8f1ab8ef58b3c0ffc1783a8c7d9f4f50227e6
@@ -1383,9 +1265,7 @@ whitenoise[brotli]==5.2.0 \
     # via -r requirements.in
 wrapt==1.11.1 \
     --hash=sha256:4aea003270831cceb8a90ff27c4031da6ead7ec1886023b80ce0dfe0adf61533
-    # via
-    #   -r requirements.in
-    #   aws-xray-sdk
+    # via -r requirements.in
 xmltodict==0.11.0 \
     --hash=sha256:8f8d7d40aa28d83f4109a7e8aa86e67a4df202d9538be40c0cb1d70da527b0df \
     --hash=sha256:add07d92089ff611badec526912747cf87afd4f9447af6661aca074eeaf32615
@@ -1398,37 +1278,6 @@ zipp==1.2.0 \
     # via
     #   importlib-metadata
     #   pep517
-zope.interface==4.6.0 \
-    --hash=sha256:086707e0f413ff8800d9c4bc26e174f7ee4c9c8b0302fbad68d083071822316c \
-    --hash=sha256:1157b1ec2a1f5bf45668421e3955c60c610e31913cc695b407a574efdbae1f7b \
-    --hash=sha256:11ebddf765bff3bbe8dbce10c86884d87f90ed66ee410a7e6c392086e2c63d02 \
-    --hash=sha256:14b242d53f6f35c2d07aa2c0e13ccb710392bcd203e1b82a1828d216f6f6b11f \
-    --hash=sha256:1b3d0dcabc7c90b470e59e38a9acaa361be43b3a6ea644c0063951964717f0e5 \
-    --hash=sha256:20a12ab46a7e72b89ce0671e7d7a6c3c1ca2c2766ac98112f78c5bddaa6e4375 \
-    --hash=sha256:298f82c0ab1b182bd1f34f347ea97dde0fffb9ecf850ecf7f8904b8442a07487 \
-    --hash=sha256:2f6175722da6f23dbfc76c26c241b67b020e1e83ec7fe93c9e5d3dd18667ada2 \
-    --hash=sha256:3b877de633a0f6d81b600624ff9137312d8b1d0f517064dfc39999352ab659f0 \
-    --hash=sha256:4265681e77f5ac5bac0905812b828c9fe1ce80c6f3e3f8574acfb5643aeabc5b \
-    --hash=sha256:550695c4e7313555549aa1cdb978dc9413d61307531f123558e438871a883d63 \
-    --hash=sha256:5f4d42baed3a14c290a078e2696c5f565501abde1b2f3f1a1c0a94fbf6fbcc39 \
-    --hash=sha256:62dd71dbed8cc6a18379700701d959307823b3b2451bdc018594c48956ace745 \
-    --hash=sha256:7040547e5b882349c0a2cc9b50674b1745db551f330746af434aad4f09fba2cc \
-    --hash=sha256:7e099fde2cce8b29434684f82977db4e24f0efa8b0508179fce1602d103296a2 \
-    --hash=sha256:7e5c9a5012b2b33e87980cee7d1c82412b2ebabcb5862d53413ba1a2cfde23aa \
-    --hash=sha256:81295629128f929e73be4ccfdd943a0906e5fe3cdb0d43ff1e5144d16fbb52b1 \
-    --hash=sha256:95cc574b0b83b85be9917d37cd2fad0ce5a0d21b024e1a5804d044aabea636fc \
-    --hash=sha256:968d5c5702da15c5bf8e4a6e4b67a4d92164e334e9c0b6acf080106678230b98 \
-    --hash=sha256:9e998ba87df77a85c7bed53240a7257afe51a07ee6bc3445a0bf841886da0b97 \
-    --hash=sha256:a0c39e2535a7e9c195af956610dba5a1073071d2d85e9d2e5d789463f63e52ab \
-    --hash=sha256:a15e75d284178afe529a536b0e8b28b7e107ef39626a7809b4ee64ff3abc9127 \
-    --hash=sha256:a6a6ff82f5f9b9702478035d8f6fb6903885653bff7ec3a1e011edc9b1a7168d \
-    --hash=sha256:b639f72b95389620c1f881d94739c614d385406ab1d6926a9ffe1c8abbea23fe \
-    --hash=sha256:bad44274b151d46619a7567010f7cde23a908c6faa84b97598fd2f474a0c6891 \
-    --hash=sha256:bbcef00d09a30948756c5968863316c949d9cedbc7aabac5e8f0ffbdb632e5f1 \
-    --hash=sha256:d788a3999014ddf416f2dc454efa4a5dbeda657c6aba031cf363741273804c6b \
-    --hash=sha256:eed88ae03e1ef3a75a0e96a55a99d7937ed03e53d0cffc2451c208db445a2966 \
-    --hash=sha256:f99451f3a579e73b5dd58b1b08d1179791d49084371d9a47baad3b22417f0317
-    # via datetime
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==21.0.1 \
@@ -1439,9 +1288,8 @@ setuptools==56.0.0 \
     --hash=sha256:08a1c0f99455307c48690f00d5c2ac2c1ccfab04df00454fef854ec145b81302 \
     --hash=sha256:7430499900e443375ba9449a9cc5d78506b801e929fef4a186496012f93683b5
     # via
-    #   cfn-lint
     #   ipython
     #   jsonschema
     #   markdown
+    #   moto
     #   python-rocksdb
-    #   zope.interface


### PR DESCRIPTION
This is a little messy. In an effort to upgrade `urllib3`, I found I had to pin `botocore` in `requirements.in` (which I later removed), then ran 
```
docker-compose exec web fab "pip-compile:-P urllib3 -P moto -P boto3 -P requests"
```
I then had to add `mock` to `requirements.in`.