### PR TITLE
Replace Watchdog to fix celery error in dev

### DIFF
--- a/capstone/capdb/management/commands/run_celery_worker.py
+++ b/capstone/capdb/management/commands/run_celery_worker.py
@@ -1,0 +1,21 @@
+import shlex
+import subprocess
+
+from django.utils import autoreload
+from django.core.management.base import BaseCommand
+
+# Create a command to autoreload celery beat for elasticsearch indexing
+def autoreload_celery(*args, **kwargs):
+    print("Restarting celery...")
+    autoreload.raise_last_exception()
+    kill_celery = "ps aux | grep bin/celery | awk '{print $2}' | xargs kill -9"
+    subprocess.call(kill_celery, shell=True)
+    start_celery = "celery worker -A config.celery.app -c 1 -B"
+    subprocess.call(shlex.split(start_celery))
+
+class Command(BaseCommand):
+    help = 'Autoreload celery beat worker for elasticsearch indexing'
+
+    def handle(self, *args, **options):
+        self.stdout.write("Starting celery worker with autoreload...")
+        autoreload.run_with_reloader(autoreload_celery, args=None, kwargs=None)

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -64,6 +64,7 @@ def run_django(port="127.0.0.1:8000"):
     if os.environ.get('DOCKERIZED'):
         port = "0.0.0.0:8000"
     # run celerybeat in background for elasticsearch indexing
+    # this function uses Django's autoreload
     with open_subprocess("python manage.py run_celery_worker"):
         # This was `management.call_command('runserver', port)`, but then the Django autoreloader
         # itself calls fab run and we get two copies of everything!

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -64,7 +64,7 @@ def run_django(port="127.0.0.1:8000"):
     if os.environ.get('DOCKERIZED'):
         port = "0.0.0.0:8000"
     # run celerybeat in background for elasticsearch indexing
-    with open_subprocess("watchmedo auto-restart -d ./ -p '*.py' -R -- celery worker -A config.celery.app -c 1 -B"):
+    with open_subprocess("python manage.py run_celery_worker"):
         # This was `management.call_command('runserver', port)`, but then the Django autoreloader
         # itself calls fab run and we get two copies of everything!
         # --nostatic so whitenoise is used in dev

--- a/capstone/requirements.in
+++ b/capstone/requirements.in
@@ -20,8 +20,6 @@ dictdiffer          # supports a hack to avoid clobbering timelines with outdate
 celery[redis,sqs]   # task queue
 pycurl              # let celery talk to SQS queue
 flower              # monitoring
-watchdog            # restart celery in dev (via 'watchmedo' command)
-argh                # needed by watchdog
 
 # xml
 lxml

--- a/capstone/requirements.txt
+++ b/capstone/requirements.txt
@@ -51,10 +51,6 @@ apipkg==1.5 \
     --hash=sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6 \
     --hash=sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c
     # via execnet
-argh==0.26.2 \
-    --hash=sha256:a9b3aaa1904eeb78e32394cd46c6f37ac0fb4af6dc488daa58971bdc7d7fcaf3 \
-    --hash=sha256:e9535b8c84dc9571a48999094fda7f33e63c3f1b74f3e5f3ac0105a58405bb65
-    # via -r requirements.in
 asgiref==3.3.4 \
     --hash=sha256:92906c611ce6c967347bbfea733f13d6313901d54dcca88195eaeb52b2a8e8ee \
     --hash=sha256:d1216dfbdfb63826470995d31caed36225dcaf34f182e0fa257a4dd9e86f1b78
@@ -939,9 +935,6 @@ pathlib2==2.3.5 \
     --hash=sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db \
     --hash=sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868
     # via -r requirements.in
-pathtools==0.1.2 \
-    --hash=sha256:7c35c5421a39bb82e58018febd90e3b6e5db34c5443aaaf742b3f33d4655f1c0
-    # via watchdog
 pep517==0.10.0 \
     --hash=sha256:ac59f3f6b9726a49e15a649474539442cf76e0697e39df4869d25e68e880931b \
     --hash=sha256:eba39d201ef937584ad3343df3581069085bacc95454c80188291d5b3ac7a249
@@ -1518,9 +1511,6 @@ vine==1.3.0 \
     # via
     #   amqp
     #   celery
-watchdog==0.10.3 \
-    --hash=sha256:4214e1379d128b0588021880ccaf40317ee156d4603ac388b9adcf29165e0c04
-    # via -r requirements.in
 wcwidth==0.2.5 \
     --hash=sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784 \
     --hash=sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83


### PR DESCRIPTION
[This issue](https://github.com/harvard-lil/capstone/issues/2094) brought to light an issue with using Watchmedo (Watchdog) to auto reload the celery worker for elastic search indexing. Unfortunately, this is a [known issue](https://github.com/gorakhargosh/watchdog/issues/838) with the current solution of switching to `arm64-capable` (we're running `linux/amd64`). Changing that would mean changing our regex library, which is a lot of work! Instead, I found you could use the Django's `autoreload` built in utility. 

I used this as a reference to create the command: 
https://github.com/fceruti/django-starter-project/blob/fa22e6b2496aa9943d50d9690143a2b4c9bac3be/apps/misc/management/commands/celery_autoreload.py

This PR removes the watchdog and argh requirements, since they're no longer used.