### PR TITLE
Removed plural from reporters label for single-reporter states on homepage map 

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -86,6 +86,7 @@ class CaseDocument(Document):
     docket_numbers = fields.TextField(multi=True)
     docket_number = fields.TextField()
     last_updated = fields.KeywordField()
+    #whitelisted =  fields.BooleanField()
 
     volume = fields.ObjectField(properties={
         "barcode": fields.KeywordField(),


### PR DESCRIPTION
Because @bensteinberg ❤️'s proper plural placement and we ❤️ @bensteinberg 

resolves #684