### PR TITLE
Remove old banner

### DIFF
--- a/capstone/cite/templates/cite/case.html
+++ b/capstone/cite/templates/cite/case.html
@@ -32,15 +32,6 @@
 {% endblock %}
 
 {% block title_section %}
-  {% if not request.user.is_authenticated %}
-    <div class="alert alert-success m-0" role="alert">
-      Welcome to the Caselaw Access Project! We allow free access to up to 500 cases per person per day &mdash; see
-      our
-      <a href="{% url 'terms' %}">terms of use</a> for details. <a href="{% url 'register' %}">Sign up for an
-      account</a>
-      to use our API or apply for unlimited research scholar access.
-    </div>
-  {% endif %}
   <div class="sr-only sr-only-focusable" tabindex="0">
     Press Ctrl + / (Windows, Chrome OS) or ⌘ + / (Mac) to jump to the Tools menu.
     Press escape to return to last selected case text.


### PR DESCRIPTION
Remove the now-confusing green banner displayed to not-logged-in users viewing cases.
![image](https://github.com/harvard-lil/capstone/assets/11020492/58b7bef2-7a01-4bc0-9602-ac62f8aa6a0b)
