### PR TITLE
Fix body_format=html; validate query params on single case page; expand API tests

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -169,25 +169,6 @@ class CaseDocument(Document):
         except CaseLastUpdate.DoesNotExist:
             return None
 
-    def get_all_text_fields(self, start_array, prefix, recursive_field=None, ignore=None):
-        output = []
-        text_fields = recursive_field if recursive_field else self._fields 
-        for item in start_array:
-            text_fields = text_fields[item]
-        text_fields = text_fields._doc_class._doc_type.mapping.properties._params.get('properties', {}).items()
-
-        # Don't use comprehensions because we can't iterate through a generator twice, and the ugliness of copying 
-        # seems greater.
-        for field, value in text_fields:
-            if f'{prefix}.{field}' in ignore:
-                continue
-            if type(value) == fields.ObjectField or type(value) == fields.NestedField:
-                output = output + self.get_all_text_fields([], f'{prefix}.{field}', recursive_field=value, ignore=ignore)
-            else:
-                output.append(f'{prefix}.{field}')
-
-        return output
-
     def prepare_casebody_data(self, instance):
         body = instance.body_cache
         serializer = self._fields['casebody_data']['text']['opinions']['extracted_citations']

--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -166,7 +166,23 @@ class UserHistoryFilter(FilterSet):
         fields = ['case_id', 'date']
 
 
