### PR TITLE
Rek alter casebody format

### DIFF
--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -594,7 +594,6 @@ class ConvertNoLoginCaseDocumentSerializer(CaseDocumentSerializerWithCasebody):
             data["casebody"] = data["casebody"]["data"]
         except KeyError:
             print("No casebody field in case.")
-            pass
 
         data.pop("reporter", None)
         data.pop("volume", None)
@@ -607,14 +606,12 @@ class ConvertNoLoginCaseDocumentSerializer(CaseDocumentSerializerWithCasebody):
             data["court"].pop("url", None)
         except KeyError:
             print("Cannot pop fields because 'court' doesn't exist")
-            pass
         try:
             data["jurisdiction"].pop("slug", None)
             data["jurisdiction"].pop("whitelisted", None)
             data["jurisdiction"].pop("url", None)
         except KeyError:
             print("Cannot pop fields because 'jurisdiction' doesn't exist")
-            pass
 
         data.pop("preview", None)
 

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -584,21 +584,33 @@ class ConvertNoLoginCaseDocumentSerializer(CaseDocumentSerializerWithCasebody):
         last_page_order = self.context.get("last_page_order")
 
         data = super().to_representation(instance, check_permissions=check_permissions)
-        data["casebody"] = data["casebody"]["data"]
+        try:
+            data["casebody"] = data["casebody"]["data"]
+        except KeyError:
+            print("No casebody field in case.")
+            pass
 
-        data.pop("reporter")
-        data.pop("volume")
-        data.pop("url")
-        data.pop("frontend_url")
-        data.pop("frontend_pdf_url")
-        data["court"].pop("slug")
-        data["court"].pop("url")
-        data["jurisdiction"].pop("slug")
-        data["jurisdiction"].pop("whitelisted")
-        data["jurisdiction"].pop("url")
+        data.pop("reporter", None)
+        data.pop("volume", None)
+        data.pop("url", None)
+        data.pop("frontend_url", None)
+        data.pop("frontend_pdf_url", None)
 
-        if "preview" in data:
-            data.pop("preview")
+        try:
+            data["court"].pop("slug", None)
+            data["court"].pop("url", None)
+        except KeyError:
+            print("Cannot pop fields because 'court' doesn't exist")
+            pass
+        try:
+            data["jurisdiction"].pop("slug", None)
+            data["jurisdiction"].pop("whitelisted", None)
+            data["jurisdiction"].pop("url", None)
+        except KeyError:
+            print("Cannot pop fields because 'jurisdiction' doesn't exist")
+            pass
+
+        data.pop("preview", None)
 
         data["first_page_order"] = first_page_order
         data["last_page_order"] = last_page_order

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -572,3 +572,39 @@ class ConvertCaseDocumentSerializer(CaseDocumentSerializer):
         data["first_page_order"] = first_page_order
         data["last_page_order"] = last_page_order
         return data
+
+
+class ConvertNoLoginCaseDocumentSerializer(CaseDocumentSerializerWithCasebody):
+    first_page_order = serializers.CharField()
+    last_page_order = serializers.CharField()
+
+    def to_representation(self, instance, check_permissions=False):
+        """Tell get_casebody not to check for case download permissions."""
+        first_page_order = self.context.get("first_page_order")
+        last_page_order = self.context.get("last_page_order")
+
+        data = super().to_representation(instance, check_permissions=check_permissions)
+        data["casebody"] = data["casebody"]["data"]
+
+        data.pop("reporter")
+        data.pop("volume")
+        data.pop("url")
+        data.pop("frontend_url")
+        data.pop("frontend_pdf_url")
+        data["court"].pop("slug")
+        data["court"].pop("url")
+        data["jurisdiction"].pop("slug")
+        data["jurisdiction"].pop("whitelisted")
+        data["jurisdiction"].pop("url")
+
+        if "preview" in data:
+            data.pop("preview")
+
+        data["first_page_order"] = first_page_order
+        data["last_page_order"] = last_page_order
+        return data
+
+    @property
+    def data(self):
+        """Skip tracking of download counts."""
+        return super(DocumentSerializer, self).data

--- a/capstone/capapi/serializers.py
+++ b/capstone/capapi/serializers.py
@@ -604,14 +604,14 @@ class ConvertNoLoginCaseDocumentSerializer(CaseDocumentSerializerWithCasebody):
         try:
             data["court"].pop("slug", None)
             data["court"].pop("url", None)
-        except KeyError:
-            print("Cannot pop fields because 'court' doesn't exist")
+        except KeyError as err:
+            print(f"Cannot pop field {err} because 'court' doesn't exist")
         try:
             data["jurisdiction"].pop("slug", None)
             data["jurisdiction"].pop("whitelisted", None)
             data["jurisdiction"].pop("url", None)
-        except KeyError:
-            print("Cannot pop fields because 'jurisdiction' doesn't exist")
+        except KeyError as err:
+            print(f"Cannot pop field {err} because 'jurisdiction' doesn't exist")
 
         data.pop("preview", None)
 

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       # MOUNTS
       - .:/app
       - ../services:/services
+      - ~/.aws/credentials:/root/.aws/credentials:ro
     depends_on:
       - redis
       - db

--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -36,7 +36,6 @@ services:
       # MOUNTS
       - .:/app
       - ../services:/services
-      - ~/.aws/credentials:/root/.aws/credentials:ro
     depends_on:
       - redis
       - db

--- a/capstone/scripts/convert_s3.py
+++ b/capstone/scripts/convert_s3.py
@@ -10,7 +10,7 @@ from collections import namedtuple
 from capapi.documents import CaseDocument
 from capapi.serializers import (
     ConvertCaseDocumentSerializer,
-    NoLoginCaseDocumentSerializer,
+    ConvertNoLoginCaseDocumentSerializer,
 )
 from capdb.models import Reporter, VolumeMetadata, CaseMetadata
 
@@ -102,7 +102,7 @@ def export_cases_by_volume(volumes: list, dest_bucket: str, redacted: bool) -> N
     """
     formats = {
         "text": {
-            "serializer": NoLoginCaseDocumentSerializer,
+            "serializer": ConvertNoLoginCaseDocumentSerializer,
             "query_params": {"body_format": "text"},
         },
         "metadata": {
@@ -178,7 +178,7 @@ def export_single_case(case: object, case_prefix: str, bucket: str) -> None:
 
     # set up vars for text format
     vars = {
-        "serializer": NoLoginCaseDocumentSerializer,
+        "serializer": ConvertNoLoginCaseDocumentSerializer,
         "query_params": {"body_format": "text"},
     }
     # fake Request object used for serializing case with DRF's serializer


### PR DESCRIPTION
This is the final PR in the series. It should be landed fourth after:
1. https://github.com/harvard-lil/capstone/pull/2152 
2. https://github.com/harvard-lil/capstone/pull/2153
3. https://github.com/harvard-lil/capstone/pull/2154

This PR alters content of Cases.jsonl and the individual case files to maintain the same format as CasesMetadata ([PR here](https://github.com/harvard-lil/capstone/pull/2152 )).
It also moves the nested "data" dict a level up so that instead of having ["casebody"]["data"], you have ["casebody"]. By nature, that removes the ["casebody"]["status"] field.
