### PR TITLE
Skip missing case IDs

### DIFF
--- a/capstone/scripts/convert_s3.py
+++ b/capstone/scripts/convert_s3.py
@@ -225,7 +225,10 @@ def export_cases_by_volume(
     # store the serialized case data
     for case in cases:
         # identify associated search item to add additional data
-        item = cases_search_by_id[case.id]
+        try:
+            item = cases_search_by_id[case.id]
+        except KeyError:
+            continue
 
         serializer = vars["serializer"](
             item["_source"],


### PR DESCRIPTION
This should resolve a KeyError that appears when the over-stuffed `cases` is compared with the more limited `cases_search_by_id`.