### PR TITLE
Case delete

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -2558,6 +2558,13 @@ class CaseLastUpdate(models.Model):
     indexed = models.BooleanField(default=False, db_index=True)
 
 
+class CaseDeleted(models.Model):
+    """Tombstone so deleted cases are deleted from elasticsearch."""
+    case_id = models.IntegerField()
+    timestamp = models.DateTimeField()
+    indexed = models.BooleanField(default=False, db_index=True)
+
+
 class CaseAnalysis(models.Model):
     case = models.ForeignKey(CaseMetadata, related_name='analysis', on_delete=models.DO_NOTHING)
     timestamp = models.DateTimeField(auto_now=True)

--- a/services/postgres/last_update_function.sql
+++ b/services/postgres/last_update_function.sql
@@ -15,6 +15,14 @@ BEGIN
 
     -- get row object to use for case_id
     IF TG_OP = 'DELETE' THEN
+        -- special case if case itself is being deleted
+        IF TG_ARGV[0] = 'id' THEN
+            -- write to CaseDeleted
+            EXECUTE 'INSERT INTO capdb_casedeleted (case_id, timestamp, indexed) VALUES($1.' || TG_ARGV[0] || ', NOW(), false);'
+                USING OLD;
+            RETURN NULL;
+        END IF;
+
         row = OLD;
     ELSE
         row = NEW;


### PR DESCRIPTION
The fastcase ingest brought in some duplicate volumes because of a bug in the duplicate volume check. This fixes that bug, and updates our case.last_update and elasticsearch indexing logic to allow for cases to be fully deleted so we can clean up the duplicates.