### PR TITLE
Fix PDF unredaction

### DIFF
--- a/capstone/scripts/helpers.py
+++ b/capstone/scripts/helpers.py
@@ -302,7 +302,7 @@ def copy_file(from_path, to_path, from_storage=None, to_storage=None):
     """
     from_storage = from_storage or _root_file_system_storage
     to_storage = to_storage or _root_file_system_storage
-    to_storage.save(str(to_path), from_storage.open(str(from_path)))
+    return to_storage.save(str(to_path), from_storage.open(str(from_path)))
 
 
 def ordered_query_iterator(queryset, chunk_size=1000):


### PR DESCRIPTION
Fix an issue where volumes being unredacted resulted in a new unredacted PDF appearing beside the original, with a modified filename like "/mnt/storage/prod/downloads/PDFs/open/Arkansas/Ark./165 Ark_WYVf0Q5.pdf", rather than replacing the redacted version. Existing instances of this problem will have to fixed with a separate script.