### PR TITLE
Unmetered -> Unrestricted

### DIFF
--- a/capstone/capapi/admin.py
+++ b/capstone/capapi/admin.py
@@ -92,7 +92,7 @@ class CapUserAdmin(UserAdmin):
     def unlimited_access_in_effect(self, instance):
         instance._is_harvard_ip = True  # show unlimited access if user would have access given Harvard IP
         return instance.unlimited_access_in_effect()
-    unlimited_access_in_effect.short_description = "Unmetered Access"
+    unlimited_access_in_effect.short_description = "Unrestricted Access"
 
 
 @admin.register(models.SiteLimits)

--- a/capstone/capapi/templates/registration/user-details.html
+++ b/capstone/capapi/templates/registration/user-details.html
@@ -27,7 +27,7 @@
     </div>
     {% if request.user.unlimited_access or request.user.harvard_access %}
       <div class="row">
-        <div class="h5 col-sm-12">Unmetered access</div>
+        <div class="h5 col-sm-12">Unrestricted access</div>
         <div class="col-sm-12">
           {% if request.user.unlimited_access_until %}
             {% if request.user.unlimited_access_in_effect %}expires{% else %}expired{% endif %}
@@ -37,7 +37,7 @@
           {% endif %}
           {% if request.user.harvard_access and not request.user.harvard_ip %}
             <div>
-              Your Harvard unmetered access will only work when accessing this website from a Harvard IP address.
+              Your Harvard unrestricted access will only work when accessing this website from a Harvard IP address.
               Your current IP address of {{ request.user.ip_address }} is not a Harvard IP address.
             </div>
           {% endif %}
@@ -54,10 +54,10 @@
         </div>
       </div>
       <div class="row">
-        <div class="h5 col-sm-12">Unmetered access</div>
+        <div class="h5 col-sm-12">Unrestricted access</div>
         <div class="col-sm-12">
           {% if research_contract %}
-            You submitted an application for unmetered access on
+            You submitted an application for unrestricted access on
             {{ research_contract.user_signature_date|date:"F j, Y" }}.
             {% if research_contract.status == "denied" %}
               Your application was denied by LexisNexis. Please contact us if you would like to discuss further options.
@@ -65,7 +65,7 @@
               Your application is pending.
             {% endif %}
           {% elif research_request %}
-            You submitted a request for unmetered access on {{ research_request.submitted_date }}
+            You submitted a request for unrestricted access on {{ research_request.submitted_date }}
           {% else %}
             Are you a research scholar? <br/>
             <a href="{% url 'research-options' %}">Request access</a>

--- a/capstone/capapi/templates/research_request/emails/contract_request_email.txt
+++ b/capstone/capapi/templates/research_request/emails/contract_request_email.txt
@@ -1,4 +1,4 @@
-A user has submitted a signed application for unmetered research-scholar access to the CAP database.
+A user has submitted a signed application for unrestricted research-scholar access to the CAP database.
 
 Name: {{ data.name }}
 Email: {{ data.email }}

--- a/capstone/capapi/templates/research_request/emails/contract_welcome_email.html
+++ b/capstone/capapi/templates/research_request/emails/contract_welcome_email.html
@@ -1,4 +1,4 @@
-Good news! You now have unmetered access to <a href="https://case.law/">Caselaw Access Project</a> data.
+Good news! You now have unrestricted access to <a href="https://case.law/">Caselaw Access Project</a> data.
 
 To get started, <a href="https://case.law/user/login/">log in</a> using your account. Once you're in, you can start by accessing the <a href="https://case.law/docs/site_features/api">CAP API</a>, <a href="https://cite.case.law/">browsing cases</a>, and <a href="https://case.law/download/">viewing downloads</a> like our <a href="https://case.law/download/citation_graph/">citation graph</a>
 , <a href="https://case.law/download/PDFs/">case PDFs</a>, and more. If you run into any questions or obstacles, share them with us

