### PR TITLE
Adds an index block to pages with meta tags

### DIFF
--- a/capstone/capweb/templates/main_base.html
+++ b/capstone/capweb/templates/main_base.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
 
     {# title #}
     {% capture as title_out silent %}{% block title %}{% if title %}{{ title }}{% endif %}{% endblock title %}{% block title_suffix %} | Caselaw Access Project{% endblock title_suffix %}{% endcapture %}

--- a/capstone/cite/templates/cite/check_js.html
+++ b/capstone/cite/templates/cite/check_js.html
@@ -2,7 +2,6 @@
   <head>
     <noscript>
       <meta http-equiv="Refresh" content="0;URL=?no_js=1&next={{ next }}" />
-      <meta name="robots" content="noindex" />
     </noscript>
   </head>
   <body>

--- a/capstone/cite/templates/cite/check_js.html
+++ b/capstone/cite/templates/cite/check_js.html
@@ -2,13 +2,14 @@
   <head>
     <noscript>
       <meta http-equiv="Refresh" content="0;URL=?no_js=1&next={{ next }}" />
+      <meta name="robots" content="noindex" />
     </noscript>
   </head>
   <body>
     <form method="post" id="not-a-bot-form">
       {% csrf_token %}
-      <input type="hidden" name="not_a_bot" value="yes">
-      <input type="hidden" name="next" value="{{ next }}" id="next">
+      <input type="hidden" name="not_a_bot" value="yes" />
+      <input type="hidden" name="next" value="{{ next }}" id="next" />
     </form>
     <script>
       {# set form next value from JS to include url fragment, which we can't see on the server side #}

--- a/capstone/labs/templates/lab/chronolawgic/labs_base.html
+++ b/capstone/labs/templates/lab/chronolawgic/labs_base.html
@@ -9,6 +9,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex">
 
     {# title #}
     {% capture as title_out silent %}{% block title %}{% if title %}{{ title }}{% endif %}{% endblock title %}{% block title_suffix %} | Caselaw Access Project{% endblock title_suffix %}{% endcapture %}

--- a/capstone/labs/templates/lab/chronolawgic/labs_base.html
+++ b/capstone/labs/templates/lab/chronolawgic/labs_base.html
@@ -9,7 +9,6 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="robots" content="noindex">
 
     {# title #}
     {% capture as title_out silent %}{% block title %}{% if title %}{{ title }}{% endif %}{% endblock title %}{% block title_suffix %} | Caselaw Access Project{% endblock title_suffix %}{% endcapture %}


### PR DESCRIPTION
This work corresponds to issue 94 [on Linear](https://linear.app/harvard-lil/issue/ENG-94/cap-remove-cases-from-google-indexsearch-platforms)

It is part of the effort to make deindexing permanent for CAP pages. This is what will stop our site from getting re-indexed. The process is [described here](https://developers.google.com/search/docs/crawling-indexing/remove-information).

main_base.html is the only page that is used throughout the site as the template all other templates build from, so I think that's actually the only one really necessary here.

