### PR TITLE
Less pytest complexity in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,8 +57,9 @@ jobs:
         run: |
           set -x
           docker-compose exec web pytest \
-            -n 2                                           `# run tests in parallel for speed` \
-            --junitxml=junit/pytest/test-results.xml       `# write junit test results so they can be displayed somewhere later?` \
+            `# disabling these in case it helps with intermittent test timeouts:` \
+            `#-n 2                                           # run tests in parallel for speed` \
+            `#--junitxml=junit/pytest/test-results.xml       # write junit test results so they can be displayed somewhere later?` \
             --cov --cov-config=setup.cfg --cov-report xml  `# write coverage data to .coverage for upload by codecov` \
             -v
 


### PR DESCRIPTION
We had some repeated timeouts right when tests finished in the last PR, so let's try making the pytest call a little simpler -- no xdist (which makes tests faster, but I think only by 10 or 20 seconds right now), no junit files (which we aren't using anyway).