### PR TITLE
Rek add top level

### DIFF
--- a/capstone/scripts/convert_s3.py
+++ b/capstone/scripts/convert_s3.py
@@ -118,12 +118,14 @@ def export_cases_to_s3(bucket: str, redacted: bool, reporter_id: str) -> tuple:
     # Make sure there are volumes in the reporter
     if not reporter.volumes.exclude(out_of_scope=True):
         print("WARNING: Reporter '{}' contains NO VOLUMES.".format(reporter.full_name))
+        # Returning empty string to have something to append to reporter metadata
         return ("", "")
 
     # Make sure there are cases in the reporter
     cases_search = CaseDocument.raw_search().filter("term", reporter__id=reporter.id)
     if cases_search.count() == 0:
         print("WARNING: Reporter '{}' contains NO CASES.".format(reporter.full_name))
+        # Returning empty string to have something to append to reporter metadata
         return ("", "")
 
     # TODO: address reporters that share slug
@@ -172,6 +174,7 @@ def export_cases_by_volume(
 
     if len(cases) == 0:
         print("WARNING: Volume '{}' contains NO CASES.".format(volume.barcode))
+        # Returning empty string to have something to append to volume metadata
         return ""
 
     # open each volume and put case text or metadata into file based on format


### PR DESCRIPTION
This PR addresses an issue that popped up when I realized I'd taken out the ReportersMetadata.jsonl and VolumesMetadata.jsonl that were supposed to live at the top level of the file structure. These contain metadata for all the reporters and all the volumes, respectively.

I ended up threading a tuple up with string containing the contents of each of these, but I'm not sure that is the best solution. I'm especially unsure about returning ("", "") for cases where the reporter has no volumes or cases. I just don't know whether that's the correct thing to do, so happy for advice on that.