### PR TITLE
extract_cites query optimization

### DIFF
--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -260,7 +260,7 @@ def test_redact_id_numbers(case_factory):
 
 
 @pytest.mark.django_db(databases=['capdb'])
-def test_extract_citations(reset_sequences, case_factory, elasticsearch, client):
+def test_extract_citations(reset_sequences, case_factory, elasticsearch, client, django_assert_num_queries):
     paragraph_1 = """
         correct: Foo v. Bar, 1 U.S. 1, 12 (2000) (overruling).
         extra cruft matched: 2 F.-'Supp.- 2
@@ -279,7 +279,8 @@ def test_extract_citations(reset_sequences, case_factory, elasticsearch, client)
 
     case = case_factory(decision_date=datetime(2000, 1, 1))
     set_case_text(case, paragraph_1, text3=paragraph_2)
-    case.sync_case_body_cache()
+    with django_assert_num_queries(select=4, insert=2, update=1):
+        case.sync_case_body_cache()
     update_elasticsearch_from_queue()
 
     # check html

--- a/capstone/config/pre_django_setup.py
+++ b/capstone/config/pre_django_setup.py
@@ -2,3 +2,6 @@
 
 # patch this here because we have to make sure we do it before any file imports the eyecite library
 import scripts.patch_reporters_db  # noqa
+
+# patch django's CursorDebugWrapper before any other file imports it
+import django_sql_trace  # noqa

--- a/capstone/django_sql_trace/__init__.py
+++ b/capstone/django_sql_trace/__init__.py
@@ -1,6 +1,5 @@
-from django.conf import settings
-from django.utils.module_loading import import_string
-import django.db.backends.base.base
+import django.db.backends.utils
 
-WrapperClass = import_string(getattr(settings, 'SQL_TRACE_WRAPPER_CLASS', 'django_sql_trace.wrapper.TracingDebugWrapper'))
-django.db.backends.base.base.BaseDatabaseWrapper.make_debug_cursor = lambda self, cursor: WrapperClass(cursor, self)
+from .wrapper import TracingDebugWrapper
+
+django.db.backends.utils.CursorDebugWrapper = TracingDebugWrapper

--- a/capstone/scripts/extract_cites.py
+++ b/capstone/scripts/extract_cites.py
@@ -88,8 +88,9 @@ def extract_citations(case, html, xml):
             Q(cite__in=cites_by_type['cite']) |
             Q(normalized_cite__in=cites_by_type['normalized_cite']) |
             Q(rdb_cite__in=cites_by_type['rdb_cite']) |
-            Q(rdb_normalized_cite__in=cites_by_type['rdb_normalized_cite'])
-        ))
+            Q(rdb_normalized_cite__in=cites_by_type['rdb_normalized_cite']))
+        .select_related('case')
+    )
     for cite in target_cites:
         for cite_type in cites_by_type:
             cite_str = getattr(cite, cite_type)

--- a/capstone/scripts/link_scdb.py
+++ b/capstone/scripts/link_scdb.py
@@ -12,7 +12,7 @@ from tqdm import tqdm
 from capdb.models import Citation, EditLog, Reporter, CaseMetadata
 from scripts.helpers import group_by, normalize_cite
 
-"""
+r"""
     Usage: fab run_script:scripts.link_scdb
     
     This script attempts to link up CAP cases with SCDB cases.
@@ -100,7 +100,7 @@ def manual_pre_edits(dry_run='true'):
 
     if dry_run == 'false':
         with EditLog(
-            description='Delete incorrectly identified cites matching "\d+ U. S. \d+" (extra space). '
+            description=r'Delete incorrectly identified cites matching "\d+ U. S. \d+" (extra space). '
             'These all refer to prior history of the case.'
         ).record():
             for cite in to_delete:


### PR DESCRIPTION
Avoid some extra queries when calling `extract_cites`.

Also in this PR, encountered while debugging:

* Fix `TracingDebugWrapper` so `pytest -v` works with `django_assert_num_queries`
* Tweak a couple of strings in `link_scdb.py` to silence pytest warnings