### PR TITLE
add author, author_type fields to search pane

### DIFF
--- a/capstone/static/js/search/search-form.vue
+++ b/capstone/static/js/search/search-form.vue
@@ -124,6 +124,26 @@
                 {{ $store.getters.getField('court').info }}
               </small>
             </div>
+
+            <div class="search-field shown">
+              <field-item :clearable="true" :multiple="true" :field="$store.getters.getField('author')"></field-item>
+              <div v-if="$store.getters.fieldHasError('author')" class="invalid-feedback">
+                {{ $store.getters.getField('author').error }}
+              </div>
+              <small :id="`help-text-author`" class="form-text text-muted">
+                {{ $store.getters.getField('author').info }}
+              </small>
+            </div>
+
+            <div class="search-field shown">
+              <field-item :clearable="true" :multiple="true" :field="$store.getters.getField('author_type')"></field-item>
+              <div v-if="$store.getters.fieldHasError('author_type')" class="invalid-feedback">
+                {{ $store.getters.getField('author_type').error }}
+              </div>
+              <small :id="`help-text-author_type`" class="form-text text-muted">
+                {{ $store.getters.getField('author_type').info }}
+              </small>
+            </div>
           </template>
         </div>
         <button class="btn btn-tertiary show-advanced-options"

--- a/capstone/static/js/search/store.js
+++ b/capstone/static/js/search/store.js
@@ -145,7 +145,7 @@ const store = new Vuex.Store({
       author_type: {
         value: null,
         default_value: null,
-        label: "Author e.g. scalia:dissent",
+        label: "Author Type e.g. scalia:dissent",
         placeholder: "e.g. scalia:dissent",
         highlight_field: false,
         highlight_explainer: false,

--- a/capstone/static/js/search/store.js
+++ b/capstone/static/js/search/store.js
@@ -132,6 +132,26 @@ const store = new Vuex.Store({
         error: null,
         value_when_searched: null
       },
+      author: {
+        value: null,
+        default_value: null,
+        label: "Author e.g. breyer",
+        placeholder: "e.g. breyer",
+        highlight_field: false,
+        highlight_explainer: false,
+        error: null,
+        value_when_searched: null
+      },
+      author_type: {
+        value: null,
+        default_value: null,
+        label: "Author e.g. scalia:dissent",
+        placeholder: "e.g. scalia:dissent",
+        highlight_field: false,
+        highlight_explainer: false,
+        error: null,
+        value_when_searched: null
+      },
     },
     ordering: {
       value: "relevance",


### PR DESCRIPTION
Add author and author_type fields to CAP Search panel:

![Screen Shot 2021-08-02 at 11 14 29 AM](https://user-images.githubusercontent.com/9059403/127884157-eac2e9ec-d2a5-410f-b514-f128ee84731b.png)

