### PR TITLE
Rek change nominative locations

### DIFF
--- a/capstone/scripts/convert_s3.py
+++ b/capstone/scripts/convert_s3.py
@@ -230,7 +230,6 @@ def put_reporter_metadata(bucket: str, reporter: object, key: str) -> None:
 
     # add additional fields from reporter obj
     results["harvard_hollis_id"] = reporter.hollis
-    results["nominative_for_id"] = reporter.nominative_for_id
 
     # remove unnecessary fields
     results.pop("url", None)
@@ -284,6 +283,8 @@ def put_volume_metadata(bucket: str, volume: object, key: str) -> None:
         ] = volume.nominative_volume_number
     else:
         results["nominative_reporter"] = volume.nominative_reporter_id
+    results.pop("nominative_volume_number", None)
+    results.pop("nominative_name", None)
 
     # remove unnecessary fields
     results.pop("reporter", None)

--- a/capstone/scripts/convert_s3.py
+++ b/capstone/scripts/convert_s3.py
@@ -281,6 +281,8 @@ def put_volume_metadata(bucket: str, volume: object, key: str) -> None:
         results["nominative_reporter"][
             "volume_number"
         ] = volume.nominative_volume_number
+        results.pop("nominative_volume_number", None)
+        results.pop("nominative_name", None)
     elif volume.nominative_reporter_id is None and (volume.nominative_volume_number or volume.nominative_name):
         results["nominative_reporter"] = {}
         results["nominative_reporter"]["volume_number"] = volume.nominative_volume_number

--- a/capstone/scripts/convert_s3.py
+++ b/capstone/scripts/convert_s3.py
@@ -281,10 +281,12 @@ def put_volume_metadata(bucket: str, volume: object, key: str) -> None:
         results["nominative_reporter"][
             "volume_number"
         ] = volume.nominative_volume_number
+    elif volume.nominative_reporter_id is None and (volume.nominative_volume_number or volume.nominative_name):
+        results["nominative_reporter"] = {}
+        results["nominative_reporter"]["volume_number"] = volume.nominative_volume_number
+        results["nominative_reporter"]["nominative_name"] = volume.nominative_name
     else:
-        results["nominative_reporter"] = volume.nominative_reporter_id
-    results.pop("nominative_volume_number", None)
-    results.pop("nominative_name", None)
+        results["nominative_reporter"] = None
 
     # remove unnecessary fields
     results.pop("reporter", None)


### PR DESCRIPTION
We decided not to include the reporter's nominative_for_id since it also exists in the volume. 
We're also handling what to do if there is a nominative_volume_number and nominative_name but no nominative_for_id--in that case, make a different dict with those values. And if they exist when the nominative_for_id field also exists, remove them from the upper level result.