### PR TITLE
tweak readme instructions and add bulk download docs to tools page

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,18 +137,6 @@ If you are working on javascript files, frontend, use `fab run_frontend`:
     # fab run_frontend
 
 ## Administering and Developing Capstone <a id="administering-and-developing-capstone"></a>
-- [Capstone](#capstone)
-  - [Project Background ](#project-background-)
-  - [The Data ](#the-data-)
-    - [Format Documentation and Samples ](#format-documentation-and-samples-)
-    - [Obtaining Real Data ](#obtaining-real-data-)
-    - [Reporting Data Errors ](#reporting-data-errors-)
-    - [Errata ](#errata-)
-  - [The Capstone Application ](#the-capstone-application-)
-  - [Installing Capstone and CAPAPI ](#installing-capstone-and-capapi-)
-    - [Hosts Setup ](#hosts-setup-)
-    - [Docker Setup ](#docker-setup-)
-  - [Administering and Developing Capstone ](#administering-and-developing-capstone-)
     - [Testing ](#testing-)
     - [Requirements ](#requirements-)
     - [Applying model changes ](#applying-model-changes-)
@@ -160,7 +148,6 @@ If you are working on javascript files, frontend, use `fab run_frontend`:
     - [Download real data locally ](#download-real-data-locally-)
     - [Working with javascript ](#working-with-javascript-)
     - [Elasticsearch ](#elasticsearch-)
-  - [Code examples ](#code-examples-)
 
 ### Testing <a id="testing"></a>
 

--- a/README.md
+++ b/README.md
@@ -5,29 +5,30 @@ Capstone
 
 This is the source code for [case.law](https://case.law), a website written by the Harvard Law School Library Innovation Lab to manage and serve court opinions. Other than several cases used for our automated testing, this repository does not contain case data. Case data may be obtained through the website.
 
-- [Project Background](#project-background)
-- [The Data](#the-data)
-  - [Format Documentation and Samples](#documentation-and-samples)
-  - [Obtaining Real Data](#obtaining-real-data)
-  - [Reporting Data Errors](#reporting-data-errors)
-  - [Errata](#errata)
-- [The Capstone Application](#the-capstone-application)
-- [CAPAPI](#capapi)
-- [Installing Capstone](#installing-capstone-and-capapi)
-- [Administering and Developing Capstone](#administering-and-developing-capstone)
-  - [Testing](#testing)
-  - [Requirements](#requirements)
-  - [Applying model changes](#applying-model-changes)
-  - [Stored Postgres functions](#stored-postgres-functions)
-  - [Running Command Line Scripts](#running-command-line-scripts)
-  - [Logging In](#logging-in)
-  - [Local debugging tools](#local-debugging-tools)
-  - [Download real data locally](#download-real-data-locally )
-  - [Model versioning](#model-versioning)
-  - [Working with javascript](#working-with-javascript)
-  - [Elasticsearch](#elasticsearch)
-- [Documentation](#documentation)
-- [Examples](#examples)
+- [Capstone](#capstone)
+  - [Project Background ](#project-background-)
+  - [The Data ](#the-data-)
+    - [Format Documentation and Samples ](#format-documentation-and-samples-)
+    - [Obtaining Real Data ](#obtaining-real-data-)
+    - [Reporting Data Errors ](#reporting-data-errors-)
+    - [Errata ](#errata-)
+  - [The Capstone Application ](#the-capstone-application-)
+  - [Installing Capstone and CAPAPI ](#installing-capstone-and-capapi-)
+    - [Hosts Setup ](#hosts-setup-)
+    - [Docker Setup ](#docker-setup-)
+  - [Administering and Developing Capstone ](#administering-and-developing-capstone-)
+    - [Testing ](#testing-)
+    - [Requirements ](#requirements-)
+    - [Applying model changes ](#applying-model-changes-)
+    - [Stored Postgres functions ](#stored-postgres-functions-)
+    - [Running Command Line Scripts ](#running-command-line-scripts-)
+    - [Logging In ](#logging-in-)
+    - [Local debugging tools ](#local-debugging-tools-)
+    - [Model versioning ](#model-versioning-)
+    - [Download real data locally ](#download-real-data-locally-)
+    - [Working with javascript ](#working-with-javascript-)
+    - [Elasticsearch ](#elasticsearch-)
+  - [Code examples ](#code-examples-)
 
 ## Project Background <a id="project-background"></a>
 The Caselaw Access Project is a large-scale digitization project hosted by the Harvard Law School [Library Innovation Lab.](http://lil.law.harvard.edu "LIL Website") Visit [case.law](https://case.law/) for more details.
@@ -107,19 +108,19 @@ From now on all commands starting with `#` are assumed to be run from within `do
 
 Load dev data:
 
+> ⚠️ **Note:** Make sure that Docker has sufficient resources allocated to run Elastic Search. Lower allocations may cause `rebuild_search_index` to crash.
+> _Recommended minimum:_
+> - CPUs: 6
+> - Memory: 10 GB
+> - Swap: 1 GB
+> - Disk image: ~256 GB
+
     # fab init_dev_db
     # fab ingest_fixtures
     # fab import_web_volumes
     # fab refresh_case_body_cache
     # fab rebuild_search_index
 
-> ⚠️ **Note:** If `rebuild_search_index` crashes, make sure that Docker has sufficient resources allocated to run Elastic Search.
-> _Recommended minimum:_
-> - CPUs: 6
-> - Memory: 10 GB
-> - Swap: 1 GB
-> - Disk image: ~256 GB
-    
 To get ngrams working, run:
 
     # mkdir test_data/ngrams
@@ -136,14 +137,30 @@ If you are working on javascript files, frontend, use `fab run_frontend`:
     # fab run_frontend
 
 ## Administering and Developing Capstone <a id="administering-and-developing-capstone"></a>
-- [Testing](#testing)
-- [Requirements](#requirements)
-- [Applying model changes](#applying-model-changes)
-- [Stored Postgres functions](#stored-postgres-functions)
-- [Running Command Line Scripts](#running-command-line-scripts)
-- [Local debugging tools](#local-debugging-tools)
-- [Download real data locally](#download-real-data-locally )
-- [Model versioning](#model-versioning)
+- [Capstone](#capstone)
+  - [Project Background ](#project-background-)
+  - [The Data ](#the-data-)
+    - [Format Documentation and Samples ](#format-documentation-and-samples-)
+    - [Obtaining Real Data ](#obtaining-real-data-)
+    - [Reporting Data Errors ](#reporting-data-errors-)
+    - [Errata ](#errata-)
+  - [The Capstone Application ](#the-capstone-application-)
+  - [Installing Capstone and CAPAPI ](#installing-capstone-and-capapi-)
+    - [Hosts Setup ](#hosts-setup-)
+    - [Docker Setup ](#docker-setup-)
+  - [Administering and Developing Capstone ](#administering-and-developing-capstone-)
+    - [Testing ](#testing-)
+    - [Requirements ](#requirements-)
+    - [Applying model changes ](#applying-model-changes-)
+    - [Stored Postgres functions ](#stored-postgres-functions-)
+    - [Running Command Line Scripts ](#running-command-line-scripts-)
+    - [Logging In ](#logging-in-)
+    - [Local debugging tools ](#local-debugging-tools-)
+    - [Model versioning ](#model-versioning-)
+    - [Download real data locally ](#download-real-data-locally-)
+    - [Working with javascript ](#working-with-javascript-)
+    - [Elasticsearch ](#elasticsearch-)
+  - [Code examples ](#code-examples-)
 
 ### Testing <a id="testing"></a>
 

--- a/capstone/capweb/templates/tools.md
+++ b/capstone/capweb/templates/tools.md
@@ -33,6 +33,7 @@ Browse and cite all of our cases sorted by jurisdiction, series, and volume.
 Our downloads directory includes derivative datasets, bulk exports, and summaries from the Caselaw Access Project. 
 
 [DOWNLOADS]({% url "download-files" "" %}){: class="btn-primary" }
+[DOCS]({% url "bulk-docs" %}){: class="btn-secondary" }
 {: class="btn-group" }
 
 # Historical Trends {: class="subtitle" }


### PR DESCRIPTION
This PR addresses this issue: https://github.com/harvard-lil/capstone/issues/2004 by adding a link to the tools page for the bulk download docs. It also reworks the readme very slightly to address a known issue.