### PR TITLE
Update Elasticsearch

### DIFF
--- a/capstone/docker-compose.yml
+++ b/capstone/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     redis:
         image: redis:6.0.15
     elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.19
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.20
         environment:
           - node.name=es01
           - bootstrap.memory_lock=true


### PR DESCRIPTION
This point version update to Elasticsearch matches an inadvertent upgrade on prod 🙄 

The release notes do not communicate much:

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.20.html

But I suspect this is a fix for the known issue in 7.17.19:

> Due to a bug in the bundled JDK 22 nodes might crash abruptly under high memory pressure. We recommend [downgrading to JDK 21.0.2](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/install-elasticsearch.html#jvm-version) asap to mitigate the issue.

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.19.html

The stakes are low here, obviously.