### PR TITLE
Reduce warnings in tests

### DIFF
--- a/capstone/capdb/storages.py
+++ b/capstone/capdb/storages.py
@@ -47,7 +47,7 @@ class CapStorageMixin(object):
 
 class CapS3Storage(CapStorageMixin, S3Boto3Storage):
     def _fix_path(self, path):
-        return self._encode_name(self._normalize_name(self._clean_name(path)))
+        return self._normalize_name(self._clean_name(path))
 
     def iter_files(self, path="", partial_path=False):
         """
@@ -82,9 +82,9 @@ class CapS3Storage(CapStorageMixin, S3Boto3Storage):
             path += '/'  # should end with exactly one slash
         entries = self.bucket.objects.filter(Prefix=self._fix_path(path))
         if with_md5:
-            return ((self.relpath(self._decode_name(entry.key)), entry.e_tag.strip('"')) for entry in entries)
+            return ((self.relpath(entry.key), entry.e_tag.strip('"')) for entry in entries)
         else:
-            return (self.relpath(self._decode_name(entry.key)) for entry in entries)
+            return (self.relpath(entry.key) for entry in entries)
 
     def tag_file(self, path, key, value):
         """ Tag S3 item at path with key=value. """

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -15,6 +15,9 @@ services:
           - bootstrap.memory_lock=true
           - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
           - discovery.type=single-node
+          # Silence "Elasticsearch built-in security features are not enabled." warning message.
+          # This is safe because `ports` includes `127.0.0.1` to bind only to localhost.
+          - xpack.security.enabled=false
         ulimits:
           memlock:
             soft: -1

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -397,9 +397,9 @@ django-simple-history==3.0.0 \
     --hash=sha256:66fe76c560054be393c52b1799661e104fbe372918d37d151e5d41c676158118 \
     --hash=sha256:a312adfe8fbec4c450b08e641b11249a8a589a7e7d1ba2404764b8b5bed53552
     # via -r requirements.in
-django-storages==1.9.1 \
-    --hash=sha256:3103991c2ee8cef8a2ff096709973ffe7106183d211a79f22cf855f33533d924 \
-    --hash=sha256:a59e9923cbce7068792f75344ed7727021ee4ac20f227cf17297d0d03d141e91
+django-storages==1.11.1 \
+    --hash=sha256:c823dbf56c9e35b0999a13d7e05062b837bae36c518a40255d522fbe3750fbb4 \
+    --hash=sha256:f28765826d507a0309cfaa849bd084894bc71d81bf0d09479168d44785396f80
     # via -r requirements.in
 django-webpack-loader==0.6.0 \
     --hash=sha256:60bab6b9a037a5346fad12d2a70a6bc046afb33154cf75ed640b93d3ebd5f520 \


### PR DESCRIPTION
Prevent warnings when running `pytest`, by updating django-storages and silencing elasticsearch security warning in docker-compose.