### PR TITLE
Make export_cases_by_volume a shared task

### DIFF
--- a/capstone/config/celery.py
+++ b/capstone/config/celery.py
@@ -17,6 +17,7 @@ app = Celery('config', include=[
     'scripts.update_snippets',
     'scripts.refactor_xml',
     'scripts.make_pdf',
+    'scripts.convert_s3',
 ])
 
 # Using a string here means the worker doesn't have to serialize


### PR DESCRIPTION
I've tested this code with a local S3-alike minio container and `CELERY_TASK_ALWAYS_EAGER = False`. I have not included the minio setup here, but I can add it if that seems desirable.

Note that I had to change the volume argument to `export_cases_by_volume` from an object to a string, since the object is not JSON serializable. I suppose the excess queries could slow this down, but I don't think it will be a problem.