### PR TITLE
simplify modal structure

### DIFF
--- a/capstone/static/css/scss/labs-chronolawgic.scss
+++ b/capstone/static/css/scss/labs-chronolawgic.scss
@@ -560,8 +560,10 @@ main#main-app {
       transform: rotate(90deg);
       transform-origin: 0 100% 0;
       z-index: 1;
-      position: relative;
-      top: -1.25rem;
+      position: absolute;
+      top: 0;
+      text-align: left;
+      text-transform: none;
       left: 0;
       margin: 0;
       font-weight: $font-weight-semibold;
@@ -569,7 +571,6 @@ main#main-app {
       color: $color-white;
       height: 1.25rem;
       line-height: 1.25rem;
-      padding-left: 1rem;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/capstone/static/js/labs/chronolawgic/case.vue
+++ b/capstone/static/js/labs/chronolawgic/case.vue
@@ -1,7 +1,6 @@
 <template>
   <button class="case-button"
           type="button"
-          @focus="handleFocus"
           @click="openModal(case_data)"
           data-toggle="modal"
           :data-target="dataTarget"
@@ -82,9 +81,6 @@ export default {
     },
     closeModal() {
       EventBus.$emit('closeModal')
-    },
-    handleFocus() {
-      EventBus.$emit('closePreview')
     },
     repopulateTimeline() {
       this.$parent.repopulateTimeline();

--- a/capstone/static/js/labs/chronolawgic/timeline-slice.vue
+++ b/capstone/static/js/labs/chronolawgic/timeline-slice.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="spans row" @click="$store.commit('expandMobileEvents')">
     <div v-for="(event_data, index) in event_list" v-bind:key="year_value + index"
+         :title="event_data.name"
          :class="[ 'event_col', 'ec_' + (index + 1), 'col-1', 'e' + year_value, ]">
       <template v-if="$store.getters.isMobile && !$store.getters.mobileEventsExpanded">
 
@@ -20,7 +21,7 @@
 
       </template>
       <template v-else>
-        <div :class="{
+        <button :class="{
           'fill': true,
           'first-event-year': parseInt(year_value) === new Date(event_data.start_date).getUTCFullYear(),
           'last-event-year': parseInt(year_value) === new Date(event_data.end_date).getUTCFullYear(),
@@ -34,9 +35,7 @@
                       'min-height': '1rem'
                   }"
              @click="openModal(event_data)"
-             @blur="handleFocus(event_data)"
-             @focus="handleFocus(event_data)"
-             :data-toggle="dataToggle"
+             data-toggle="modal"
              :data-target="dataTarget"
              :data-event-fill="event_data.id"
              :ref="fillRefGenerator(event_data, year_value)">
@@ -46,8 +45,7 @@
                v-text="event_data.name"
                :ref="'event-label' + event_data.id">
           </div>
-
-        </div>
+        </button>
       </template>
     </div>
   </div>
@@ -60,53 +58,21 @@ export default {
   name: "TimelineSlice",
   props: ['year_value', 'event_list'],
   computed: {
-    dataToggle: () => {
-      // attribute for showing either modal or event preview
-      if (store.getters.isMobile || (store.state.isAuthor && !store.getters.isMobile)) {
-        return 'modal'
-      } else {
-        return ''
-      }
-    },
     dataTarget: () => {
-      // attribute for showing what kind of modal or event preview
-      if (store.getters.isMobile) {
+      // show readonly or event modal
+      if (store.getters.isMobile || !store.state.isAuthor) {
         return '#readonly-modal'
-      } else if (store.state.isAuthor && !store.getters.isMobile) {
-        return '#add-event-modal'
       } else {
-        // keeping blank will show event preview
-        return ''
+        return '#add-event-modal'
       }
     },
-    showPreview: () => {
-      // showing preview or showing modal
-      return !store.state.isAuthor && !store.getters.isMobile
-    }
   },
   methods: {
     closeModal() {
       this.$emit('closeModal')
     },
     openModal(event_data) {
-      if (this.showPreview) {
-        this.toggleEventPreview(event_data, true)
-      } else {
-        this.$parent.$parent.openModal(event_data, 'event')
-      }
-    },
-    handleFocus(event_data) {
-      this.toggleEventPreview(event_data, true)
-    },
-    handleBlur(event_data) {
-      this.toggleEventPreview(event_data, false)
-    },
-    toggleEventPreview(event_data, open) {
-      if (!this.showPreview) return;
-      if (open)
-        this.$parent.previewEvent(event_data);
-      else
-        this.$parent.clearPreviewEvent()
+      this.$parent.$parent.openModal(event_data, 'event')
     },
     fillRefGenerator(event_data, year_value) {
       const firstEventYear = parseInt(year_value) === new Date(event_data.start_date).getUTCFullYear();

--- a/capstone/static/js/labs/chronolawgic/timeline.vue
+++ b/capstone/static/js/labs/chronolawgic/timeline.vue
@@ -220,7 +220,6 @@ export default {
       this.keyShown = !this.keyShown;
     },
     handleEscape() {
-      EventBus.$emit('closePreview')
       this.closeModal();
     },
     repopulateTimeline() {

--- a/capstone/static/js/labs/chronolawgic/year.vue
+++ b/capstone/static/js/labs/chronolawgic/year.vue
@@ -28,7 +28,6 @@
       <div class="simple-mobile-year-label">{{year_value}}</div>
     </div>
     <TimeLineSlice :event_list="year_data.event_list" :year_value="year_value"></TimeLineSlice>
-    <event-preview :event="event"></event-preview>
   </div>
   <div class="year placeholder"
        v-else-if="year_data.firstYearNoNewItems && !year_data.involvesAnyItem && $store.getters.minimized">
@@ -44,8 +43,6 @@
 <script>
 import TimeLineSlice from './timeline-slice';
 import Case from './case';
-import EventPreview from "./event-preview";
-import {EventBus} from "./event-bus";
 import MoreVertical from '../../../../static/img/icons/more-vertical.svg';
 import MoreHorizontal from '../../../../static/img/icons/more-horizontal.svg';
 import YearLabel from './year-label'
@@ -55,7 +52,6 @@ export default {
   components: {
     TimeLineSlice,
     Case,
-    EventPreview,
     MoreVertical,
     MoreHorizontal,
     YearLabel
@@ -89,17 +85,6 @@ export default {
     clearPreviewEvent() {
       this.event = null;
     },
-    previewEvent(event_data) {
-      this.event = event_data;
-      EventBus.$emit('closePreview', this.year_value);
-    },
   },
-  mounted() {
-    EventBus.$on('closePreview', (year_value) => {
-      if (this.year_value !== year_value) {
-        this.event = null;
-      }
-    })
-  }
 }
 </script>


### PR DESCRIPTION
turn timeslice divs into buttons, change spacing to make things look good again, etc. Clicking or keypressing enter on either case or events will pop open the modals (either editable or read-only, depending on mode). Can navigate using keyboard (tab, enter). Tested on Chrome and Firefox.