### PR TITLE
updates all reporters command and creates a trial command

### DIFF
--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -458,15 +458,23 @@ def export_cases_to_s3():
     by reporter and volume.
     """
     redacted = True
-    convert_s3.export_cases_to_s3(redacted, "996")
+    convert_s3.export_cases_to_s3(redacted, "528")
 
 
 @task
-def export_volumes_reporters_to_s3():
+def export_reporters_to_s3():
     """
-    Run export of all volumes and all reporters, unfiltered, to S3.
+    Run export of all reporters, unfiltered, to S3.
     """
-    convert_s3.put_volumes_reporters_on_s3(redacted=True)
+    convert_s3.put_reporters_on_s3(redacted=True)
+
+
+@task
+def export_reporters_to_s3_trial():
+    """
+    Run export of all reporters for first API page, unfiltered, to S3.
+    """
+    convert_s3.put_reporters_on_s3_trial(redacted=True)
 
 
 @task

--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -464,7 +464,7 @@ def export_cases_to_s3():
 @task
 def export_reporters_to_s3():
     """
-    Run export of all reporters, unfiltered, to S3.
+    Run export of all reporters and their contents to S3.
     """
     convert_s3.put_reporters_on_s3(redacted=True)
 
@@ -472,7 +472,8 @@ def export_reporters_to_s3():
 @task
 def export_reporters_to_s3_trial():
     """
-    Run export of all reporters for first API page, unfiltered, to S3.
+    Run export of all reporters  and their contents to S3
+    for first API page.
     """
     convert_s3.put_reporters_on_s3_trial(redacted=True)
 


### PR DESCRIPTION
This PR updates the all reporters command and creates a trial command so we can run this on prod with just a subset of reporters.
The reporters command had not been updated since some changes had been made to the bulk of the script that changed the way metadata for reporters and volumes were being saved. That was an oversight!
It's to address this issue: https://linear.app/harvard-lil/issue/ENG-12/test-s3-conversion-script-on-subset-of-prod-db
