### PR TITLE
Web performance and accessibility improvements (round 2)

### DIFF
--- a/capstone/capweb/templates/index.html
+++ b/capstone/capweb/templates/index.html
@@ -26,7 +26,7 @@
   <div class="main-content bg-black">
 
     <!-- START MAP -->
-    <div class="map-section-layout-shift-buffer">
+    <div class="layout-shift-buffer">
       <div id="app"></div>
     </div>
     <!-- END MAP -->

--- a/capstone/capweb/templates/index.html
+++ b/capstone/capweb/templates/index.html
@@ -176,6 +176,8 @@
             <img class="boxcontainer-img"
                  loading="lazy"
                  alt="a technician holding disbound pages from a case reporter in front of a high speed scanner"
+                 width="800"
+                 height="533"
                  src='{% static "img/book-scan.jpg" %}'>
             <div class="boxcontainer-footer item-credit mt-2">Image: Brooks Kraft/Harvard Law School</div>
           </div>
@@ -183,6 +185,8 @@
             <img class="boxcontainer-img"
                  loading="lazy"
                  alt="case reporter books in in stacks"
+                 width="1200"
+                 height="799"
                  src='{% static "img/reporters.jpg" %}'/>
             <div class="boxcontainer-footer item-credit mt-2">Image: Brooks Kraft/Harvard Law School</div>
           </div>

--- a/capstone/capweb/templates/search.html
+++ b/capstone/capweb/templates/search.html
@@ -15,7 +15,9 @@
 {% block sidebar_menu %}{% endblock %}
 
 {% block main_content %}
-  <div id="app" class="content"></div>
+  <div class="layout-shift-buffer">
+    <div id="app" class="content"></div>
+  </div>
 
   <script>
     const config = {

--- a/capstone/static/css/scss/floating-labels.scss
+++ b/capstone/static/css/scss/floating-labels.scss
@@ -20,6 +20,13 @@
   cursor: text;
   transition: all .1s ease-in-out;
   pointer-events: none;
+
+  @include media-breakpoint-down(sm) {
+    top: -36px;
+    line-height: 1.25;
+    padding-right: 1ch;
+  }
+  
   @include media-breakpoint-up(lg) {
     font-size: 0.8em;
   }

--- a/capstone/static/css/scss/index.scss
+++ b/capstone/static/css/scss/index.scss
@@ -146,11 +146,9 @@ p.section-subtitle {
 * == Map Section ==
 *
 ***************************************************************/
-.map-section-layout-shift-buffer {
-
-  // Reduce layout shift while the map / stats block displays
+// This wrapper allows to apply a minimal height on elements whose rendering is delayed (JS) as to reduce layout shift.
+.layout-shift-buffer {
   min-height: 286px;
-
   @include media-breakpoint-up(md) {
     min-height: 90vh;
   }

--- a/capstone/static/css/scss/index.scss
+++ b/capstone/static/css/scss/index.scss
@@ -85,6 +85,7 @@ p.section-subtitle {
 
 .boxcontainer-img {
   max-width: 100%;
+  height: auto;
 }
 
 .short-standalone-quote {

--- a/capstone/static/css/scss/index.scss
+++ b/capstone/static/css/scss/index.scss
@@ -147,7 +147,10 @@ p.section-subtitle {
 *
 ***************************************************************/
 .map-section-layout-shift-buffer {
-  // Reduce layout shift on desktop while the map loads
+
+  // Reduce layout shift while the map / stats block displays
+  min-height: 286px;
+
   @include media-breakpoint-up(md) {
     min-height: 90vh;
   }

--- a/capstone/static/css/scss/search.scss
+++ b/capstone/static/css/scss/search.scss
@@ -8,6 +8,14 @@
 @import "search_results";
 @import "vue-select/vue-select.scss";
 
+// This wrapper allows to apply a minimal height on elements whose rendering is delayed (JS) as to reduce layout shift.
+.layout-shift-buffer {
+  min-height: 100vh;
+  @include media-breakpoint-up(md) {
+    min-height: 1020px;
+  }
+}
+
 $color-search-gray-light: #ced4da;
 .top-section {
   padding-bottom: 0 !important;
@@ -38,6 +46,10 @@ input, textarea,
 
 .form-label-group {
   font-family: $font-sans-title;
+
+  @include media-breakpoint-down(md) {
+    padding: 0.1rem;
+  }
 
   .queryfield, .vs__dropdown-toggle {
     margin-bottom: 0;
@@ -229,6 +241,11 @@ label.dropdown-label {
     color: $color-black;
     text-transform: none;
     border-radius: 0;
+
+    @include media-breakpoint-down(md) {
+      position: relative;
+      top: 1px;
+    }
   }
   input.vs__search::placeholder {
       color: $color-black;


### PR DESCRIPTION
## Goals and status 
- **Goals:** Second round of accessibility and performance tweaks.
- ~**Status:** WIP~

---

⚠️ **Note:** All videos shown here are captured using _"Fast 3G"_ throttling to make layout shift changes more obvious. 

---

## Homepage: Layout shift reduction on mobile

**Before:**

https://user-images.githubusercontent.com/625889/171471739-09e0cacf-01cd-41a0-889e-cf0678323f8b.mov

**After:**


https://user-images.githubusercontent.com/625889/171471801-d70ba263-0b06-4eab-a08a-97697b8d0d0d.mov

---

## Search page: Layout shift reduction on desktop

**Before:**

https://user-images.githubusercontent.com/625889/171471945-fe6be9c1-fb3b-4bb3-bc01-3f58180c1364.mov

**After:**

https://user-images.githubusercontent.com/625889/171471996-1b67435c-b422-4b01-99a5-ee978b704c6b.mov

---

## Search page: Layout shift reduction on mobile

**Before:**

https://user-images.githubusercontent.com/625889/171472084-8a74d1fb-49ac-414b-8de2-c242878b8b40.mov

**After:**

https://user-images.githubusercontent.com/625889/171472133-d4d61902-2d84-44b1-bd23-5cf65e52f3e0.mov

----

## Search page: Cosmetic upgrades on the search form (mobile)

**Before:**

<img width="423" alt="Search before" src="https://user-images.githubusercontent.com/625889/171472385-9e126362-1a69-498d-bd11-f122e656c202.png">

**After:**

<img width="423" alt="Search after" src="https://user-images.githubusercontent.com/625889/171472331-dd2f4859-69a8-43b8-bff4-e549bbade094.png">




