### PR TITLE
Surface

### DIFF
--- a/capstone/labs/migrations/0010_timeline_remove_author.py
+++ b/capstone/labs/migrations/0010_timeline_remove_author.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def add_author(apps, schema_editor):
+    Timeline = apps.get_model("labs", "Timeline")
+
+    for timeline in Timeline.objects.all():
+        if "author" in timeline.timeline and timeline.timeline["author"] == "CAP User":
+            timeline.timeline["author"] = ""
+        timeline.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('labs', '0009_timeline_add_author'),
+    ]
+
+    operations = [
+        migrations.RunPython(add_author, migrations.RunPython.noop),
+    ]

--- a/capstone/labs/models.py
+++ b/capstone/labs/models.py
@@ -100,7 +100,7 @@ class Timeline(models.Model):
     schemas = {
         'timeline': [
             {'name': 'title', 'type': str, 'required': True, 'default': 'Untitled Timeline'},
-            {'name': 'author', 'type': str, 'required': True},
+            {'name': 'author', 'type': str, 'required': True, 'default': ''},
             {'name': 'description', 'type': str, 'required': False},
             {'name': 'cases', 'type': list, 'required': False},
             {'name': 'events', 'type': list, 'required': False},

--- a/capstone/labs/models.py
+++ b/capstone/labs/models.py
@@ -100,7 +100,7 @@ class Timeline(models.Model):
     schemas = {
         'timeline': [
             {'name': 'title', 'type': str, 'required': True, 'default': 'Untitled Timeline'},
-            {'name': 'author', 'type': str, 'required': True, 'default': 'CAP user'},
+            {'name': 'author', 'type': str, 'required': True},
             {'name': 'description', 'type': str, 'required': False},
             {'name': 'cases', 'type': list, 'required': False},
             {'name': 'events', 'type': list, 'required': False},

--- a/capstone/labs/templates/lab/chronolawgic/timeline.html
+++ b/capstone/labs/templates/lab/chronolawgic/timeline.html
@@ -18,7 +18,7 @@
     // This is essentially each endpoint with its API interface
     // eslint-disable-next-line
     const urls = {
-
+      chronolawgic: "{% url 'labs:chronolawgic' %}",
       api_delete_subobject: "{% url 'labs:chronolawgic-delete-subobject' 2147483625 2147483626 2147483627%}"
           .replace('2147483625', "__TIMELINE_ID__")
           .replace('2147483626', "__SUBOBJECT_TYPE__")
@@ -40,6 +40,7 @@
       chronolawgic_api_create_h2o: "{% url 'labs:chronolawgic-api-create-h2o' %}",
       static: "{% static '' %}",
       api_root: "{% api_url 'api-root' %}v1/",
+      contact: "{% url 'contact' %}",
     };
 
     // eslint-disable-next-line

--- a/capstone/labs/tests/chronolawgic/test_chronolawgic_views.py
+++ b/capstone/labs/tests/chronolawgic/test_chronolawgic_views.py
@@ -5,7 +5,7 @@ from capapi.tests.helpers import check_response
 from labs.models import Timeline
 
 
-timeline = {"title": "My first timeline", "author": "CAP User", "description": "And my very best one"}
+timeline = {"title": "My first timeline", "author": "Caselaw Bob", "description": "And my very best one"}
 create_url = reverse('labs:chronolawgic-api-create')
 retrieve_url = reverse('labs:chronolawgic-api-retrieve')
 cases = [
@@ -35,7 +35,7 @@ categories = [
     {'name': 'tesstcat3', 'shape': 'polygon3', 'color': '#ff736c', 'id': 'arbitrary_string3'}
 ]
 complete_timeline = {"title": "My first timeline",
-                     "author": "CAP User",
+                     "author": "Caselaw Bob",
                      "description": "And my very best one",
                      'events': events,
                      'cases': cases,

--- a/capstone/labs/views.py
+++ b/capstone/labs/views.py
@@ -279,7 +279,7 @@ def h2o_import(request):
 
             timeline_record = Timeline(
                 timeline=Timeline.generate_empty_timeline(
-                    {"author": "Imported from H2O",
+                    {"author": "(Imported from H2O)",
                     "description": "Original H2O textbook can be found at this URL: " + original_casebook_url,
                     "cases": timeline_cases}
                 ),

--- a/capstone/static/css/scss/labs-chronolawgic.scss
+++ b/capstone/static/css/scss/labs-chronolawgic.scss
@@ -1109,7 +1109,7 @@ main#main-app {
 }
 
 .disclaimer {
-  font-size: 0.6em;
+  font-size: 0.55em;
   line-height: 1.1em;
   font-weight: 600;
   font-family: $font-family-sans-serif;

--- a/capstone/static/css/scss/labs-chronolawgic.scss
+++ b/capstone/static/css/scss/labs-chronolawgic.scss
@@ -1108,6 +1108,13 @@ main#main-app {
   }
 }
 
+.disclaimer {
+  font-size: 0.6em;
+  line-height: 1.1em;
+  font-weight: 600;
+  font-family: $font-family-sans-serif;
+  padding-bottom: 1em;
+}
 
 // categories
 .shape {

--- a/capstone/static/js/labs/chronolawgic/admin.vue
+++ b/capstone/static/js/labs/chronolawgic/admin.vue
@@ -93,7 +93,7 @@
               <div
                   :class="{'author': true, 'editmode': Object.prototype.hasOwnProperty.call(editMode, timeline.id)}">
                 <p v-if="!Object.prototype.hasOwnProperty.call(editMode, timeline.id)">
-                  Author: {{ timeline.author }}
+                  Author: <span class="cap-user">CAP User</span> {{ timeline.author }}
                 </p>
                 <div class="author-edit" v-else>
                   <div class="label">Author</div>

--- a/capstone/static/js/labs/chronolawgic/sidebar.vue
+++ b/capstone/static/js/labs/chronolawgic/sidebar.vue
@@ -27,6 +27,13 @@
           </li>
         </ul>
       </div>
+      <div v-if="!this.$store.state.isAuthor" class="disclaimer mt-4 pl-2 pr-2">
+        Note: timelines are user generated and are not reviewed by the Caselaw Access Project. <br/><a
+          :href="this.$store.state.urls.chronolawgic">Create your
+        own timeline! </a><br/><br/>
+        To let us know about inappropriate content,
+        <a :href="this.$store.state.urls.contact">click here</a>.
+      </div>
     </div>
   </div>
 </template>

--- a/capstone/static/js/labs/chronolawgic/store.js
+++ b/capstone/static/js/labs/chronolawgic/store.js
@@ -146,7 +146,7 @@ const store = new Vuex.Store({
         },
         setTimeline(state, json) {
             state.title = json.title;
-            state.author = json.author ? json.author : "CAP User";
+            state.author = json.author;
             state.description = json.description;
             state.categories = json.categories;
             state.events = json.events;

--- a/capstone/static/js/labs/chronolawgic/store.js
+++ b/capstone/static/js/labs/chronolawgic/store.js
@@ -70,6 +70,8 @@ const store = new Vuex.Store({
         requestStatus: 'nominal', // can be nominal, success, error, or pending. Prone to race conditions, so use only for user feedback until its improved
         notificationMessage: null,
         urls: { // Doing this the long way to make it a little easier to see what's going on.
+            chronolawgic: importUrls.chronolawgic,
+
             chronolawgic_api_create: importUrls.chronolawgic_api_create,
             chronolawgic_api_retrieve: importUrls.chronolawgic_api_retrieve,
             chronolawgic_api_delete: importUrls.chronolawgic_api_delete,
@@ -82,6 +84,7 @@ const store = new Vuex.Store({
 
             static: importUrls.static,
             api_root: importUrls.api_root,
+            contact: importUrls.contact,
         },
         availableTimelines: [],
         minimized: true,

--- a/capstone/static/js/labs/chronolawgic/timeline.vue
+++ b/capstone/static/js/labs/chronolawgic/timeline.vue
@@ -15,10 +15,18 @@
 
             <header :class="{ 'header-section': true, 'title': true, 'expanded': headerExpanded}">
               <h4 id="timeline-title" @click="toggleHeader()">{{ $store.state.title }}</h4>
-              <div id="timeline-author">By {{ $store.state.author }}</div>
+              <div id="timeline-author">By CAP User {{ $store.state.author }}</div>
 
               <div id="timeline-description" v-if="$store.state.description" v-text="$store.state.description"
                    @click="toggleHeader()"></div>
+              <div @click="toggleHeader()" v-if="!this.$store.state.isAuthor && this.$store.getters.isMobile && this.headerExpanded" class="disclaimer mt-2 p-1">
+                <hr/>
+                Note: timelines are user generated and are not reviewed by the Caselaw Access Project. <br/><a
+                  :href="this.$store.state.urls.chronolawgic">Create your
+                own timeline! </a><br/><br/>
+                To let us know about inappropriate content,
+                <a :href="this.$store.state.urls.contact">click here</a>.
+              </div>
             </header>
             <div class="header-section years"></div>
             <div :class="{'header-section': true, 'zoom-section': true, 'expanded': headerExpanded}">

--- a/capstone/static/js/labs/chronolawgic/timeline.vue
+++ b/capstone/static/js/labs/chronolawgic/timeline.vue
@@ -15,7 +15,7 @@
 
             <header :class="{ 'header-section': true, 'title': true, 'expanded': headerExpanded}">
               <h4 id="timeline-title" @click="toggleHeader()">{{ $store.state.title }}</h4>
-              <div id="timeline-author">By CAP User {{ $store.state.author }}</div>
+              <div id="timeline-author">By <span class="cap-user">CAP User</span> {{ $store.state.author }}</div>
 
               <div id="timeline-description" v-if="$store.state.description" v-text="$store.state.description"
                    @click="toggleHeader()"></div>


### PR DESCRIPTION
- add disclaimer (thanks @jcushman)
<img width="592" alt="Screen Shot 2021-06-28 at 2 44 49 PM" src="https://user-images.githubusercontent.com/1494102/123687869-6b41eb00-d81f-11eb-8962-607ae37e469e.png">

- undo CAP User default string — making it immutable. Everyone is now "CAP User <their name>"