### PR TITLE
Add Sample field and remove jurisdiction searches for `cites_to__` subquery

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -143,6 +143,7 @@ class CaseDocument(Document):
 
     analysis = fields.ObjectField(properties={
         'sha256': fields.KeywordField(),
+        'sample': fields.KeywordField(),
         'simhash': fields.KeywordField(),
     })
 

--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -143,7 +143,7 @@ class CaseDocument(Document):
 
     analysis = fields.ObjectField(properties={
         'sha256': fields.KeywordField(),
-        'sample': fields.KeywordField(),
+        'sample': fields.IntegerField(),
         'simhash': fields.KeywordField(),
     })
 

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -186,8 +186,8 @@ def parallel_execute(query_body, max_workers=20, page_size=1000):
             '_source': 'false',
         }
         body['sort'] = [{
-            'field': { 
-                'analysis.sample': 'long'
+            'analysis.sample': { 
+                'order': 'asc'
             }
         }]
 

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -185,13 +185,11 @@ def parallel_execute(query_body, max_workers=20, page_size=1000):
             'size': page_size,
             '_source': 'false',
         }
-        body['sort'] = {
-            "_script" : { 
-                "script" : "(doc['_id'].value + 'capsalt').hashCode()",
-                "type" : "number",
-                "order" : "asc"
+        body['sort'] = [
+            "field" : { 
+                "analysis.sample" : "keyword"
             }
-        }
+        ]
 
         resp = await es.search(index='cases', body=body)
         results.append(deep_get(resp, ['hits','hits']))

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -187,7 +187,7 @@ def parallel_execute(query_body, max_workers=20, page_size=1000):
         }
         body['sort'] = [{
             'field': { 
-                'analysis.sample': 'keyword'
+                'analysis.sample': 'long'
             }
         }]
 

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -191,6 +191,12 @@ def parallel_execute(query_body, max_workers=20, page_size=1000):
             }
         }]
 
+        # delete highlight blocks. 
+        body.pop('highlight', None)
+        for obj in deep_get(body, ['query', 'bool', 'must']):
+            obj = obj.get('nested', None)
+            obj.pop('inner_hits', None)
+
         resp = await es.search(index='cases', body=body)
         results.append(deep_get(resp, ['hits','hits']))
 

--- a/capstone/capapi/resources.py
+++ b/capstone/capapi/resources.py
@@ -185,11 +185,11 @@ def parallel_execute(query_body, max_workers=20, page_size=1000):
             'size': page_size,
             '_source': 'false',
         }
-        body['sort'] = [
-            "field" : { 
-                "analysis.sample" : "keyword"
+        body['sort'] = [{
+            'field': { 
+                'analysis.sample': 'keyword'
             }
-        ]
+        }]
 
         resp = await es.search(index='cases', body=body)
         results.append(deep_get(resp, ['hits','hits']))

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1258,7 +1258,7 @@ class CaseMetadata(models.Model):
             CaseAnalysis(case=self, key='cardinality', value=len(set(words))),
             CaseAnalysis(case=self, key='simhash', value=get_simhash(text)),
             CaseAnalysis(case=self, key='sha256', value=hashvalue),
-            CaseAnalysis(case=self, key='sample', value=int(hashvalue[-4:])),
+            CaseAnalysis(case=self, key='sample', value=int(hashvalue[-4:], 16)),
         ]
         confidence = None
         if self.human_corrected:

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1251,12 +1251,14 @@ class CaseMetadata(models.Model):
 
         text = self.body_cache.text
         words = list(tokenize(text))
+        hashvalue = hashlib.sha256(text.encode('utf8')).hexdigest()
         analyses = [
             CaseAnalysis(case=self, key='char_count', value=len(text)),
             CaseAnalysis(case=self, key='word_count', value=len(words)),
             CaseAnalysis(case=self, key='cardinality', value=len(set(words))),
             CaseAnalysis(case=self, key='simhash', value=get_simhash(text)),
             CaseAnalysis(case=self, key='sha256', value=hashlib.sha256(text.encode('utf8')).hexdigest()),
+            CaseAnalysis(case=self, key='sample', value=hashvalue[-4:]),
         ]
         confidence = None
         if self.human_corrected:

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1257,7 +1257,7 @@ class CaseMetadata(models.Model):
             CaseAnalysis(case=self, key='word_count', value=len(words)),
             CaseAnalysis(case=self, key='cardinality', value=len(set(words))),
             CaseAnalysis(case=self, key='simhash', value=get_simhash(text)),
-            CaseAnalysis(case=self, key='sha256', value=hashlib.sha256(text.encode('utf8')).hexdigest()),
+            CaseAnalysis(case=self, key='sha256', value=hashvalue),
             CaseAnalysis(case=self, key='sample', value=hashvalue[-4:]),
         ]
         confidence = None

--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1258,7 +1258,7 @@ class CaseMetadata(models.Model):
             CaseAnalysis(case=self, key='cardinality', value=len(set(words))),
             CaseAnalysis(case=self, key='simhash', value=get_simhash(text)),
             CaseAnalysis(case=self, key='sha256', value=hashvalue),
-            CaseAnalysis(case=self, key='sample', value=hashvalue[-4:]),
+            CaseAnalysis(case=self, key='sample', value=int(hashvalue[-4:])),
         ]
         confidence = None
         if self.human_corrected:


### PR DESCRIPTION
This PR removes jurisdiction fields from cites_to__ queries.

This PR also generates a new `analysis.sample` field that creates the long representation of the last two bytes of the document sha256 hash, then sorts the cites_to__ subquery using that field. This was built from our observation that sorting on the `analysis.char_count` long was substantially faster than script sort.