### PR TITLE
refresh case body cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Load dev data:
     # fab import_web_volumes
     # fab refresh_case_body_cache
     # fab rebuild_search_index
+    
+To get ngrams working, run:
+
+    # mkdir test_data/ngrams
+    # fab ngram_jurisdictions
 
 Run the dev server:
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Load dev data:
     # fab init_dev_db
     # fab ingest_fixtures
     # fab import_web_volumes
+    # fab refresh_case_body_cache
     # fab rebuild_search_index
 
 Run the dev server:


### PR DESCRIPTION
When starting with a fresh installation and following the instructions in the README, I found that `fab rebuild_search_index` resulted in this error:

```
  File "/app/capapi/documents.py", line 209, in prepare_casebody_data
    cites_by_id = {k: list(v) for k,v in groupby(sorted(outbound_cites, key=lambda c: c.opinion_id), lambda c: c.opinion_id)}
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```
`fab refresh_case_body_cache` just before index rebuild does the trick; I'm not sure this is the minimal move that would fix it.