-class CaseFilter(FilterSet):
+class SingleCaseFilter(FilterSet):
+    """Filters that apply to single-case endpoint as well as list endpoint."""
+    full_case = filters.ChoiceFilter(
+        label='Include full case text or just metadata?',
+        choices=(('false', 'Just metadata (default)'), ('true', 'Full case text')),
+    )
+    body_format = filters.ChoiceFilter(
+        label='Format for case text (applies only if including case text)',
+        choices=(('text', 'text only (default)'), ('html', 'HTML'), ('xml', 'XML')),
+    )
+
+    class Meta:
+        model = models.CaseMetadata
+        fields = []
+
+
+class CaseFilter(SingleCaseFilter):
     """
         Used for HTML display and validation, but not actual filtering.
         Rendered by CaseFilterBackend, which applies filters to the ES query.
@@ -184,20 +200,12 @@ class CaseFilter(FilterSet):
     docket_number = filters.CharFilter(label='Docket Number (contains)')
     court = filters.ChoiceFilter(choices=court_choices)
     court_id = filters.NumberFilter(label='Court ID')
-    full_case = filters.ChoiceFilter(
-        label='Include full case text or just metadata?',
-        choices=(('false', 'Just metadata (default)'), ('true', 'Full case text')),
-    )
     author = filters.CharFilter(
         label='Filter by opinion author'
         )
     author_type = filters.CharFilter(
         label='Filter by opinion author and their opinion type in a ruling. Values must be separated by a colon; invalid input will be \
             ignored. Example: author_type=scalia:dissent.'
-    )
-    body_format = filters.ChoiceFilter(
-        label='Format for case text (applies only if including case text)',
-        choices=(('text', 'text only (default)'), ('html', 'HTML'), ('xml', 'XML'), ('tokens', 'debug tokens')),
     )
     cites_to = filters.CharFilter(label='Cases citing to citation (citation or case id)')
     facet = filters.CharFilter(label='Facet for which to aggregate results. Can be jurisdiction, \

--- a/capstone/capapi/tests/test_serializers.py
+++ b/capstone/capapi/tests/test_serializers.py
@@ -1,5 +1,6 @@
 import pytest
 from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 
 from capapi import serializers
 from capapi.documents import CaseDocument
@@ -7,12 +8,12 @@ from capapi.resources import api_reverse
 
 
 @pytest.mark.django_db(databases=['capdb'])
-def test_CaseDocumentSerializerWithCasebody(api_request_factory, case_factory, elasticsearch):
+def test_CaseDocumentSerializerWithCasebody(case_factory, elasticsearch):
     cases = [case_factory() for i in range(3)]
     case_documents = [CaseDocument.get(c.id) for c in cases]
 
     # can get single case data
-    request = api_request_factory.get(api_reverse("cases-list"))
+    request = APIRequestFactory().get(api_reverse("cases-list"))
     request.accepted_renderer = None
     serializer_context = {'request': Request(request)}
 

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -279,7 +279,7 @@ def test_extract_citations(reset_sequences, case_factory, elasticsearch, client,
 
     case = case_factory(decision_date=datetime(2000, 1, 1))
     set_case_text(case, paragraph_1, text3=paragraph_2)
-    with django_assert_num_queries(select=4, insert=2, update=1):
+    with django_assert_num_queries(select=5, insert=2, update=1, delete=1):
         case.sync_case_body_cache()
     update_elasticsearch_from_queue()
 
@@ -365,7 +365,7 @@ def test_sync_case_body_cache_for_vol(volume_metadata, case_factory, django_asse
 
     # full sync
     CaseBodyCache.objects.update(text='blank')
-    with django_assert_num_queries(select=7, update=2, insert=1):
+    with django_assert_num_queries(select=8, update=2, insert=1, delete=1):
         sync_case_body_cache_for_vol(volume_metadata.barcode)
     assert all(c.text == 'Case text 0\nCase text 1Case text 2\nCase text 3\n' for c in CaseBodyCache.objects.all())
 

--- a/capstone/test_data/test_fixtures/factories.py
+++ b/capstone/test_data/test_fixtures/factories.py
@@ -302,6 +302,16 @@ class CaseStructureFactory(factory.DjangoModelFactory):
 
 
 @register
+class ExtractedCitationFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = ExtractedCitation
+
+    cite = factory.LazyAttribute(lambda o: "%s U.S. %s" % (random.randint(1,999), random.randint(1, 999)))
+    # cited_by = factory.SubFactory(CaseFactory)
+    opinion_id = 0
+
+
+@register
 class CaseFactory(factory.DjangoModelFactory):
     class Meta:
         model = CaseMetadata
@@ -322,6 +332,7 @@ class CaseFactory(factory.DjangoModelFactory):
     structure = factory.RelatedFactory(CaseStructureFactory, 'metadata')
     citations = factory.RelatedFactory(CitationFactory, 'case')
     body_cache = factory.RelatedFactory(CaseBodyCacheFactory, 'metadata')
+    extracted_citations = factory.RelatedFactory(ExtractedCitationFactory, 'cited_by')
 
     @post_generation
     def post(obj, create, extracted, **kwargs):
@@ -383,14 +394,3 @@ class CaseExportFactory(factory.DjangoModelFactory):
     public = True
     filter_type = 'jurisdiction'
     filter_id = factory.LazyAttribute(lambda o: JurisdictionFactory.create().pk)
-
-
-@register
-class ExtractedCitationFactory(factory.DjangoModelFactory):
-    class Meta:
-        model = ExtractedCitation
-
-    cite = factory.LazyAttribute(lambda o: "%s U.S. %s" % (random.randint(1,999), random.randint(1, 999)))
-    cited_by = factory.SubFactory(CaseFactory)
-
-

--- a/capstone/test_data/test_fixtures/fixtures.py
+++ b/capstone/test_data/test_fixtures/fixtures.py
@@ -334,11 +334,6 @@ def admin_client(admin_user_factory):
     return client_with_user(admin_user_factory())
 
 
-@pytest.fixture
-def api_request_factory():
-    return APIRequestFactory()
-
-
 @pytest.fixture()
 def private_case_export():
     return CaseExportFactory.create(public=False)


### PR DESCRIPTION
* Fix a prod bug where `/v1/cases/?full_case=true&body_format=html` is throwing an error.
* Simplify elasticsearch exclude logic, in part by just excluding `casebody_data.text.opinions.text` and not other text fields.
* Validate `full_case` and `body_format` query params on single-case endpoint as well as list endpoint.
* Expand tests to include an `extracted_citation` in the default case fixture, to fetch all body_formats for the list endpoint as well as the single-case endpoint, and to verify that elasticsearch exclude logic works.