### PR TITLE
Adds a check for out_of_scope volumes to citation extraction

### DIFF
--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -414,15 +414,16 @@ def test_run_text_analysis(reset_sequences, case):
 
 
 @pytest.mark.django_db(databases=['capdb'])
-def test_export_citation_graph(case_factory, tmpdir, elasticsearch, citation_factory, jurisdiction_factory):
+def test_export_citation_graph(case_factory, tmpdir, citation_factory, jurisdiction_factory, volume_metadata_factory):
     output_folder = Path(str(tmpdir))
 
     (
         cite_from, cite_to, different_jur_cite, cite_to_aka, another_cite_to,
-        cite_not_in_cap, duplicate_cite, future_cite
-    ) = ["%s U.S. %s" % (i, i) for i in range(1, 9)]
+        cite_not_in_cap, duplicate_cite, future_cite, duplicate_volume_cite
+    ) = ["%s U.S. %s" % (i, i) for i in range(1, 10)]
 
     jur1, jur2, jur3 = [jurisdiction_factory() for _ in range(3)]
+    out_of_scope_vol = volume_metadata_factory(out_of_scope=True, scope_reason='Duplicate')
 
     # cases
     case_from = case_factory(citations__cite=cite_from, decision_date=datetime(2000, 1, 1), jurisdiction=jur1)
@@ -432,16 +433,18 @@ def test_export_citation_graph(case_factory, tmpdir, elasticsearch, citation_fac
     different_jur_case = case_factory(citations__cite=different_jur_cite, decision_date=datetime(2000, 1, 1), jurisdiction=jur2)
     [case_factory(citations__cite=duplicate_cite, jurisdiction=jur1) for _ in range(3)]  # ambiguous cases
     case_factory(citations__cite=future_cite, decision_date=datetime(2010, 1, 1), jurisdiction=jur1)  # future case
-
+    case_factory(citations__cite=duplicate_volume_cite, decision_date=datetime(1989, 1, 1), jurisdiction=jur3,
+                                         volume=out_of_scope_vol) # volume out of scope due to duplication
     # case text to extract
     set_case_text(case_from, f"""
         Cite to self ignored during extraction: {cite_from}
         Parallel cite to another case included once: {cite_to}, {cite_to_aka}
         Cite to another case: {another_cite_to}
         Duplicate cite to another case: {another_cite_to}
-        Ambiguous cites not included: {duplicate_cite}
+        Ambiguous cites excluded: {duplicate_cite}
         Unknown cites excluded: {cite_not_in_cap}
         Cites into the future excluded: {future_cite}
+        Cites to cases in out of scope volumes excluded: {duplicate_volume_cite}
     """)
     set_case_text(different_jur_case, f"""
         Cite to case: {cite_to}
@@ -455,7 +458,8 @@ def test_export_citation_graph(case_factory, tmpdir, elasticsearch, citation_fac
     extracted = case_from.extracted_citations.all()
     assert set(e.cite for e in extracted) == {
         cite_to, another_cite_to,
-        duplicate_cite, cite_not_in_cap, future_cite
+        duplicate_cite, cite_not_in_cap,
+        future_cite, duplicate_volume_cite
     }
 
     # perform export

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -1188,9 +1188,12 @@ def export_citation_graph(output_folder="graph"):
                 capdb_casemetadata target_case on ec.target_case_id = target_case.id
             inner join
                 capdb_casemetadata cited_by on ec.cited_by_id = cited_by.id
+            inner join
+                capdb_volumemetadata target_volume on target_case.volume_id = target_volume.barcode
         where 
             cited_by.in_scope is true
             and target_case.in_scope is true
+            and target_volume.out_of_scope is false
             and cited_by.decision_date_original >= target_case.decision_date_original
             and cited_by.id != target_case.id
         group by cited_by.id;


### PR DESCRIPTION
This PR addresses the [check if volumes are out of scope for cases when exporting citation graph](https://github.com/harvard-lil/capstone/issues/1920) issue.

It adds another inner join to check the volume `out_of_scope` field. We've tested how much this slows the query added here [in that issue](https://github.com/harvard-lil/capstone/issues/1920#issuecomment-1485687774) and this seems like a reasonable fix.

The test adds a case in an out of scope volume with a citation. Like the `future_cite` or `cite_not_in_cap`, it is not included in the exported citation graph.

Comments welcome