### PR TITLE
Fix pagerank percentile

### DIFF
--- a/capstone/fabfile.py
+++ b/capstone/fabfile.py
@@ -1758,6 +1758,7 @@ def calculate_pagerank_scores(
             if score > last_score:
                 percentile = i
             csv_output.writerow([id, score, percentile / total_rows])
+            last_score = score
 
 
 @task


### PR DESCRIPTION
I noticed this when a user asked me to explain the meaning of the numbers in our [pagerank export](https://case.law/download/citation_graph/), and figured I may as well throw in a fix --

The code to generate pagerank percentiles was obviously intended to give all cases with the same pagerank the same percentile score, but missing a `last_score = score` line. The upshot is that row one gets a percentile of 1/n, row 2 gets a percentile of 2/n, etc, instead of them all having the same percentile if they have the same score:

```
id,raw_score,percentile
4,4.076306636737454e-08,0.0
5,4.076306636737454e-08,1.9539073261755196e-07
7,4.076306636737454e-08,3.907814652351039e-07
13,4.076306636737454e-08,5.861721978526558e-07
17,4.076306636737454e-08,7.815629304702078e-07
```

This just puts in the missing assignment so those would all have percentile 0.0. Note this has the largest effect on the lowest-ranked cases -- about a third of our cases have the same lowest pagerank, so case 1.7 million has a percentile of 33% when it should be 0%. After that there's more gradation so there's less effect from this bug.