### PR TITLE
don't lowercase api() queries

### DIFF
--- a/capstone/capapi/views/api_views.py
+++ b/capstone/capapi/views/api_views.py
@@ -517,7 +517,7 @@ class NgramViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     def list(self, request, *args, **kwargs):
         # without specific ngram search, return nothing
-        q = self.request.GET.get('q', '').strip().lower()
+        q = self.request.GET.get('q', '').strip()
         if not q:
             return Response({})
 
@@ -526,7 +526,7 @@ class NgramViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
         api_query_body, err_msg = self.get_query_data_from_api_query(q)
 
         # prepend word count as first byte. only applicable for n-grams
-        words = q.split(' ')[:3]  # use first 3 words
+        words = q.lower().split(' ')[:3]  # use first 3 words
         q_len = len(words)
         q_sig = bytes([q_len]) + ' '.join(words).encode('utf8')
 


### PR DESCRIPTION
allows users to query keyword fields with upper case characters.

i.e.:
![Screen Shot 2021-07-26 at 2 46 17 PM](https://user-images.githubusercontent.com/9059403/127042138-d590fb88-d844-4e53-bc76-cbb660c2eba0.png)