--- a/capstone/capapi/templates/research_request/harvard_research_request.html
+++ b/capstone/capapi/templates/research_request/harvard_research_request.html
@@ -2,7 +2,7 @@
 {% load bootstrap4 %}
 
 {% block title %}Harvard Community Member Application{% endblock %}
-{% block meta_description %}Request unmetered access to the cases made available by the Caselaw Access Project{% endblock %}
+{% block meta_description %}Request unrestricted access to the cases made available by the Caselaw Access Project{% endblock %}
 
 {% block main_content %}
   <form class="form" method="post">

--- a/capstone/capapi/templates/research_request/harvard_research_request_intro.html
+++ b/capstone/capapi/templates/research_request/harvard_research_request_intro.html
@@ -2,11 +2,11 @@
 {% load bootstrap4 %}
 
 {% block title %}Harvard Community Member Application{% endblock %}
-{% block meta_description %}Request unmetered access to the cases made available by the Caselaw Access Project{% endblock %}
+{% block meta_description %}Request unrestricted access to the cases made available by the Caselaw Access Project{% endblock %}
 
 {% block main_content %}
   <p>
-    Our contract with LexisNexis allows us to offer unmetered access to members of the Harvard community.
+    Our contract with LexisNexis allows us to offer unrestricted access to members of the Harvard community.
   </p>
   <p>
     To qualify, you must:
@@ -17,10 +17,10 @@
     <li>access the site from a Harvard IP address.</li>
   </ul>
   <p class="alert alert-danger">
-    <strong>Important:</strong> unmetered access requires you to enter a contract between you, the Harvard
+    <strong>Important:</strong> unrestricted access requires you to enter a contract between you, the Harvard
     Law School Library, and LexisNexis. <strong>The contract permits LexisNexis to sue you personally
     if you use caselaw for commercial or non-research purposes or if you share it with others.</strong>
-    Please read the contract carefully and consider whether full unmetered
+    Please read the contract carefully and consider whether full unrestricted
     access is necessary for your project. CAP provides all users with access to 500 cases per day, unlimited metadata,
     and bulk data from whitelisted jurisdictions without entering this contract.
   </p>

--- a/capstone/capapi/templates/research_request/harvard_research_request_success.html
+++ b/capstone/capapi/templates/research_request/harvard_research_request_success.html
@@ -1,11 +1,11 @@
 {% extends "registration/base.html" %}
 
 {% block title %}Harvard Community Member Application{% endblock %}
-{% block meta_description %}Request unmetered access to the cases made available by the Caselaw Access Project{% endblock %}
+{% block meta_description %}Request unrestricted access to the cases made available by the Caselaw Access Project{% endblock %}
 
 {% block main_content %}
   <p>
-    Your account is approved for unmetered access as a current member of the Harvard community. Unmetered access
+    Your account is approved for unrestricted access as a current member of the Harvard community. Unrestricted access
     requires that you access this site from a Harvard IP address.
   </p>
   <p><a href="{% url "user-details" %}">Back to your account page.</a></p>

--- a/capstone/capapi/templates/research_request/non_harvard_email.html
+++ b/capstone/capapi/templates/research_request/non_harvard_email.html
@@ -1,11 +1,11 @@
 {% extends "registration/base.html" %}
 
 {% block title %}Access for Harvard Community Members{% endblock %}
-{% block meta_description %}Request unmetered access to the cases made available by the Caselaw Access Project{% endblock %}
+{% block meta_description %}Request unrestricted access to the cases made available by the Caselaw Access Project{% endblock %}
 
 {% block main_content %}
   <p>
-    Our contract with LexisNexis allows us to offer unmetered access to members of the Harvard community. For unmetered
+    Our contract with LexisNexis allows us to offer unrestricted access to members of the Harvard community. For unrestricted
     access, you must have a harvard.edu email address and access the site from a Harvard IP address.
   </p>
   <p>

