### PR TITLE
Fix boolean search

### DIFF
--- a/capstone/capapi/documents.py
+++ b/capstone/capapi/documents.py
@@ -76,16 +76,17 @@ class RawSearch(Search):
 class CaseDocument(Document):
     # IMPORTANT: If you change what values are indexed here, also change the "CaseLastUpdate triggers"
     # section in set_up_postgres.py to keep Elasticsearch updated.
-    name_abbreviation = SuggestField(analyzer='english')
-    name = fields.TextField(index_phrases=True, analyzer='english')
+    name_abbreviation = SuggestField(analyzer='english', copy_to="multi_field_content")
+    name = fields.TextField(index_phrases=True, analyzer='english', copy_to="multi_field_content")
     frontend_url = fields.KeywordField()
     frontend_pdf_url = fields.KeywordField()
     last_page = fields.KeywordField()
     first_page = fields.KeywordField()
     decision_date_original = fields.KeywordField()
     docket_numbers = fields.TextField(multi=True)
-    docket_number = fields.TextField()
+    docket_number = fields.TextField(copy_to="multi_field_content")
     last_updated = fields.KeywordField()
+    multi_field_content = fields.TextField()
 
     volume = fields.ObjectField(properties={
         "barcode": fields.KeywordField(),
@@ -105,7 +106,7 @@ class CaseDocument(Document):
     court = fields.ObjectField(properties={
         "id": fields.IntegerField(),
         "slug": fields.KeywordField(),
-        "name": fields.TextField(),
+        "name": fields.TextField(copy_to="multi_field_content"),
         "name_abbreviation": SuggestField(),
     })
 
@@ -120,7 +121,7 @@ class CaseDocument(Document):
         "id": fields.IntegerField(),
         "slug": fields.KeywordField(),
         "name": fields.KeywordField(),
-        "name_long": SuggestField(),
+        "name_long": SuggestField(copy_to="multi_field_content"),
         "whitelisted": fields.BooleanField()
     })
 
@@ -132,8 +133,8 @@ class CaseDocument(Document):
             'judges': fields.TextField(multi=True),
             'parties': fields.TextField(multi=True),
             'opinions': fields.NestedField(multi=True, properties={
-                'author': FTSField(),
-                'text': FTSField(),
+                'author': FTSField(copy_to=["multi_field_content"]),
+                'text': FTSField(copy_to=["multi_field_content"]),
                 'type': fields.KeywordField(),
                 'extracted_citations': fields.NestedField(properties={
                     "cite": fields.KeywordField(),
@@ -153,7 +154,8 @@ class CaseDocument(Document):
                     "opinion_id": fields.IntegerField(),
                 })  
             }),
-            'corrections': fields.TextField(),
+            'corrections': fields.TextField(copy_to="multi_field_content"),
+            'head_matter': fields.TextField(copy_to="multi_field_content")
         }),
     })
 
@@ -171,6 +173,9 @@ class CaseDocument(Document):
     })
 
     restricted = fields.BooleanField()
+
+    def prepare_multi_field_content(self, instance):
+        pass
 
     def prepare_provenance(self, instance):
         return {

--- a/capstone/capapi/filters.py
+++ b/capstone/capapi/filters.py
@@ -499,13 +499,7 @@ class NestedFTSFilter(BaseSearchFilterBackend):
 class MultiFieldFTSFilter(BaseSearchFilterBackend):
     search_param = 'search'
     fields = (
-        'name',
-        'name_abbreviation',
-        'jurisdiction.name_long',
-        'court.name',
-        'casebody_data.text.head_matter',
-        'casebody_data.text.corrections',
-        'docket_number',
+        'multi_field_content',
     )
 
     nested_query_fields = (


### PR DESCRIPTION
This PR addresses the [issue around boolean search failure](https://github.com/harvard-lil/capstone/issues/1981) due to ES not searching across multiple fields when using the AND keyword.
To fix, I implemented `copy_to` to grab the content of all the fields we wanted to search into a single field that could be searched.
This is what happens when you search `"Argued before BELL" AND "rationale of Gardner"` on the live site:
<img width="993" alt="Screenshot 2023-04-06 at 3 47 47 PM" src="https://user-images.githubusercontent.com/7401870/230479799-bb4a94d4-d0a9-447f-864e-a7dae7818915.png">
That's because the first phrase is in the `head_matter` field and the second is in `casebody_data.opinions.text`. 

This is what happens when you run the same search with this change:
<img width="1064" alt="Screenshot 2023-04-06 at 3 48 39 PM" src="https://user-images.githubusercontent.com/7401870/230479946-8f05b5ce-93fc-4dc3-8dc3-4e9b7c00f800.png">

Deploying this will require running `fab rebuild_search_index` on prod, so we will have to plan when that is appropriate.