### PR TITLE
Make sure fabfile.export_cases sees up-to-date search index

### DIFF
--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -31,6 +31,7 @@ def test_export_cases(case_factory, tmp_path, django_assert_num_queries, elastic
     version = date.today().strftime('%Y%m%d')
     case1 = case_factory(jurisdiction__slug="aaa", volume__reporter__short_name="aaa", jurisdiction__whitelisted=False)
     case2 = case_factory(jurisdiction__slug="bbb", volume__reporter__short_name="bbb", jurisdiction__whitelisted=True)
+    update_elasticsearch_from_queue()
     monkeypatch.setattr("scripts.export.download_files_storage", FileSystemStorage(location=str(tmp_path)))
     changelog = "changelogtext"
     fabfile.export_cases(changelog)


### PR DESCRIPTION
I think this might fix a rare race condition that caused the initial test failure on #2045.