--- a/capstone/capapi/templates/research_request/research_request.html
+++ b/capstone/capapi/templates/research_request/research_request.html
@@ -2,11 +2,11 @@
 {% load bootstrap4 %}
 
 {% block title %}Research Scholar Agreement{% endblock %}
-{% block meta_description %}Request unmetered access to the cases made available by the Caselaw Access Project{% endblock %}
+{% block meta_description %}Request unrestricted access to the cases made available by the Caselaw Access Project{% endblock %}
 
 {% block main_content %}
   <div class="alert alert-info">
-    <p>The following agreement is your application for unmetered CAP access as a
+    <p>The following agreement is your application for unrestricted CAP access as a
     research scholar. Please read the contract carefully before signing. Your application will be reviewed and approved
       by LexisNexis.</p>
   </div>

--- a/capstone/capapi/templates/research_request/research_request_success.html
+++ b/capstone/capapi/templates/research_request/research_request_success.html
@@ -1,11 +1,11 @@
 {% extends "registration/base.html" %}
 
 {% block title %}Research Scholar Application{% endblock %}
-{% block meta_description %}Request unmetered access to the cases made available by the Caselaw Access Project{% endblock %}
+{% block meta_description %}Request unrestricted access to the cases made available by the Caselaw Access Project{% endblock %}
 
 {% block main_content %}
   <p>
-    Thank you for applying for unmetered access as a research scholar! We will process your application as soon as
+    Thank you for applying for unrestricted access as a research scholar! We will process your application as soon as
     possible and be back in touch. In the meantime, we invite you to explore our open API for metadata and our open
     bulk data, which currently includes all cases from Illinois, Arkansas, New Mexico, and North Carolina.
   </p>

--- a/capstone/capapi/tests/test_user_views.py
+++ b/capstone/capapi/tests/test_user_views.py
@@ -179,7 +179,7 @@ def test_view_user_details(auth_user, auth_client):
     response = auth_client.get(reverse('user-details'))
     check_response(response)
     content = re.sub(r'\s+', ' ', response.content.decode()).strip()
-    assert "Unmetered access" in content
+    assert "Unrestricted access" in content
 
 ### test reset api key ###
 

--- a/capstone/capapi/views/user_views.py
+++ b/capstone/capapi/views/user_views.py
@@ -269,7 +269,7 @@ def approve_research_access(request):
                 message = loader.get_template('research_request/emails/contract_welcome_email.html').render({
                     'contact_url': reverse('contact', scheme='https'),
                 })
-                send_mail('Your CAP unmetered access application is approved!', message, settings.DEFAULT_FROM_EMAIL, [contract.user.email])
+                send_mail('Your CAP unrestricted access application is approved!', message, settings.DEFAULT_FROM_EMAIL, [contract.user.email])
 
                 # show status message
                 approver_message = "Research access for %s approved" % contract.name
@@ -285,7 +285,7 @@ def approve_research_access(request):
             })
             emails = [contract.user.email, settings.DEFAULT_FROM_EMAIL] + \
                      [user.email for user in CapUser.objects.filter(groups__name='contract_approvers')]
-            subject = 'CAP unmetered access application denied for {} {}'.format(contract.user.first_name,
+            subject = 'CAP unrestricted access application denied for {} {}'.format(contract.user.first_name,
                                                                                  contract.user.last_name)
             send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, emails)
 

--- a/capstone/capweb/templates/docs/01_user_pathways/01_researchers.md
+++ b/capstone/capweb/templates/docs/01_user_pathways/01_researchers.md
@@ -87,7 +87,7 @@ at the top of the page.
 # How do I apply for researcher access?
 
 If you are a research scholar and your work requires access to the full text of more than 500 cases per day, you may 
-apply for unmetered access via your account page.
+apply for unrestricted access via your account page.
 
 ## Important Caveats
 You must enter into a special bulk access agreement with LexisNexis, which prohibits you from:


### PR DESCRIPTION
Following #2042, this changes the word "unmetered" to "unrestricted" everywhere else except in the agreement at `capstone/capapi/templates/research_request/contracts/scholar.html`.