### PR TITLE
Updates some broken urls and pulls relevant explanation higher

### DIFF
--- a/capstone/capweb/templates/docs/02_site_features/03_api.md
+++ b/capstone/capweb/templates/docs/02_site_features/03_api.md
@@ -118,7 +118,7 @@ case in our system, you can append it to the [path]({% docs_url 'glossary' %}#de
 
 ### Endpoint Parameters
 
-Many parameters can be appended with `__in`, `__exclude`, `__gt`, `__gte`, `__lt`, or `__lte`. See [Filtering](#case-filtering).
+Many parameters can be appended with `__in`, `__exclude`, `__gt`, `__gte`, `__lt`, or `__lte`. See [Filtering]({% docs_url 'in_depth' %}#case-filtering).
 
 * `analysis.<key>`
 {: add_list_class="parameter-list" }

--- a/capstone/capweb/templates/docs/04_specs_and_reference/02_data_formats.md
+++ b/capstone/capweb/templates/docs/04_specs_and_reference/02_data_formats.md
@@ -158,6 +158,8 @@ to transform our XML-formatted data to semantic HTML ready for CSS formatting of
     
 ### Analysis Fields
 
+Analysis fields are values calculated by processing the raw case text. They can be searched with [filters]({% docs_url 'in_depth' %}#case-filtering).
+
 Each case result in the API returns an analysis section, such as:
 
     "analysis": { 
@@ -172,8 +174,6 @@ Each case result in the API returns an analysis section, such as:
         "cardinality": 390,
         "simhash": "1:3459aad720da314e" 
     }
-
-Analysis fields are values calculated by processing the raw case text. They can be searched with [filters](#case-filtering).
 
 All analysis fields are optional, and may or may not appear for a given case.
 

--- a/capstone/cite/templates/cite/case.html
+++ b/capstone/cite/templates/cite/case.html
@@ -3,6 +3,7 @@
 {% load static %}
 {% load django_vite %}
 {% load api_url %}
+{% load docs_url %}
 {% load redaction %}
 {% load humanize %}
 
@@ -108,7 +109,7 @@
               <div class="sidebar-section d-none d-lg-block" id="analysis-section">
                 <h3>
                   Analysis
-                  <a class="analysis-link" href="{% url "api" %}#analysis-fields">
+                  <a class="analysis-link" href="{% docs_url "data_formats" %}#analysis-fields">
                     <img class="analysis-info" alt="More information about analysis fields" src="{% static "img/icons/question.svg" %}">
                   </a>
                 </h3>


### PR DESCRIPTION
This PR fixes a [broken link on the analysis explainer](https://github.com/harvard-lil/capstone/issues/1974) and a couple of instances of a broken link for case filtering. I pulled the info explaining what the analysis stats are up as well so that unfamiliar users would read that before the stats break down.