### PR TITLE
Set 404 status when NoReverseMatch error raised for missing volume

### DIFF
--- a/capstone/cite/tests/test_views.py
+++ b/capstone/cite/tests/test_views.py
@@ -89,6 +89,10 @@ def test_volume(client, django_assert_num_queries, case_factory, elasticsearch):
     response = client.get(reverse('volume', args=['Mass.', '1'], host='cite'), follow=True)
     check_response(response, status_code=200)
 
+    # make sure we get 404 if bad volume input
+    response = client.get(reverse('volume', args=['Mass.', '*'], host='cite'))
+    check_response(response, status_code=404)
+
 
 @pytest.mark.django_db(databases=['capdb'])
 def test_case_not_found(client, django_assert_num_queries, elasticsearch):

--- a/capstone/cite/views.py
+++ b/capstone/cite/views.py
@@ -147,8 +147,11 @@ def volume(request, series_slug, volume_number_slug):
 
     # redirect if series slug or volume number slug is in the wrong format
 
-    if slugify(series_slug) != series_slug or slugify(volume_number_slug) != volume_number_slug:
-        return HttpResponseRedirect(reverse('volume', args=[slugify(series_slug), slugify(volume_number_slug)], host='cite'))
+    try:
+        if slugify(series_slug) != series_slug or slugify(volume_number_slug) != volume_number_slug:
+            return HttpResponseRedirect(reverse('volume', args=[slugify(series_slug), slugify(volume_number_slug)], host='cite'))
+    except NoReverseMatch:
+        raise Http404
 
     vols = list(VolumeMetadata.objects
         .select_related('reporter')


### PR DESCRIPTION
To address issue [Catch error displaying invalid volume-URL page](https://github.com/harvard-lil/capstone/issues/1993), this PR adds a try/except block to `raise Http404` in case of `NoReverseMatch` error for a non existent volume query. PR includes a test for this functionality.

<img width="914" alt="Screen Shot 2023-02-06 at 11 56 58 AM" src="https://user-images.githubusercontent.com/7401870/217042503-eb2af55e-fbe2-45dd-8886-0d72890c212b.png">
