### PR TITLE
Remove info about special "researcher" access and disable forms.

### DIFF
--- a/capstone/capapi/templates/registration/user-details.html
+++ b/capstone/capapi/templates/registration/user-details.html
@@ -53,25 +53,27 @@
           <span class="case-number">{{ request.user.total_case_allowance }}</span> total per day
         </div>
       </div>
-      <div class="row">
-        <div class="h5 col-sm-12">Unrestricted access</div>
-        <div class="col-sm-12">
-          {% if research_contract %}
-            You submitted an application for unrestricted access on
-            {{ research_contract.user_signature_date|date:"F j, Y" }}.
-            {% if research_contract.status == "denied" %}
-              Your application was denied by LexisNexis. Please contact us if you would like to discuss further options.
+      {% if not DISABLE_SIGNUPS %}
+        <div class="row">
+          <div class="h5 col-sm-12">Unrestricted access</div>
+          <div class="col-sm-12">
+            {% if research_contract %}
+              You submitted an application for unrestricted access on
+              {{ research_contract.user_signature_date|date:"F j, Y" }}.
+              {% if research_contract.status == "denied" %}
+                Your application was denied by LexisNexis. Please contact us if you would like to discuss further options.
+              {% else %}
+                Your application is pending.
+              {% endif %}
+            {% elif research_request %}
+              You submitted a request for unrestricted access on {{ research_request.submitted_date }}
             {% else %}
-              Your application is pending.
+              Are you a research scholar? <br/>
+              <a href="{% url 'research-options' %}">Request access</a>
             {% endif %}
-          {% elif research_request %}
-            You submitted a request for unrestricted access on {{ research_request.submitted_date }}
-          {% else %}
-            Are you a research scholar? <br/>
-            <a href="{% url 'research-options' %}">Request access</a>
-          {% endif %}
+          </div>
         </div>
-      </div>
+      {% endif %}
     {% endif %}
     <div class="row">
       <div class="h5 col-sm-12">History</div>

--- a/capstone/capapi/views/user_views.py
+++ b/capstone/capapi/views/user_views.py
@@ -167,6 +167,9 @@ def user_history(request):
 @user_has_harvard_email()
 def request_harvard_research_access_intro(request):
     """ Warning shown before Harvard access page """
+    if settings.DISABLE_SIGNUPS:
+        return HttpResponseRedirect('/')
+
     return render(request, 'research_request/harvard_research_request_intro.html')
 
 
@@ -174,6 +177,9 @@ def request_harvard_research_access_intro(request):
 @user_has_harvard_email()
 def request_harvard_research_access(request):
     """ Sign Harvard-email based contract """
+    if settings.DISABLE_SIGNUPS:
+        return HttpResponseRedirect('/')
+
     name = "%s %s" % (request.user.first_name, request.user.last_name)
     form = form_for_request(request, HarvardContractForm, initial={'name': name, 'email': request.user.email})
 
@@ -207,6 +213,9 @@ def request_harvard_research_access(request):
 @login_required
 def request_research_access(request):
     """ Sign academic/nonprofit based contract """
+    if settings.DISABLE_SIGNUPS:
+        return HttpResponseRedirect('/')
+
     name = "%s %s" % (request.user.first_name, request.user.last_name)
     form = form_for_request(request, ResearchContractForm, initial={'name': name, 'email': request.user.email})
 

--- a/capstone/capweb/helpers.py
+++ b/capstone/capweb/helpers.py
@@ -172,13 +172,19 @@ def send_contact_email(title, content, from_address):
     ).send(fail_silently=False)
 
 
-def user_has_harvard_email(failure_url='non-harvard-email'):
+def user_has_harvard_email(failure_url=None):
     """
         Decorator to forward user if they don't have Harvard email. E.g.:
 
         @user_has_harvard_email()
         def my_view(request):
     """
+    if not failure_url:
+        if settings.DISABLE_SIGNUPS:
+            failure_url = '/'
+        else:
+            failure_url = 'non-harvard-email'
+
     return user_passes_test(
         test_func=lambda u: bool(re.search(r'[.@]harvard.edu$', u.email)),
         login_url=failure_url)

--- a/capstone/capweb/urls.py
+++ b/capstone/capweb/urls.py
@@ -86,7 +86,6 @@ urlpatterns = [
     path('user/delete-account', user_views.delete_account, name='delete_account'),
 
     # research access requests
-    path('user/research/', TemplateView.as_view(template_name='research_request/index.html'), name='research-options'),
     path('user/research/approve/', user_views.approve_research_access, name='research-approval'),
     path('user/research/apply/', user_views.request_research_access,
          name='research-request'),
@@ -95,13 +94,18 @@ urlpatterns = [
          name='research-request-success'),
     path('user/research/harvard-intro/', user_views.request_harvard_research_access_intro,
          name='harvard-research-request-intro'),
-    path('user/research/non-harvard-email/',
-         TemplateView.as_view(template_name='research_request/non_harvard_email.html'), name='non-harvard-email'),
     path('user/research/harvard/', user_views.request_harvard_research_access, name='harvard-research-request'),
     path('user/research/harvard-success/',
          TemplateView.as_view(template_name='research_request/harvard_research_request_success.html'),
          name='harvard-research-request-success'),
 ]
+
+if not settings.DISABLE_SIGNUPS:
+    urlpatterns += [
+        path('user/research/', TemplateView.as_view(template_name='research_request/index.html'), name='research-options'),
+        path('user/research/non-harvard-email/',
+        TemplateView.as_view(template_name='research_request/non_harvard_email.html'), name='non-harvard-email'),
+    ]
 
 if settings.DEBUG:
     # debugging routes to see error pages


### PR DESCRIPTION
See ENG-718.

A logged-in user gains access to a number of URLs at `/user`, including several related to requesting unmetered "researcher" access to CAP data. 

This PR arranges for those URLs to redirect to `/` if settings.DISABLE_SIGNUPS is set, and removes the links that would cause users to navigate there. 