### PR TITLE
Update for new docker-compose-update-action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,22 +17,12 @@ jobs:
 
       ### build docker images ###
 
-      - name: Rebuild harvardlil/capstone-postgres if necessary
+      - name: Rebuild docker images
+        id: rebuild
         uses: harvard-lil/docker-compose-update-action@main
         with:
           working-directory: capstone
-          image: "harvardlil/capstone-postgres"
-          docker-file: "../services/docker/extended-postgres.dockerfile"
-          rebuild-if-changed: "../services/docker/extended-postgres.dockerfile"
-          registry-user: ${{ secrets.REPOSITORY_USER }}
-          registry-pass: ${{ secrets.REPOSITORY_TOKEN }}
-
-      - name: Rebuild harvardlil/capstone if necessary
-        uses: harvard-lil/docker-compose-update-action@main
-        with:
-          working-directory: capstone
-          image: "harvardlil/capstone"
-          rebuild-if-changed: "Dockerfile requirements.txt yarn.lock"
+          registry: "registry.lil.tools"
           registry-user: ${{ secrets.REPOSITORY_USER }}
           registry-pass: ${{ secrets.REPOSITORY_TOKEN }}
 

--- a/capstone/docker-compose.override.yml
+++ b/capstone/docker-compose.override.yml
@@ -1,9 +1,24 @@
 version: '2.2'
 services:
-    db:
-        build:
-          context: ../services/docker
-          dockerfile: extended-postgres.dockerfile
-    web:
-        build:
-            context: .
+  db:
+    build:
+      context: ../services/docker
+      dockerfile: extended-postgres.dockerfile
+      x-bake:
+        tags:
+          - registry.lil.tools/harvardlil/cap-db:0.6-nohash
+        platforms:
+          - linux/amd64
+      x-hash-paths:
+        - extended-postgres.dockerfile
+  web:
+    build:
+      context: .
+      x-bake:
+        tags:
+          - registry.lil.tools/harvardlil/cap-web:186-nohash
+        platforms:
+          - linux/amd64
+      x-hash-paths:
+        - requirements.txt
+        - yarn.lock

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.2'
 services:
     db:
-        image: harvardlil/capstone-postgres:0.6-db4d5dc41ff0371933fb6e4e7ffd051e
+        image: registry.lil.tools/harvardlil/cap-db:0.6-nohash
         platform: linux/amd64
         environment:
             POSTGRES_PASSWORD: password
@@ -28,7 +28,7 @@ services:
         ports:
           - 127.0.0.1:9200:9200
     web:
-        image: harvardlil/capstone:186-961af45c62e4fde35a03f9524a635f8b
+        image: registry.lil.tools/harvardlil/cap-web:186-nohash
         platform: linux/amd64
         volumes:
             # NAMED VOLUMES


### PR DESCRIPTION
Switch CAP to the new docker-compose-update-action setup, with config in docker-compose.override.yml. Also switch to using LIL's registry instead of docker.io. Will require changing REPOSITORY_USER and REPOSITORY_TOKEN.