### PR TITLE
refactor search results for multiple parameters

### DIFF
--- a/capstone/static/js/api.js
+++ b/capstone/static/js/api.js
@@ -1,12 +1,8 @@
 import {encodeQueryData} from './utils';
 
 
-export function getApiUrl(api_url, endpoint, params) {
-  return `${api_url}${endpoint}/?${encodeQueryData(params)}`;
-}
-
-export function getApiUrlNoEncode(api_url, endpoint, params) {
-  return `${api_url}${endpoint}/?${params}`;
+export function getApiUrl(api_url, endpoint, params, split_arrays = false) {
+  return `${api_url}${endpoint}/?${encodeQueryData(params, split_arrays)}`;
 }
 
 export function jsonQuery(url) {


### PR DESCRIPTION
sorry, one last nit - i noticed that the way the click-through was picking up jurisdictions was wonky, in such that if a query contains `jurisdiction=X` but the line was also split on the outside by jurisdictions, the latter would not be respected as each parameter was accounted for, thus picking the union of all  of the possible param values.

the following refactor simplifies the jurisdiction parsing and simply does not add the jurisdiction value if it is the case that it is already specified in params, forcing a more contained search when clicking on a split line.