### PR TITLE
Removes links for courts and jurisdications in search result returns

### DIFF
--- a/capstone/static/js/search/case-result.vue
+++ b/capstone/static/js/search/case-result.vue
@@ -22,15 +22,11 @@
       <span class="court"
             v-if="result.court">
       &nbsp;&middot;
-        <a class="simple" target="_blank" :href="result.court.url">
           {{ result.court.name }}
-        </a>
       </span>
       <span class="jurisdiction">
         &nbsp;&middot;
-        <a class="simple" target="_blank" :href="result.jurisdiction.url">
           {{result.jurisdiction.name_long}}
-        </a>
       </span>
     </div>
     <div class="row" v-if="result.preview.length > 0">


### PR DESCRIPTION
To address the fact that [linking to courts and jurisdictions in our search results was confusing and unhelpful](https://github.com/harvard-lil/capstone/issues/2023), this PR removes those links. 

<img width="631" alt="Screen Shot 2023-02-03 at 6 38 53 PM" src="https://user-images.githubusercontent.com/7401870/216730489-b76b69fb-c052-48b0-973d-b5d8688bca45.png">

Beauty.