### PR TITLE
Add bounding rectangles from PDF to each paragraph in exported HTML

### DIFF
--- a/capstone/capdb/models.py
+++ b/capstone/capdb/models.py
@@ -1209,8 +1209,12 @@ class CaseMetadata(models.Model):
         """
             Update self.body_cache with new values based on the current value of self.structure.
             blocks_by_id and fonts_by_id can be provided for efficiency if updating a bunch of cases from the same volume.
-        """
 
+            Return value:
+                If case contents have changed, return (True, analyses, cites_to_delete, cites_to_create)
+                    These return values are useful if using save=False and bulk saving results in the caller.
+                Else return False, [], [], []
+        """
         # if rerender is false, just regenerate json and text attributes from existing html
         if not rerender:
             try:
@@ -2258,7 +2262,8 @@ class PageStructure(models.Model):
         blocks = {}
         for page in pages:
             for block in page.blocks:
-                blocks[block['id']] = block
+                # include page_order in block so we can use it when rendering HTML
+                blocks[block['id']] = {**block, 'page_order': page.order}
         return blocks
 
     @staticmethod

--- a/capstone/capdb/tests/test_tasks.py
+++ b/capstone/capdb/tests/test_tasks.py
@@ -286,8 +286,9 @@ def test_extract_citations(reset_sequences, case_factory, elasticsearch, client,
     update_elasticsearch_from_queue()
 
     # check html
-    assert """
-    <p id="b83-6">
+    assert (
+        """
+    <p id="b83-6" data-blocks=\'[["BL_83.6",3,[226,1320,752,926]],["BL_83.7",3,[226,1320,752,926]]]\'>
         correct: Foo v. Bar, <a href="http://cite.case.test:8000/us/1/1/#p12" class="citation" data-index="0" data-case-ids="1">1 U.S. 1</a>, 12 (2000) (overruling).
         extra cruft matched: <a href="http://cite.case.test:8000/citations/?q=2%20F.%20Supp.%202" class="citation" data-index="1">2 F.-'Supp.- 2</a>
         custom reporters: <a href="http://cite.case.test:8000/citations/?q=125%20Vt.%20152" class="citation" data-index="2">125 Yt. 152</a>
@@ -296,13 +297,15 @@ def test_extract_citations(reset_sequences, case_factory, elasticsearch, client,
     </p>
     <aside data-label="1" class="footnote" id="footnote_1_1">
       <a href="#ref_footnote_1_1">1</a>
-      <p id="b83-11">
+      <p id="b83-11" data-blocks=\'[["BL_83.16",3,[226,1320,752,926]]]\'>
         normalized: <a href="http://cite.case.test:8000/us/2/2/" class="citation" data-index="5" data-case-ids="2,3">2 US 2</a>
         short cites: <a href="http://cite.case.test:8000/us/2/2/" class="citation" data-index="6" data-case-ids="2,3">id.</a> <a href="http://cite.case.test:8000/us/1/1/#p12" class="citation" data-index="7" data-case-ids="1">1 U.S. at 153</a>.
         ignored, too much cruft: 125 f. supp.-' 152
     </p>
     </aside>
-    """.strip() in case.body_cache.html
+    """.strip()
+        in case.body_cache.html
+    )
 
     # check ExtractedCites entries
     extracted_cites_fields = [

--- a/capstone/cite/tests/test_views.py
+++ b/capstone/cite/tests/test_views.py
@@ -343,10 +343,12 @@ def test_retrieve_page_image(admin_client, auth_client, volume_metadata):
     check_response(response, status_code=302)
 
 
-@pytest.mark.django_db(databases=['default', 'capdb'])
-def test_case_editor(reset_sequences, admin_client, auth_client, unrestricted_case_factory):
+@pytest.mark.django_db(databases=["default", "capdb"])
+def test_case_editor(
+    reset_sequences, admin_client, auth_client, unrestricted_case_factory
+):
     unrestricted_case = unrestricted_case_factory(first_page_order=1, last_page_order=3)
-    url = reverse('case_editor', args=[unrestricted_case.pk], host='cite')
+    url = reverse("case_editor", args=[unrestricted_case.pk], host="cite")
     response = admin_client.get(url)
     check_response(response)
     response = auth_client.get(url)
@@ -361,37 +363,45 @@ def test_case_editor(reset_sequences, admin_client, auth_client, unrestricted_ca
     page = unrestricted_case.structure.pages.first()
     response = admin_client.post(
         url,
-        json.dumps({
-            'metadata': {
-                'name': [unrestricted_case.name, 'new name'],
-                'decision_date_original': [unrestricted_case.decision_date_original, '2020-01-01'],
-                'first_page': [old_first_page, 'ignore this'],
-                'human_corrected': [False, True],
-            },
-            'description': description,
-            'edit_list': {
-                page.id: {
-                    'BL_81.3': {
-                        3: ["Case text 0", "Replacement text"],
+        json.dumps(
+            {
+                "metadata": {
+                    "name": [unrestricted_case.name, "new name"],
+                    "decision_date_original": [
+                        unrestricted_case.decision_date_original,
+                        "2020-01-01",
+                    ],
+                    "first_page": [old_first_page, "ignore this"],
+                    "human_corrected": [False, True],
+                },
+                "description": description,
+                "edit_list": {
+                    page.id: {
+                        "BL_81.3": {
+                            3: ["Case text 0", "Replacement text"],
+                        }
                     }
-                }
+                },
             }
-        }),
-        content_type="application/json")
+        ),
+        content_type="application/json",
+    )
     check_response(response)
 
     # check OCR edit
     body_cache.refresh_from_db()
     new_html = body_cache.html
-    assert list(unified_diff(old_html.splitlines(), new_html.splitlines(), n=0))[3:] == [
-        '-    <h4 class="parties" id="b81-4">Case text 0</h4>',
-        '+    <h4 class="parties" id="b81-4">Replacement text</h4>',
+    assert list(unified_diff(old_html.splitlines(), new_html.splitlines(), n=0))[
+        3:
+    ] == [
+        '-    <h4 class="parties" id="b81-4" data-blocks=\'[["BL_81.3",0,[226,1320,752,926]]]\'>Case text 0</h4>',
+        '+    <h4 class="parties" id="b81-4" data-blocks=\'[["BL_81.3",0,[226,1320,752,926]]]\'>Replacement text</h4>',
     ]
 
     # check metadata
     unrestricted_case.refresh_from_db()
-    assert unrestricted_case.name == 'new name'
-    assert unrestricted_case.decision_date_original == '2020-01-01'
+    assert unrestricted_case.name == "new name"
+    assert unrestricted_case.decision_date_original == "2020-01-01"
     assert unrestricted_case.decision_date == datetime.date(year=2020, month=1, day=1)
     assert unrestricted_case.human_corrected is True
     assert unrestricted_case.first_page == old_first_page  # change ignored


### PR DESCRIPTION
Add the data-blocks attribute to exported HTML, listing the (arbitrary assigned by vendor) block ID, PDF page order, and bounding box for each rectangle in the PDF that contributed to the paragraph. Example output:

```
<p id="b415-10" data-blocks='[["BL_415.10",415,[249,2172,1145,146]],["BL_416.1",416,[314,411,1150,756]]]'>Chief Justice Fuller in <em>United States v. Lacher ...
```

Bex will pick up stewarding this PR from here; once we're happy with it, we'd like to run `fab refresh_case_body_cache` on prod and see if all the volumes work.