### PR TITLE
Updates for devs with non-amd64 machines, catch-up for move to GitHub Actions

### DIFF
--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update \
     && apt-get install -y redis-server postgresql-client libtiff-tools pdftk \
     && apt-get install -y librocksdb5.17 librocksdb-dev libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev rocksdb-tools \
     && apt-get install -y libx11-xcb1 libxtst6 libgtk-3-0 libnss3 \
-    && apt-get -t buster-backports install -y libhyperscan-dev \
+    && PKG=$(( ${BUILDARCH} == 'arm64' ? 'libvectorscan-dev' : 'libhyperscan-dev' )) apt-get -t buster-backports install -y ${PKG} \
     && apt-get install -y tidy
 
 # pip

--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -1,6 +1,9 @@
 FROM python:3.7-buster
 ENV PYTHONUNBUFFERED 1
 
+ARG BUILDARCH
+ENV BUILDARCH=${BUILDARCH:-amd64}
+
 # Enable apt-get -t buster-backports
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
 
@@ -42,7 +45,7 @@ RUN echo "--modules-folder /node_modules" > /.yarnrc
 COPY package.json /app
 COPY yarn.lock /app
 # pin node version -- see https://github.com/nodesource/distributions/issues/33
-RUN curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_14.19.0-1nodesource1_amd64.deb \
+RUN curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_14.19.0-1nodesource1_${BUILDARCH}.deb \
     && dpkg -i ./nodejs.deb \
     && rm nodejs.deb \
     && npm install -g yarn@1.22.5 \

--- a/capstone/Dockerfile
+++ b/capstone/Dockerfile
@@ -1,9 +1,6 @@
 FROM python:3.7-buster
 ENV PYTHONUNBUFFERED 1
 
-ARG BUILDARCH
-ENV BUILDARCH=${BUILDARCH:-amd64}
-
 # Enable apt-get -t buster-backports
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list
 
@@ -27,7 +24,7 @@ RUN apt-get update \
     && apt-get install -y redis-server postgresql-client libtiff-tools pdftk \
     && apt-get install -y librocksdb5.17 librocksdb-dev libsnappy-dev zlib1g-dev libbz2-dev libgflags-dev liblz4-dev rocksdb-tools \
     && apt-get install -y libx11-xcb1 libxtst6 libgtk-3-0 libnss3 \
-    && PKG=$(( ${BUILDARCH} == 'arm64' ? 'libvectorscan-dev' : 'libhyperscan-dev' )) apt-get -t buster-backports install -y ${PKG} \
+    && echo libhyperscan5 libhyperscan/cpu-ssse3 boolean true | debconf-set-selections && apt-get -t buster-backports install -y libhyperscan-dev \
     && apt-get install -y tidy
 
 # pip
@@ -45,7 +42,7 @@ RUN echo "--modules-folder /node_modules" > /.yarnrc
 COPY package.json /app
 COPY yarn.lock /app
 # pin node version -- see https://github.com/nodesource/distributions/issues/33
-RUN curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_14.19.0-1nodesource1_${BUILDARCH}.deb \
+RUN curl -o nodejs.deb https://deb.nodesource.com/node_14.x/pool/main/n/nodejs/nodejs_14.19.0-1nodesource1_amd64.deb \
     && dpkg -i ./nodejs.deb \
     && rm nodejs.deb \
     && npm install -g yarn@1.22.5 \

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         ports:
           - 127.0.0.1:9200:9200
     web:
-        image: harvardlil/capstone:182-d0bad67f55045e4fd2b1aacac6032ffd
+        image: harvardlil/capstone:183-003c633f3f3bd1c5d0acd414620433a1
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -27,7 +27,7 @@ services:
         ports:
           - 127.0.0.1:9200:9200
     web:
-        image: harvardlil/capstone:183-003c633f3f3bd1c5d0acd414620433a1
+        image: harvardlil/capstone:182-d0bad67f55045e4fd2b1aacac6032ffd
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2.2'
 services:
     db:
         image: harvardlil/capstone-postgres:0.5-ca8798950ba608ad388c1052d79a4690
+        platform: linux/amd64
         environment:
             POSTGRES_PASSWORD: password
         volumes:
@@ -28,6 +29,7 @@ services:
           - 127.0.0.1:9200:9200
     web:
         image: harvardlil/capstone:182-d0bad67f55045e4fd2b1aacac6032ffd
+        platform: linux/amd64
         volumes:
             # NAMED VOLUMES
             - node_modules:/app/node_modules:delegated

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -93,38 +93,6 @@ def pip_compile(args=''):
     subprocess.check_call(command, env=dict(os.environ, CUSTOM_COMPILE_COMMAND='fab pip-compile'))
 
 @task
-def update_docker_image_version():
-    """
-        Update the image version in docker-compose.yml to contain a hash of all files that affect the Dockerfile build.
-    """
-    import re
-
-    # get hash of Dockerfile input files
-    # if this list changes, also update .github/workflows/tests.yml
-    paths = ['Dockerfile', 'requirements.txt', 'yarn.lock']
-    hasher = hashlib.sha256()
-    for path in paths:
-        hasher.update(Path(path).read_bytes())
-    hash = hasher.hexdigest()[:32]
-
-    # see if hash appears in docker-compose.yml
-    docker_compose_path = Path(settings.BASE_DIR, 'docker-compose.yml')
-    docker_compose = docker_compose_path.read_text()
-    if hash not in docker_compose:
-
-        # if hash not found, increment image version number, append new hash, and insert
-        current_version = re.findall(r'image: harvardlil/capstone:(.*)', docker_compose)[0]
-        digits = current_version.split('-')[0].split('.')
-        digits[-1] = str(int(digits[-1])+1)
-        new_version = "%s-%s" % (".".join(digits), hash)
-        docker_compose = docker_compose.replace(current_version, new_version)
-        docker_compose_path.write_text(docker_compose)
-        print("%s updated to version %s" % (docker_compose_path, new_version))
-
-    else:
-        print("%s is already up to date" % docker_compose_path)
-
-@task
 def show_urls():
     """ Show routable URLs and their names, across all subdomains. """
     for name, host in settings.HOSTS.items():

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -100,7 +100,7 @@ def update_docker_image_version():
     import re
 
     # get hash of Dockerfile input files
-    # if this list changes, also update .circleci/config.yml
+    # if this list changes, also update .github/workflows/tests.yml
     paths = ['Dockerfile', 'requirements.txt', 'yarn.lock']
     hasher = hashlib.sha256()
     for path in paths:
@@ -113,7 +113,7 @@ def update_docker_image_version():
     if hash not in docker_compose:
 
         # if hash not found, increment image version number, append new hash, and insert
-        current_version = re.findall(r'image: capstone:(.*)', docker_compose)[0]
+        current_version = re.findall(r'image: harvardlil/capstone:(.*)', docker_compose)[0]
         digits = current_version.split('-')[0].split('.')
         digits[-1] = str(int(digits[-1])+1)
         new_version = "%s-%s" % (".".join(digits), hash)

--- a/services/docker/extended-postgres.dockerfile
+++ b/services/docker/extended-postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:11.13
+FROM postgres:11.15
 
 RUN apt-get update && \
     apt-get install -y libpq-dev


### PR DESCRIPTION
So far, this just updates the capstone image -- changes for the postgres image will follow, with any luck. https://github.com/docker-library/postgres/issues/549 exposes what I think is the basic problem.