### PR TITLE
Update certifi

### DIFF
--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -165,9 +165,9 @@ celery[redis,sqs]==4.3.0 \
     # via
     #   -r requirements.in
     #   flower
-certifi==2018.11.29 \
-    --hash=sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7 \
-    --hash=sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033
+certifi==2022.12.7 \
+    --hash=sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3 \
+    --hash=sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18
     # via
     #   elasticsearch
     #   requests


### PR DESCRIPTION
This version of certifi removes TrustCor's root certificate. I haven't found release notes, but here's the diff from the previous version to this:

https://github.com/certifi/python-certifi/compare/2022.09.24...2022.12.07

(We're running an older package -- here's the [longer diff](https://github.com/certifi/python-certifi/compare/2018.11.29...2022.12.07).)