### PR TITLE
Additional polish for trendlines 

### DIFF
--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -181,6 +181,8 @@ class CaseFilter(FilterSet):
         choices=(('text', 'text only (default)'), ('html', 'HTML'), ('xml', 'XML'), ('tokens', 'debug tokens')),
     )
     cites_to = filters.CharFilter(label='Cases citing to citation (citation or case id)')
+    facet = filters.CharFilter(label='Facet for which to aggregate results. Can be jurisdiction, \
+        decision_date, or a comma-separated permutation of either.')
     ordering = filters.ChoiceFilter(
         label='Sort order (defaults to relevance, if search is provided, else decision_date)',
         choices=[

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -176,12 +176,17 @@ def api_request(request, viewset, method, url_kwargs={}, get_params={}):
 
     api_request.GET = QueryDict(mutable=True)
 
-    for key in get_params:
-        paramvalues = get_params.getlist(key, [])
+    # if QueryDicts are supplied, allow users to get all parameters via 
+    # getlist rather than directly updating the dict.
+    if type(get_params) is dict:
+        api_request.GET.update(get_params)
+    else:
+        for key in get_params:
+            paramvalues = get_params.getlist(key, [])
 
-        if len(get_params.getlist(key, [])) > 1:
-            api_request.GET.setlist(key, paramvalues)
-        else:
-            api_request.GET[key] = get_params[key]
+            if len(get_params.getlist(key, [])) > 1:
+                api_request.GET.setlist(key, paramvalues)
+            else:
+                api_request.GET[key] = get_params[key]
 
     return viewset.as_view({'get': method})(api_request, **url_kwargs)

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -175,9 +175,12 @@ def api_request(request, viewset, method, url_kwargs={}, get_params={}):
     api_request.method = 'GET'
 
     api_request.GET = QueryDict(mutable=True)
+
     for key in get_params:
-        if type(get_params[key]) is list:
-            api_request.GET.setlist(key, get_params[key])
+        paramvalues = get_params.getlist(key, [])
+
+        if len(get_params.getlist(key, [])) > 1:
+            api_request.GET.setlist(key, paramvalues)
         else:
             api_request.GET[key] = get_params[key]
 

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -175,18 +175,6 @@ def api_request(request, viewset, method, url_kwargs={}, get_params={}):
     api_request.method = 'GET'
 
     api_request.GET = QueryDict(mutable=True)
-
-    # if QueryDicts are supplied, allow users to get all parameters via 
-    # getlist rather than directly updating the dict.
-    if type(get_params) is dict:
-        api_request.GET.update(get_params)
-    else:
-        for key in get_params:
-            paramvalues = get_params.getlist(key, [])
-
-            if len(get_params.getlist(key, [])) > 1:
-                api_request.GET.setlist(key, paramvalues)
-            else:
-                api_request.GET[key] = get_params[key]
+    api_request.GET.update(get_params)
 
     return viewset.as_view({'get': method})(api_request, **url_kwargs)

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -518,7 +518,6 @@ class NgramViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         q_len = len(words)
         q_sig = bytes([q_len]) + ' '.join(words).encode('utf8')
 
-        err = ''
         if api_query_body and not err_msg:
             results = self.get_citation_data(request, api_query_body, q)
             pairs = []

--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -14,6 +14,7 @@ from django_elasticsearch_dsl_drf.filter_backends import DefaultOrderingFilterBa
 from django_elasticsearch_dsl_drf.viewsets import BaseDocumentViewSet as DEDDBaseDocumentViewSet
 from django.http import QueryDict, HttpResponseRedirect, FileResponse, HttpResponseBadRequest
 from elasticsearch_dsl import TermsFacet, DateHistogramFacet
+from rest_framework.exceptions import ValidationError
 
 from capapi import serializers, filters, permissions, renderers as capapi_renderers
 from capapi.documents import CaseDocument, RawSearch, ResolveDocument
@@ -449,8 +450,9 @@ class NgramViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     )
     def get_total_dict(self, request):
         # get and cache total dictionary. 
-        total_query_params = {'page_size': 1, 'facet': ['decision_date', 'jurisdiction,decision_date']}
-        total_results = api_request(request, CaseDocumentViewSet, 'list', get_params=total_query_params).data
+        total_query_dict = QueryDict('page_size=1&facet=decision_date&facet=jurisdiction,decision_date', mutable=True)
+
+        total_results = api_request(request, CaseDocumentViewSet, 'list', get_params=total_query_dict).data
 
         return {
             **total_results['facets']['jurisdiction,decision_date'],
@@ -514,26 +516,24 @@ class NgramViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         # prepend word count as first byte. only applicable for n-grams
         words = q.split(' ')[:3]  # use first 3 words
         q_len = len(words)
-        q = bytes([q_len]) + ' '.join(words).encode('utf8')
+        q_sig = bytes([q_len]) + ' '.join(words).encode('utf8')
 
         err = ''
         if api_query_body and not err_msg:
-            results = self.get_citation_data(request, api_query_body, ' '.join(words))
+            results = self.get_citation_data(request, api_query_body, q)
             pairs = []
         elif not api_query_body and err_msg:
-            results = {}
-            pairs = []
-            err = err_msg
-        elif q.endswith(b' *'):
+            raise ValidationError({"error": err_msg})
+        elif q_sig.endswith(b' *'):
             results = {}
             # wildcard search
-            pairs = ngram_kv_store_ro.get_prefix(q[:-1], packed=True)
+            pairs = ngram_kv_store_ro.get_prefix(q_sig[:-1], packed=True)
         else:
             results = {}
             # non-wildcard search
-            value = ngram_kv_store_ro.get(q, packed=True)
+            value = ngram_kv_store_ro.get(q_sig, packed=True)
             if value:
-                pairs = [(q, value)]
+                pairs = [(q_sig, value)]
             else:
                 pairs = []
 
@@ -624,8 +624,7 @@ class NgramViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
             "count": len(results),
             "next": None,
             "previous": None,
-            "results": results,
-            "error": err
+            "results": results
         }
 
         return Response(paginated)

--- a/capstone/static/js/api.js
+++ b/capstone/static/js/api.js
@@ -5,6 +5,10 @@ export function getApiUrl(api_url, endpoint, params) {
   return `${api_url}${endpoint}/?${encodeQueryData(params)}`;
 }
 
+export function getApiUrlNoEncode(api_url, endpoint, params) {
+  return `${api_url}${endpoint}/?${params}`;
+}
+
 export function jsonQuery(url) {
   return fetch(url).then((resp) => {
       if (!resp.ok)

--- a/capstone/static/js/trends/main.vue
+++ b/capstone/static/js/trends/main.vue
@@ -764,10 +764,7 @@
             this.currentApiQueries.push([term, url]);
             return jsonQuery(url).then((resp)=>{
               // filter out responses with no results
-              if (resp.error && resp.error.length !== 0) {
-                this.errors.push(`Error: "${resp.error}"`);
-                return null;
-              } else if (Object.keys(resp.results).length === 0) {
+              if (Object.keys(resp.results).length === 0) {
                 this.errors.push(`"${term}" does not appear in our corpus.`);
                 return null;
               } 
@@ -795,11 +792,19 @@
           this.initialQuery = null;
 
           this.graphResults();
-        }).catch(response => {
+        }).catch(resp => {
           // error handling
           this.showLoading = false;
-          this.errors.push("Connection error: failed to load results");
-          console.log("Connection error:", response);  // eslint-disable-line
+          var errorsObject = this.errors;
+          Promise.resolve(resp.json()).then(function(value) {
+            if (value.error && value.error.length !== 0) {
+                  errorsObject.push(`Error: "${value.error}"`);
+                  console.log(`api() validation error: "${value.error}"`);
+                  return null;
+            }  
+            errorsObject.push("Connection error: failed to load results");
+            console.log("Connection error:", resp);  // eslint-disable-line
+          });
         });
 
       },

--- a/capstone/static/js/trends/main.vue
+++ b/capstone/static/js/trends/main.vue
@@ -832,7 +832,7 @@
             if (year === null) return 0;
             if (this.percentOrAbs === "absolute") return year[this.countType][0];
             return year[this.countType][0]/year[this.countType][1]*100;
-          });
+          }).map(value => isNaN(value) ? 0 : value);
 
           // apply smoothingFactor setting
           data = this.movingAverage(data, dataMaxYear-dataMinYear);
