### PR TITLE
Random ordering

### DIFF
--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -342,7 +342,7 @@ class CaseDocumentSerializerWithCasebody(CaseAllowanceMixin, CaseDocumentSeriali
         # check permissions for full-text access to this case
         if not check_permissions:
             status = 'ok'
-        elif not s['restricted']:
+        elif s['restricted'] is False:
             status = "ok"
         elif request.user.is_anonymous:
             status = "error_auth_required"

--- a/capstone/capapi/tests/helpers.py
+++ b/capstone/capapi/tests/helpers.py
@@ -4,7 +4,16 @@ from django.conf import settings
 from rest_framework.response import Response
 
 
-def check_response(response, status_code=200, content_type=None, content_includes=None, content_excludes=None):
+def check_response(response, status_code=None, content_type=None, content_includes=None, content_excludes=None, redirect_to=None):
+    # check redirect_to
+    if redirect_to:
+        assert response.url == redirect_to
+        if not status_code:
+            status_code = 302
+
+    # check status_code
+    if not status_code:
+        status_code = 200
     assert response.status_code == status_code
 
     # check content-type if not a redirect

--- a/capstone/capapi/tests/test_api.py
+++ b/capstone/capapi/tests/test_api.py
@@ -324,11 +324,10 @@ def test_harvard_access(request, restricted_case, client_fixture_name, elasticse
 
 
 @pytest.mark.django_db(databases=['default', 'capdb', 'user_data'])
-def test_authenticated_multiple_full_cases(auth_user, auth_client, case_factory, elasticsearch):
-    ### mixed requests should be counted only for blacklisted cases
+def test_authenticated_multiple_full_cases(auth_user, auth_client, unrestricted_case, restricted_case_factory, elasticsearch):
+    ### mixed requests should be counted only for restricted cases
 
-    [case_factory(jurisdiction__whitelisted=False) for i in range(2)]
-    [case_factory(jurisdiction__whitelisted=True) for i in range(1)]
+    [restricted_case_factory() for i in range(2)]
 
     response = auth_client.get(api_reverse("cases-list"), {"full_case": "true"})
     check_response(response)

--- a/capstone/capweb/templates/docs/02_site_features/03_api.md
+++ b/capstone/capweb/templates/docs/02_site_features/03_api.md
@@ -186,7 +186,7 @@ Many parameters can be appended with `__in`, `__exclude`, `__gt`, `__gte`, `__lt
 * `ordering`
     * __data type:__    string
     * __description:__  A field name to sort your results in ascending order. Prepend with a minus 
-    sign to sort in reverse order. See [Search](#search) for more details.
+    sign to sort in reverse order. See [Sorting]({% docs_url 'in_depth' %}#sorting) for more details.
 * `reporter`
     * __data type:__    integer
     * __description:__  [reporter](#endpoint-reporters) id

--- a/capstone/capweb/templates/docs/03_learning_tracks/01_APIs/03_in_depth.md
+++ b/capstone/capweb/templates/docs/03_learning_tracks/01_APIs/03_in_depth.md
@@ -86,7 +86,7 @@ To filter by fields not equal to a value, append `__exclude`. For example, to fe
 
     curl "{% api_url "cases-list" %}?jurisdiction__exclude=cal"
 
-## Sorting
+## Sorting {: #sorting }
   
 You can sort your search in the `/cases` endpoint using the `ordering` parameter. To sort your results in ascending order,
 supply the `ordering` parameter with the field on which you'd like to sort your results. For example, if you'd like to
@@ -98,7 +98,16 @@ You can also sort in descending order by adding a minus sign before the field on
 the same search sorted in descending order, that is, with the newest cases first, use this query:
 
     {% api_url "cases-list" %}?search=baronetcy&ordering=-decision_date
-    
+
+### Random sorting
+
+Sort order can be randomized using `ordering=random`. Random sorting comes with two caveats:
+
+* Random results cannot be paginated. Consider using `page_size` if you need a larger sample of random results.
+* Random results may be cached by CAP's content delivery network, meaning you may receive the same "random" results
+  when sending precisely the same query twice in a row. To avoid caching, make some modification to the query between
+  each request.
+
 ## Types of Data You Can Query
 
 We make data available through several API endpoints, the most popular being our `/cases` endpoint. It's the only endpoint

--- a/capstone/cite/templates/cite/case.html
+++ b/capstone/cite/templates/cite/case.html
@@ -65,7 +65,7 @@
                   {% if can_render_pdf %}
                     <li class="list-inline-item"><a class="btn" href="{{ db_case.get_pdf_url|elide:db_case|striptags }}">PDF</a></li>
                   {% endif %}
-                  <li class="list-inline-item" ><a class="btn" href="{% api_url 'cases-detail' db_case.id %}{% if request.user.is_authenticated or not case_restricted %}?full_case=true{% endif %}">API</a></li>
+                  <li class="list-inline-item" ><a class="btn" href="{% api_url 'cases-detail' db_case.id %}{% if request.user.is_authenticated or case_restricted is False %}?full_case=true{% endif %}">API</a></li>
                 </ul>
               </div>
             </div>
@@ -210,7 +210,7 @@
         "@id":"{{ db_case.get_full_frontend_url }}"
       },
       "headline": "{{ db_case.name_abbreviation|elide:db_case|striptags }}",
-      {% if case_restricted %}
+      {% if case_restricted is not False %}
         "hasPart": {
           "@type": "WebPageElement",
           "isAccessibleForFree": "False",

--- a/capstone/cite/tests/test_views.py
+++ b/capstone/cite/tests/test_views.py
@@ -426,7 +426,7 @@ def test_random_case(client, case_factory, elasticsearch):
     for i in range(2):
         case = case_factory()
         CaseAnalysis(case=case, key='word_count', value=2000).save()
-        cases.add(case.frontend_url)
+        cases.add(case.get_full_frontend_url())
     update_elasticsearch_from_queue()
 
     # try 20 times to get both

--- a/capstone/cite/tests/test_views.py
+++ b/capstone/cite/tests/test_views.py
@@ -4,6 +4,7 @@ import json
 from datetime import timedelta
 from difflib import unified_diff
 from pathlib import Path
+from urllib.parse import urlencode
 
 import mock
 import pytest
@@ -50,6 +51,16 @@ def test_series(client, django_assert_num_queries, volume_metadata_factory):
     # make sure we get 404 if bad series input
     response = client.get(reverse('series', args=['*'], host='cite'))
     check_response(response, status_code=404)
+
+
+@pytest.mark.django_db(databases=['capdb'])
+def test_series_as_citation(client):
+    # if series looks like a full case citation, redirect to case
+    response = client.get(reverse('series', args=['1 Mass. 1'], host='cite'))
+    check_response(response, redirect_to=reverse('citation', args=['mass', '1', '1'], host='cite'))
+    # if series looks like a full statutory citation, redirect to statute page
+    response = client.get(reverse('series', args=['11 U.S.C. § 550'], host='cite'))
+    check_response(response, redirect_to=reverse('citations', host='cite') + '?' + urlencode({'q': '11 U.S.C. § 550'}))
 
 
 @pytest.mark.django_db(databases=['capdb'])

--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -354,7 +354,7 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
             })
 
     # handle unrestricted case or logged-in user
-    if not case.restricted or request.user.is_authenticated:
+    if case.restricted is False or request.user.is_authenticated:
         serializer = serializers.CaseDocumentSerializerWithCasebody
 
     # handle logged-out user with cookies set up already
@@ -406,7 +406,7 @@ def citation(request, series_slug, volume_number_slug, page_number, case_id=None
 
     # meta tags
     meta_tags = []
-    if case.restricted:
+    if case.restricted is not False:
         # restricted cases shouldn't show cached version in google search results
         meta_tags.append({"name": "googlebot", "content": "noarchive"})
     if db_case.no_index:


### PR DESCRIPTION
A few tweaks:

* cases endpoint supports `?ordering=random` to randomize results. Document limitations that random results can't be paginated, and can be cached.
* Use `ordering=random` to power the cite.case.law/random endpoint, so one can provide additional query parameters like `?source=Fastcase`
* Check if `cite.case.law/<reporter>` parses as a citation, and if so redirect. This makes it quick to pull up a case by going to `cite.case.law/1 Mass. 1`