### PR TITLE
Dedup fields into generalized `search` field.

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -5,6 +5,7 @@ from django_elasticsearch_dsl import Document, Index, fields
 from django.conf import settings
 from elasticsearch_dsl import Search, Q
 
+from capapi import filters
 from capdb.models import CaseMetadata, CaseLastUpdate
 from scripts.helpers import alphanum_lower
 from scripts.simhash import get_distance
@@ -172,6 +173,8 @@ class CaseDocument(Document):
 
     restricted = fields.BooleanField()
 
+    search = FTSField()
+
     def prepare_provenance(self, instance):
         return {
             "date_added": instance.date_added.strftime('%Y-%m-%d'),
@@ -223,6 +226,17 @@ class CaseDocument(Document):
 
     def prepare_name_abbreviation(self, instance):
         return instance.redact_obj(instance.name_abbreviation)
+
+    def prepare_search(self, instance):
+        # It seems more efficient to pull the search fields manually, 
+        # as casebody and jurisdiction data is extracted differently 
+        # from the other fields.
+        filterset = filters.MultiFieldFTSFilter.fields + filters.MultiFieldFTSFilter.nested_query_fields
+
+        raise Exception(self._fields)
+
+        buffer = ""
+        return instance.redact_obj(buffer)
 
     class Django:
         model = CaseMetadata

--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -5,7 +5,7 @@ from django_elasticsearch_dsl import Document, Index, fields
 from django.conf import settings
 from elasticsearch_dsl import Search, Q
 
-from capapi import filters
+from capapi.filters import MultiFieldFTSFilter
 from capdb.models import CaseMetadata, CaseLastUpdate
 from scripts.helpers import alphanum_lower
 from scripts.simhash import get_distance
@@ -231,7 +231,7 @@ class CaseDocument(Document):
         # It seems more efficient to pull the search fields manually, 
         # as casebody and jurisdiction data is extracted differently 
         # from the other fields.
-        filterset = filters.MultiFieldFTSFilter.fields + filters.MultiFieldFTSFilter.nested_query_fields
+        filterset = MultiFieldFTSFilter.fields + MultiFieldFTSFilter.nested_query_fields
 
         raise Exception(self._fields)
 

--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -490,7 +490,9 @@ class NestedFTSFilter(BaseSearchFilterBackend):
 
 
 class MultiFieldFTSFilter(BaseSearchFilterBackend):
+    # Query fields are prepared in CaseDocument.prepare_search()
     search_param = 'search'
+    fields = ('search',)
 
     query_backends = [
         SimpleQueryStringQueryBackend,

--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -491,23 +491,8 @@ class NestedFTSFilter(BaseSearchFilterBackend):
 
 class MultiFieldFTSFilter(BaseSearchFilterBackend):
     search_param = 'search'
-    fields = (
-        'name',
-        'name_abbreviation',
-        'jurisdiction.name_long',
-        'court.name',
-        'casebody_data.text.head_matter',
-        'casebody_data.text.corrections',
-        'docket_number',
-    )
-
-    nested_query_fields = (
-        'casebody_data.text.opinions.author',
-        'casebody_data.text.opinions.text',
-    )
 
     query_backends = [
-        NestedSimpleStringQueryBackend,
         SimpleQueryStringQueryBackend,
     ]
 


### PR DESCRIPTION
not ready yet, but this is mostly for visibility's sake.

This PR adds a new `search` field to the elasticsearch backend that consists of all previously queryable fields, joined into a single space-delimited field. This allows us to cut a lot of nested logic from the `search` parameter and avoid the complexity that deals with search queries that span multiple nested field (e.g. wanting a search that looks for an OR relationship between one opinion, but also another case title).

the costs of the current implementation below are:
- repeated calls of the `prepare_%s` functions
- ugliness of the way fields are currently added into the `filter_set` variable

![Screen Shot 2022-01-06 at 8 25 29 PM](https://user-images.githubusercontent.com/9059403/148491542-4dce61f3-7b24-4b8f-8d88-97cece87d0a4.png)

attached is a successful test deploy of a query in both the case name and in the case body text.
