### PR TITLE
Add volume_folder to export json

### DIFF
--- a/capstone/test_data/cap_static/redacted/VolumesMetadata.json
+++ b/capstone/test_data/cap_static/redacted/VolumesMetadata.json
@@ -27,6 +27,7 @@
     "second_part_of_id": null,
     "redacted": true,
     "nominative_reporter": null,
+    "volume_folder": "1",
     "reporter_slug": "us"
   },
   {
@@ -57,6 +58,7 @@
     "second_part_of_id": null,
     "redacted": true,
     "nominative_reporter": null,
+    "volume_folder": "2",
     "reporter_slug": "us"
   }
 ]

--- a/capstone/test_data/cap_static/redacted/us/1/VolumeMetadata.json
+++ b/capstone/test_data/cap_static/redacted/us/1/VolumeMetadata.json
@@ -25,5 +25,6 @@
   "publication_city": null,
   "second_part_of_id": null,
   "redacted": true,
-  "nominative_reporter": null
+  "nominative_reporter": null,
+  "volume_folder": "1"
 }

--- a/capstone/test_data/cap_static/redacted/us/2/VolumeMetadata.json
+++ b/capstone/test_data/cap_static/redacted/us/2/VolumeMetadata.json
@@ -25,5 +25,6 @@
   "publication_city": null,
   "second_part_of_id": null,
   "redacted": true,
-  "nominative_reporter": null
+  "nominative_reporter": null,
+  "volume_folder": "2"
 }

--- a/capstone/test_data/cap_static/redacted/us/VolumesMetadata.json
+++ b/capstone/test_data/cap_static/redacted/us/VolumesMetadata.json
@@ -27,6 +27,7 @@
     "second_part_of_id": null,
     "redacted": true,
     "nominative_reporter": null,
+    "volume_folder": "1",
     "reporter_slug": "us"
   },
   {
@@ -57,6 +58,7 @@
     "second_part_of_id": null,
     "redacted": true,
     "nominative_reporter": null,
+    "volume_folder": "2",
     "reporter_slug": "us"
   }
 ]

--- a/capstone/test_data/cap_static/unredacted/VolumesMetadata.json
+++ b/capstone/test_data/cap_static/unredacted/VolumesMetadata.json
@@ -27,6 +27,7 @@
     "second_part_of_id": null,
     "redacted": false,
     "nominative_reporter": null,
+    "volume_folder": "1",
     "reporter_slug": "us"
   },
   {
@@ -57,6 +58,7 @@
     "second_part_of_id": null,
     "redacted": false,
     "nominative_reporter": null,
+    "volume_folder": "2",
     "reporter_slug": "us"
   }
 ]

--- a/capstone/test_data/cap_static/unredacted/us/1/VolumeMetadata.json
+++ b/capstone/test_data/cap_static/unredacted/us/1/VolumeMetadata.json
@@ -25,5 +25,6 @@
   "publication_city": null,
   "second_part_of_id": null,
   "redacted": false,
-  "nominative_reporter": null
+  "nominative_reporter": null,
+  "volume_folder": "1"
 }

--- a/capstone/test_data/cap_static/unredacted/us/2/VolumeMetadata.json
+++ b/capstone/test_data/cap_static/unredacted/us/2/VolumeMetadata.json
@@ -25,5 +25,6 @@
   "publication_city": null,
   "second_part_of_id": null,
   "redacted": false,
-  "nominative_reporter": null
+  "nominative_reporter": null,
+  "volume_folder": "2"
 }

--- a/capstone/test_data/cap_static/unredacted/us/VolumesMetadata.json
+++ b/capstone/test_data/cap_static/unredacted/us/VolumesMetadata.json
@@ -27,6 +27,7 @@
     "second_part_of_id": null,
     "redacted": false,
     "nominative_reporter": null,
+    "volume_folder": "1",
     "reporter_slug": "us"
   },
   {
@@ -57,6 +58,7 @@
     "second_part_of_id": null,
     "redacted": false,
     "nominative_reporter": null,
+    "volume_folder": "2",
     "reporter_slug": "us"
   }
 ]


### PR DESCRIPTION
Add `"volume_folder"` to exported metadata for volumes, so we can link correctly when there are multiple volumes with the same volume_number.

I also added the missing line `reporter = Reporter.objects.filter(short_name_slug=reporter_dir.name).exclude(start_year=None).get()`, which I used for the export and had sitting around locally but failed to include in a previous PR.