@@ -942,14 +942,7 @@
         if (window < 1)
           return items;
 
-        return items.map((_, i) => this.safeAverage(items.map(value => isNaN(value) ? 0 : value).slice(max(i-window, 0), min(i+window, items.length))));
-      },
-      safeAverage(arr) {
-        var filteredArr = arr.filter(value => !Number.isNaN(value) );
-        if (filteredArr.length === 0) {
-          return NaN;
-        } 
-        return average(arr);
+        return items.map((_, i) => average(items.slice(max(i-window, 0), min(i+window, items.length))));
       },
       appendJurisdictionCode(code) {
         if (this.textToGraph)


### PR DESCRIPTION
The following items are fixed with this pull request:

- More pages now renders the correct cases endpoint when clicked in.
- response keys previously truncated to the 3 words are no longer truncated.
- v1/cases now includes the `facet` parameter in casefilter
- Error keys are now read only when a 400 is thrown from the response.
- Jurisdiction parameters can now be applied multiple times, where `jurisdiction=A&jurisdiction=B` returns the union of results per the elasticsearch dsl drf standards. this is primarily due to update squashing overloaded params, which is resolved by manually calling getlist.
- a subtle bug where multi jurisdictional queries like (jurisdiction=A&jurisdiction=B) only shows the results for B in the click-through query is now fixed 

