### PR TITLE
Misc cleanup

### DIFF
--- a/capstone/capapi/api_urls.py
+++ b/capstone/capapi/api_urls.py
@@ -16,9 +16,9 @@ router.register('reporters', api_views.ReporterViewSet)
 router.register('bulk', api_views.CaseExportViewSet)
 router.register('ngrams', api_views.NgramViewSet, basename='ngrams')
 router.register('user_history', api_views.UserHistoryViewSet)
+router.register('resolve', api_views.ResolveDocumentViewSet, basename="resolve")
 
 unstable_router = routers.DefaultRouter()
-unstable_router.register('resolve', api_views.ResolveDocumentViewSet, basename="resolve")
 
 # filter out bulk endpoint from API browser listing
 class FilteredAPIRootView(routers.APIRootView):

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -945,14 +945,13 @@ class CaseMetadataQuerySet(TemporalQuerySet):
         return self.update(
             in_scope=Q(duplicative=False, duplicate=False) & ~Q(jurisdiction_id=None) & ~Q(court_id=None))
 
-    def for_indexing(self, require_body_cache=True):
+    def for_indexing(self):
         """
-            Fetch only cases that are appropriate for Elasticsearch indexing, with associated data.
+            Fetch associated data for cases that are going to be indexed by elasticsearch.
         """
-        out = self.select_related('volume', 'reporter', 'court', 'jurisdiction', 'body_cache', 'last_update').prefetch_related('extracted_citations', 'citations', 'analysis')
-        if require_body_cache:
-            out = out.exclude(body_cache=None)
-        return out
+        return self\
+            .select_related('volume', 'reporter', 'court', 'jurisdiction', 'body_cache', 'last_update')\
+            .prefetch_related('extracted_citations', 'citations', 'analysis')
 
 
 class CaseMetadata(models.Model):

--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -21,7 +21,7 @@ def run_task_for_volumes(task, volumes=None, last_run_before=None, **kwargs):
         the task has not succeeded after that time.
     """
     if volumes is None:
-        volumes = VolumeMetadata.objects.filter(out_of_scope=False, duplicate=False)
+        volumes = VolumeMetadata.objects.filter(out_of_scope=False)
     if last_run_before:
         # find volumes where task has never run, or had an error, or had a success before last_run_before date
         volumes = volumes.filter(

--- a/capstone/capdb/tasks.py
+++ b/capstone/capdb/tasks.py
@@ -142,12 +142,12 @@ def update_elasticsearch_from_queue():
         return
     while True:
         with transaction.atomic(using='capdb'):
-            case_ids = CaseLastUpdate.objects.filter(indexed=False).select_for_update(skip_locked=True)[:100].values_list('case_id', flat=True)
+            case_ids = list(CaseLastUpdate.objects.filter(indexed=False).select_for_update(skip_locked=True)[:100].values_list('case_id', flat=True))
             if not case_ids:
                 break
-            cases = CaseMetadata.objects.filter(id__in=case_ids).for_indexing()
+            cases = list(CaseMetadata.objects.filter(id__in=case_ids).for_indexing())
             CaseMetadata.reindex_cases(cases)
-            CaseLastUpdate.objects.filter(case_id__in=case_ids).update(indexed=True)
+            CaseLastUpdate.objects.filter(case__in=cases).update(indexed=True)
 
 
 @shared_task(bind=True, acks_late=True)  # use acks_late for tasks that can be safely re-run if they fail

--- a/capstone/capdb/tests/test_postgres.py
+++ b/capstone/capdb/tests/test_postgres.py
@@ -108,11 +108,3 @@ def test_last_updated(case, extracted_citation_factory, elasticsearch):
         setattr(obj, no_change_field, 'foo')
         obj.save()
         check_timestamps_unchanged(case, timestamp)
-
-    # case gets removed when in_scope changes
-    update_elasticsearch_from_queue()
-    CaseDocument.get(case.pk)
-    case.duplicative = True
-    case.save()
-    update_elasticsearch_from_queue()
-    CaseDocument.get(case.pk)

--- a/capstone/capdb/tests/test_postgres.py
+++ b/capstone/capdb/tests/test_postgres.py
@@ -3,9 +3,7 @@ from copy import deepcopy
 import pytest
 from django.db import transaction
 
-from capapi.documents import CaseDocument
 from capdb.models import CaseMetadata
-from capdb.tasks import update_elasticsearch_from_queue
 from scripts.helpers import parse_xml, serialize_xml
 from test_data.test_fixtures.helpers import get_timestamp, check_timestamps_changed, check_timestamps_unchanged
 

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -104,6 +104,6 @@ django-elasticsearch-dsl-drf
 
 # citation extraction
 # eyecite
-https://github.com/jcushman/eyecite/archive/3e6b33c211e5413170ee2bdf066461486caa0d6c.zip#egg=eyecite  # until > 2.1.0
+https://github.com/jcushman/eyecite/archive/6c1837020670328ea8ab8cef168ccabdbad1fe64.zip#egg=eyecite  # until > 2.1.0
 hyperscan
 networkx

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -408,8 +408,8 @@ execnet==1.5.0 \
     --hash=sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a \
     --hash=sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83
     # via pytest-xdist
-https://github.com/jcushman/eyecite/archive/3e6b33c211e5413170ee2bdf066461486caa0d6c.zip#egg=eyecite \
-    --hash=sha256:9cace69b9e2777d71ac823674d8c0323a62f287de74478ffd94580208d6ee1c5
+https://github.com/jcushman/eyecite/archive/6c1837020670328ea8ab8cef168ccabdbad1fe64.zip#egg=eyecite \
+    --hash=sha256:d5b1e0271595c3ffdfba6041de05a1637c8680f8906e5d77a5b75b1494fd6668
     # via -r requirements.in
 fabric3==1.14.post1 \
     --hash=sha256:647e485ec83f30b587862f92374d6affc217f3d79819d1d7f512e42e7ae51e81 \


### PR DESCRIPTION
Just some stuff I was tightening up this morning ...

* Remove separate filter for volumes with `duplicate=True` since I confirmed that such volumes are always `out_of_scope=True`.
* Update requirements to reflect the version of eyecite we installed yesterday on beta.
* Move the /unstable/resolve api endpoint to /v1/resolve
* Tweak the update_elasticsearch_from_queue task to see if we can get it updating all cases as they change
* Add a test for the "redact" and "elide" functions that would have caught the error patched in my last PR