### PR TITLE
Improve csv error messages

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -175,7 +175,7 @@ class CaseFilter(FilterSet):
     court_id = filters.NumberFilter(label='Court ID')
     full_case = filters.ChoiceFilter(
         label='Include full case text or just metadata?',
-        choices=(('', 'Just metadata (default)'), ('true', 'Full case text')),
+        choices=(('false', 'Just metadata (default)'), ('true', 'Full case text')),
     )
     body_format = filters.ChoiceFilter(
         label='Format for case text (applies only if including case text)',

--- a/capstone/capapi/renderers.py
+++ b/capstone/capapi/renderers.py
@@ -91,11 +91,12 @@ class PdfRenderer(renderers.BaseRenderer):
 class CSVRenderer(renderers.JSONRenderer):
     media_type = 'text/csv'
     format = 'csv'
+    charset = 'utf-8'
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
         if 'results' in data:
-            flattened_data = map(lambda case: flatten(case, '.', root_keys_to_ignore={'cites_to'}), data['results'])
-            json_normalize = pandas.json_normalize(list(flattened_data))
+            flattened_data = [flatten(case, '.', root_keys_to_ignore={'cites_to'}) for case in data['results']]
+            json_normalize = pandas.json_normalize(flattened_data)
         else:
             json_normalize = pandas.json_normalize(flatten(data, '.', root_keys_to_ignore={'cites_to'}))
         return json_normalize.to_csv(index=False)


### PR DESCRIPTION
Prod was throwing a 500 when hitting the cases endpoint with the invalid parameter `format=csv&full_case=false`: "renderer returned unicode, and did not specify a charset value."

This seems to be an issue with formatting the response when the API returns an error and the requested format is CSV. I switched up the error formatting, switched from `StreamingHttpResponse` because it doesn't help when the full response is already rendered to a string, added a special case to return `text/plain` for CSVs when the response code is 400, because otherwise the browser doesn't show them, and added a test for CSVs with invalid parameters.

I also changed the api so explicitly providing `full_case=false` is valid and does the same thing as omitting `full_case`.
